### PR TITLE
Add rewriter for simple nested universal quantifiers.

### DIFF
--- a/vercors/src/main/java/vct/col/rewrite/RewriteSimpleNestedQuant.java
+++ b/vercors/src/main/java/vct/col/rewrite/RewriteSimpleNestedQuant.java
@@ -1,0 +1,48 @@
+package vct.col.rewrite;
+
+import java.util.Arrays;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import vct.col.ast.ASTNode;
+import vct.col.ast.Binder;
+import vct.col.ast.BindingExpression;
+import vct.col.ast.DeclarationStatement;
+import vct.col.ast.PrimitiveSort;
+import vct.col.ast.PrimitiveType;
+import vct.col.ast.ProgramUnit;
+
+/**
+ * Rewrite simple nested universal quantifiers to quantifiers with multiple
+ * variables. E.g.
+ * <code>\forall* decl1; guard1; (\forall* decl2; guard2; body);</code> becomes
+ * <code>\forall* decl1, decl2; guard1 && guard2; body</code>.
+ * 
+ * @author Henk Mulder
+ *
+ */
+public class RewriteSimpleNestedQuant extends AbstractRewriter {
+  
+  public RewriteSimpleNestedQuant(ProgramUnit source) {
+    super(source);
+  }
+  
+  @Override
+  public void visit(BindingExpression be) {
+    if ((be.binder == Binder.Star || be.binder == Binder.Forall) && be.main instanceof BindingExpression) {
+      BindingExpression be2 = (BindingExpression) be.main;
+      if (be2.binder == be.binder && be2.result_type.equals(be.result_type)) {
+        be2 = rewrite(be2);
+        DeclarationStatement[] decls = ArrayUtils.addAll(rewrite(be.getDeclarations()), be2.getDeclarations());
+        ASTNode[][] triggers = ArrayUtils.addAll(rewrite(be.triggers), be2.triggers);
+        PrimitiveSort ps = (be.result_type instanceof PrimitiveType && ((PrimitiveType)be.result_type).sort == PrimitiveSort.Resource) || (be2.result_type instanceof PrimitiveType && ((PrimitiveType)be2.result_type).sort == PrimitiveSort.Resource) ? PrimitiveSort.Resource : PrimitiveSort.Boolean;
+        Binder binder = ps == PrimitiveSort.Resource ? Binder.Star : Binder.Forall;
+        result = create.binder(binder, create.primitive_type(ps), decls, triggers, and(rewrite(be.select), be2.select),
+            be2.main);
+        return;
+      }
+    }
+    super.visit(be);
+  }
+  
+}

--- a/vercors/src/main/java/vct/main/Main.java
+++ b/vercors/src/main/java/vct/main/Main.java
@@ -2,20 +2,16 @@
 
 package vct.main;
 
-import hre.ast.FileOrigin;
-import hre.config.BooleanSetting;
-import hre.config.Option;
-import hre.config.OptionParser;
-import hre.config.StringListSetting;
-import hre.config.StringSetting;
-import hre.debug.HeapDump;
-import hre.io.PrefixPrintStream;
-import hre.lang.HREError;
-import hre.lang.HREExitException;
-import hre.util.CompositeReport;
-import hre.util.TestReport;
+import static hre.lang.System.Abort;
+import static hre.lang.System.Fail;
+import static hre.lang.System.Output;
+import static hre.lang.System.Progress;
+import static hre.lang.System.Warning;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.PrintStream;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -29,10 +25,27 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingDeque;
 
+import hre.ast.FileOrigin;
+import hre.config.BooleanSetting;
+import hre.config.Option;
+import hre.config.OptionParser;
+import hre.config.StringListSetting;
+import hre.config.StringSetting;
+import hre.debug.HeapDump;
+import hre.io.PrefixPrintStream;
+import hre.lang.HREError;
+import hre.lang.HREExitException;
+import hre.util.CompositeReport;
+import hre.util.TestReport;
 import vct.antlr4.parser.JavaResolver;
 import vct.antlr4.parser.Parsers;
 import vct.col.annotate.DeriveModifies;
-import vct.col.ast.*;
+import vct.col.ast.ASTClass;
+import vct.col.ast.ASTNode;
+import vct.col.ast.ASTSpecial;
+import vct.col.ast.ProgramUnit;
+import vct.col.ast.SpecificationFormat;
+import vct.col.ast.StandardOperator;
 import vct.col.rewrite.AbstractRewriter;
 import vct.col.rewrite.AccessIntroduce;
 import vct.col.rewrite.AddTypeADT;
@@ -68,6 +81,7 @@ import vct.col.rewrite.RandomizedIf;
 import vct.col.rewrite.RecognizeMultiDim;
 import vct.col.rewrite.ReorderAssignments;
 import vct.col.rewrite.RewriteArrayRef;
+import vct.col.rewrite.RewriteSimpleNestedQuant;
 import vct.col.rewrite.RewriteSystem;
 import vct.col.rewrite.SatCheckRewriter;
 import vct.col.rewrite.ScaleAlways;
@@ -94,7 +108,6 @@ import vct.logging.PassReport;
 import vct.silver.ErrorDisplayVisitor;
 import vct.util.ClassName;
 import vct.util.Configuration;
-import static hre.lang.System.*;
 
 /**
  * VerCors Tool main verifier.
@@ -1024,6 +1037,7 @@ public class Main
         ProgramUnit res=trs.normalize(arg);
         // Configuration.getDiagSyntax().print(System.err,res);
         res=RewriteSystems.getRewriteSystem("simplify_quant_pass2").normalize(res);
+        res = new RewriteSimpleNestedQuant(res).rewriteAll();
         return res;
       }
     });


### PR DESCRIPTION
The current version of Viper in VerCors crashes on nested forall quantifiers. This rewriter rewrites the most trivial nested quantifiers to one quantifier with multiple variables.