### PR TITLE
Use absolute path in link to Viper page

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you have these requirements, proceed to ['Building'](#building). On MacOS X, 
 For a basic build of VerCors the following steps should be taken:
 
 1. Clone the VerCors repository using `git clone https://github.com/utwente-fmt/vercors.git` and move into the cloned directory, `cd vercors`.
-2. Create symbolic links to link the Viper modules, as described on the [vercors/viper page](master/vercors/viper). Users with a Unix system can also use the travis_build.sh script to create the symbolic links and install VerCors by running 'sh travis_build.sh' from the project's root directory.
+2. Create symbolic links to link the Viper modules, as described on the [vercors/viper page](https://github.com/utwente-fmt/vercors/tree/master/vercors/viper). Users with a Unix system can also use the travis_build.sh script to create the symbolic links and install VerCors by running 'sh travis_build.sh' from the project's root directory.
 3. Build VerCors with Ant by running `ant clean`, followed by `ant`.
 4. Test whether the build was successful by running `./unix/bin/vct --test=examples/manual --tool=silicon --lang=pvl,java`.
 


### PR DESCRIPTION
I'm sorry @sjcjoosten. It seems GitHub doesn't use relative URLs the way I expected. An absolute path should fix #176 defenitely.