### PR TITLE
fixes #196: do not reorder return statements

### DIFF
--- a/vercors/src/main/java/vct/col/rewrite/Flatten.java
+++ b/vercors/src/main/java/vct/col/rewrite/Flatten.java
@@ -239,17 +239,7 @@ public class Flatten extends AbstractRewriter {
       BlockStatement s=(BlockStatement)body;
       int N=s.getLength();
       for(int i=0;i<N;i++){
-        ASTNode stat=s.getStatement(i);
-        if (stat instanceof ReturnStatement){
-          // TODO: properly implement this with exec before and exec after.
-          ASTNode last=stat.apply(this);
-          for(i++;i<N;i++){
-            visit_body(s.getStatement(i));
-          }
-          current_block.addStatement(last);
-        } else {
-          visit_body(s.getStatement(i));
-        }
+        visit_body(s.getStatement(i));
       }
     } else {
       current_block.addStatement(body.apply(this));


### PR DESCRIPTION
As mentioned the logic to move the return statements around is probably there for a good reason. However, in the `examples` test suite there is no example that hits this case, and I don't understand why the logic should be important, so I propose that we remove it.