### PR TITLE
Rewrite rule for distributed permissions.

### DIFF
--- a/config/simplify_quant_pass2.jspec
+++ b/config/simplify_quant_pass2.jspec
@@ -80,6 +80,12 @@ class simplify_quant_pass2 {
     ==
     (\let int i=0; r1) ** (\let int i=1; r1) ** (\let int i=2; r1) ** (\let int i=3; r1)
   }
+  
+  axiom simplify_distributed_perm{
+    (\forall* int i; (i \memberof [ 0 .. e1 ) ); (\forall* int j;(j \memberof [ i*e2 .. (i+1)*e2 ) ); (r1!i) ))
+    ==
+    (\forall* int j;(j \memberof [ 0 .. (e1*e2) ) ); r1)
+  }
 
 }
 

--- a/config/simplify_quant_pass2.jspec
+++ b/config/simplify_quant_pass2.jspec
@@ -84,7 +84,7 @@ class simplify_quant_pass2 {
   axiom simplify_distributed_perm{
     (\forall* int i; (i \memberof [ 0 .. e1 ) ); (\forall* int j;(j \memberof [ i*e2 .. (i+1)*e2 ) ); (r1!i) ))
     ==
-    (\forall* int j;(j \memberof [ 0 .. (e1*e2) ) ); r1)
+    (e1 > 0) ==> (\forall* int j;(j \memberof [ 0 .. (e1*e2) ) ); r1)
   }
 
 }


### PR DESCRIPTION
Rewrite nested quantifiers for the sum of distributed permissions to a single quantifier for all the permissions.