### PR TITLE
Fix reference to hre directory in build script

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -20,7 +20,7 @@
 
   <target name="clean">
     <exec dir="${basedir}/vercors" executable="${sbtcommand}"><arg value="clean" /><env key="TERM" value="xterm-color" /></exec>
-    <exec dir="${basedir}/vercors/hre" executable="${sbtcommand}"><arg value="clean" /><env key="TERM" value="xterm-color" /></exec>
+    <exec dir="${basedir}/vercors/viper/hre" executable="${sbtcommand}"><arg value="clean" /><env key="TERM" value="xterm-color" /></exec>
     <exec dir="${basedir}/vercors/parsers" executable="${sbtcommand}"><arg value="clean" /><env key="TERM" value="xterm-color" /></exec>
     <exec dir="${basedir}/vercors/viper" executable="${sbtcommand}"><arg value="clean" /><env key="TERM" value="xterm-color" /></exec>
     <delete dir="${basedir}/doc/api"/>


### PR DESCRIPTION
This updates the build script such that we refer to vercors/viper/hre instead of vercors/hre which does not exist. This caused the command ``ant clean`` to exit with an error which should now be fixed.