### PR TITLE
[feedback wanted] fixes #268: predicate definitions are always final

### DIFF
--- a/vercors/src/main/java/vct/col/rewrite/JavaEncoder.java
+++ b/vercors/src/main/java/vct/col/rewrite/JavaEncoder.java
@@ -315,6 +315,9 @@ public class JavaEncoder extends AbstractRewriter {
   private boolean is_direct_definition(Method m){
     if (m.isStatic()) return true;
     if (m.isValidFlag(ASTFlags.INLINE) && m.getFlag(ASTFlags.INLINE)) return true;
+    if(m.kind == Kind.Predicate) {
+      return true;
+    }
     if (!m.isValidFlag(ASTFlags.FINAL)){
       m.setFlag(ASTFlags.FINAL, false);
     }


### PR DESCRIPTION
268 has an issue where some indirection is applied to predicates because of inheritance. I went for the easiest solution, which is to say that predicates are always final and cannot be overridden by subclasses, but I would like feedback whether that is the right approach.