### PR TITLE
fixes #181: cache ivy & homebrew packages, homebrew installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ cache:
   directories:
    - $HOME/.ivy2
    - $HOME/Library/Caches/Homebrew
+   - /usr/local/Homebrew
 
 script:
 # Install ant

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ addons:
       - texlive-latex-recommended
       - texlive-latex-extra
 
+cache:
+  directories:
+   - $HOME/.ivy2
+   - $HOME/Library/Caches/Homebrew
+
 script:
 # Install ant
 - brew install ant


### PR DESCRIPTION
I restarted the build on the last commit three times and everything seems to build stably still.