### PR TITLE
transform invalid integer values in a permission to a fractional permission, fixes #127

### DIFF
--- a/vercors/src/main/java/vct/silver/SilverExpressionMap.java
+++ b/vercors/src/main/java/vct/silver/SilverExpressionMap.java
@@ -50,7 +50,7 @@ public class SilverExpressionMap<T,E> implements ASTMapping<E>{
         switch(v){
           case 0 : return create.no_perm(e.getOrigin());
           case 1 : return create.write_perm(e.getOrigin());
-          default: return create.Constant(e.getOrigin(),v);
+          default: return create.frac(e.getOrigin(), create.Constant(e.getOrigin(), v), create.Constant(e.getOrigin(), 1));
         }
       } else {
         return create.Constant(e.getOrigin(),v);

--- a/viper/silver/src/main/scala/viper/api/SilverImplementation.scala
+++ b/viper/silver/src/main/scala/viper/api/SilverImplementation.scala
@@ -43,7 +43,7 @@ class SilverImplementation[O,Err](o:OriginFactory[O])
               prog.functions.asScala.toList,
               prog.predicates.asScala.toList,
               prog.methods.asScala.toList)()
-              
+
     //println("=============\n" + program + "\n=============\n")
     
     Reachable.gonogo = control.asInstanceOf[VerificationControl[Object]];
@@ -113,7 +113,7 @@ class SilverImplementation[O,Err](o:OriginFactory[O])
                   error.add_extra(because)
               }
             case ae : AbortedExceptionally =>{
-              if (detail) show("caused by ", ae.cause)
+              show("caused by ", ae.cause)
               report.add(new ViperErrorImpl(null.asInstanceOf[O],ae.fullId));
             }
             case x => {


### PR DESCRIPTION
The default null value was not the underlying issue of #127, it was actually the error generated [here](https://github.com/utwente-fmt/vercors/blob/50262799fdef5ec65bd396e5d19cac76fd6c07f5/viper/silicon/src/main/scala/state/Chunks.scala#L27). Passing an invalid integer to a permission leads to an [invalid value](https://github.com/utwente-fmt/vercors/blob/50262799fdef5ec65bd396e5d19cac76fd6c07f5/vercors/src/main/java/vct/silver/SilverExpressionMap.java#L53) being passed to [FieldAccessPredicate](https://github.com/utwente-fmt/vercors/blob/50262799fdef5ec65bd396e5d19cac76fd6c07f5/viper/silver/src/main/scala/viper/silver/ast/Expression.scala#L264). Its method check does in fact generate an error, but it appears it is not called anywhere.

This solution was chosen, since values >1 can be passed to perm by wrapping it in a fraction anyway (e.g. Perm(this.p, 101/100) leads to a pass).