### PR TITLE
remove unwanted warnings

### DIFF
--- a/vercors/src/main/java/vct/col/rewrite/JavaEncoder.java
+++ b/vercors/src/main/java/vct/col/rewrite/JavaEncoder.java
@@ -222,7 +222,7 @@ public class JavaEncoder extends AbstractRewriter {
   
   @Override
   public void visit(ASTClass cl){
-    System.err.printf("class %s%n",cl.name());
+    Debug("class %s%n",cl.name());
     if (!cl.isValidFlag(ASTFlags.FINAL)){
       cl.setFlag(ASTFlags.FINAL, false);
     }
@@ -402,24 +402,24 @@ public class JavaEncoder extends AbstractRewriter {
       String internal_name=create_method_name(INTERNAL,new ClassType(cls.getFullName()), m);
       boolean isFinal=m.isStatic()||cls.getFlag(ASTFlags.FINAL)||m.getFlag(ASTFlags.FINAL);
       if (isFinal){
-        System.err.printf("  method %s is final%n",m.name());
+        Debug("  method %s is final%n",m.name());
       } else {
-        System.err.printf("  method %s is not final%n",m.name());
+        Debug("  method %s is not final%n",m.name());
       }
       boolean isInitial=true;
       Method base=m;
       if (cls.super_classes.length>0){
-        System.err.printf("    super class is %s%n",cls.super_classes[0]);
+        Debug("    super class is %s%n",cls.super_classes[0]);
         ASTClass parent=source().find(cls.super_classes[0]);
         base=get_initial_definition(m);
         if (base!=m){
           isInitial=false;
-          System.err.printf("    overrides class %s%n",((ASTClass)base.getParent()).getDeclName());
+          Debug("    overrides class %s%n",((ASTClass)base.getParent()).getDeclName());
         } else {
-          System.err.printf("    initial declaration%n");
+          Debug("    initial declaration%n");
         }
       } else {
-        System.err.printf("    initial declaration%n");
+        Debug("    initial declaration%n");
       }
       Contract initial_contract;
       if (base==m){

--- a/vercors/src/main/java/vct/col/rewrite/SilverClassReduction.java
+++ b/vercors/src/main/java/vct/col/rewrite/SilverClassReduction.java
@@ -567,7 +567,7 @@ public class SilverClassReduction extends AbstractRewriter {
     }
     HashSet<String> names=new HashSet<String>();
     for(ASTNode n:res){
-      if (n instanceof ASTDeclaration){
+      if (n instanceof ASTDeclaration && !(n instanceof ASTSpecial)){
         ASTDeclaration d=(ASTDeclaration)n;
         if (names.contains(d.name())){
           Warning("name %s declared more than once",d.name());

--- a/viper/silver/src/main/scala/viper/api/SilverProgramFactory.scala
+++ b/viper/silver/src/main/scala/viper/api/SilverProgramFactory.scala
@@ -112,10 +112,10 @@ class SilverProgramFactory[O,Err] extends ProgramFactory[O,Err,Type,Exp,Stmt,
     val out_prog = api.prog.program()
     in_prog.domains.asScala.toList foreach {
       d => {
-        System.err.printf("%s%n",d.pos);
+//        System.err.printf("%s%n",d.pos);
         val o=get_info(d.info,d.pos,api.origin)
         val name=d.name
-        System.err.printf("%s%n",d.functions);
+//        System.err.printf("%s%n",d.functions);
         val functions:java.util.List[DFunc2]=(d.functions map {
           x => {
             val o=get_info(x.info,x.pos,api.origin)
@@ -124,7 +124,7 @@ class SilverProgramFactory[O,Err] extends ProgramFactory[O,Err,Type,Exp,Stmt,
             api.prog.dfunc(o,x.name,pars,res,d.name)
           }
         }).asJava
-        System.err.printf("%s%n",d.axioms);
+//        System.err.printf("%s%n",d.axioms);
         val axioms:java.util.List[DAxiom2]=d.axioms.map {
           x => api.prog.daxiom(o,x.name,map_expr(api,x.exp),d.name)
         }.asJava


### PR DESCRIPTION
Removes warnings about classes and methods, stops printing the prelude after parsing and no longer reports more than one declaration of <<special>>.