### PR TITLE
Adding leader election protocol by Wytse. 

### DIFF
--- a/examples/futures/elect.pvl
+++ b/examples/futures/elect.pvl
@@ -1,4 +1,8 @@
-// ./unix/bin/vct --silicon --check-history ./examples/test/elect4.pvl
+// -*- tab-width:2 ; indent-tabs-mode:nil -*-
+//:: case LeaderElect
+//:: suite puptol
+//:: tool silicon
+//:: option --check-history
 
 class Future {
 

--- a/examples/futures/elect.pvl
+++ b/examples/futures/elect.pvl
@@ -1,0 +1,429 @@
+// ./unix/bin/vct --silicon --check-history ./examples/test/elect4.pvl
+
+class Future {
+
+	/* ** Communication primitives */
+	
+	seq<seq<int>> channel; // communication channels
+	seq<int> results; // results from leader elections
+	
+	modifies channel;
+	context 0 <= rank && rank < |channel|;
+	ensures |channel| == |\old(channel)|;
+	ensures channel[rank] == \old(channel[rank]) + seq<int> { msg };
+	ensures (\forall int i; 0 <= i && i < |channel| && i != rank; channel[i] == \old(channel[i]));
+	process Send(int rank, int msg);
+	
+	modifies channel;
+	context 0 <= rank && rank < |channel|;
+	ensures |channel| == |\old(channel)|;
+	ensures seq<int> { msg } + channel[rank] == \old(channel[rank]);
+	ensures (\forall int i; 0 <= i && i < |channel| && i != rank; channel[i] == \old(channel[i]));
+	process Recv(int rank, int msg);
+	
+	
+	/* ** Leader election actions */
+	
+	modifies results;
+	context 0 <= rank && rank < |results|;
+	ensures |results| == |\old(results)|;
+	ensures results[rank] == v;
+	ensures (\forall int i; 0 <= i && i < |results| && i != rank; results[i] == \old(results[i]));
+	process Done(int rank, int v);
+	
+	// `v` is the current highest value encountered by the participant
+	// `w` is the value that is being received
+	// `n` is the number of rounds we already had
+	requires 0 <= w;
+	requires 0 <= rank && rank < size && size == |channel|;
+	process SigmaRecv(int rank, int size, int v, int w, int max, int n) =
+		0 < w ? (Recv((rank - 1) % size, w) * Check(rank, size, v, w, max, n)) + SigmaRecv(rank, size, v, w - 1, max, n) :
+						(Recv((rank - 1) % size, w) * Check(rank, size, v, w, max, n));
+
+	// compares the received value `w` with the current highest value `v` of a participant, which continues with the biggest of the two values.
+	requires 0 <= w;
+	requires 0 <= rank && rank < size && size == |channel|;
+	process Check(int rank, int size, int v, int w, int max, int n) =
+		Elect(rank, size, v <= w ? w : v, max, n + 1);
+
+	requires n <= size;
+	requires 0 <= rank && rank < size && size == |channel|;
+	process Elect(int rank, int size, int v, int max, int n) =
+		n < size ? Send((rank + 1) % size, v) * SigmaRecv(rank, size, v, max - 1, max, n) : Done(rank, v);
+	
+	
+	/* ** Parallel composition of participants */
+	
+	requires 0 <= rank && rank < size && size == |channel|;
+	requires |xs| == size;
+	requires (\forall int i; 0 <= i && i < |xs|; (\forall int j; 0 <= j && j < |xs| && i != j; xs[i] != xs[j])); // uniqueness
+	requires (\forall int i; 0 <= i && i < |xs|; 0 <= xs[i] && xs[i] < max);
+	process Spawn(int rank, int size, seq<int> xs, int max) =
+		rank < size ? Elect(rank, size, xs[rank], max, 0) || Spawn(rank + 1, size, xs, max) : empty;
+	
+	context 0 < size;
+	context |channel| == size;
+	context |results| == size;
+	context |xs| == size;
+	requires (\forall int i; 0 <= i && i < |xs|; (\forall int j; 0 <= j && j < |xs| && i != j; xs[i] != xs[j])); // uniqueness
+	requires (\forall int i; 0 <= i && i < |xs|; 0 <= xs[i] && xs[i] < max);
+	ensures (\forall int i; 0 <= i && i < |results|; results[i] == results[Program.maxint(xs, 0, 0)]);
+	process Start(int size, seq<int> xs, int max) = Spawn(0, size, xs, max);
+}
+
+class Program {
+	boolean initialised;
+	int size;
+	int maxvalue;
+	Future f;
+	
+	resource lock_invariant() =
+		Perm(initialised, 1/2) ** Perm(size, 1/2) **
+		Perm(maxvalue, 1/2) ** 0 < maxvalue **
+		(initialised ? Perm(f, 1/2) ** f != null: true) **
+		(initialised ? HPerm(f.channel, write) ** size == |f.channel| : true) **
+		(initialised ? HPerm(f.results, write) ** size == |f.results| : true) **
+		(initialised ==> (\forall int i; 0 <= i && i < size; (\forall int j; 0 <= j && j < |f.channel[i]|; 0 <= f.channel[i][j] && f.channel[i][j] < maxvalue)));
+	
+	requires 0 < max;
+	requires f != null;
+	requires HPerm(f.channel, write);
+	requires HPerm(f.results, write);
+	requires |f.results| == |f.channel|;
+	requires |f.channel| == size;
+	requires (\forall int i; 0 <= i && i < |f.channel|; (\forall int j; 0 <= j && j < |f.channel[i]|; 0 <= f.channel[i][j] && f.channel[i][j] < max));
+	ensures Perm(this.f, 1/2) ** this.f == f;
+	ensures Perm(this.size, 1/2) ** this.size == size;
+	ensures Perm(this.maxvalue, 1/2) ** this.maxvalue == max;
+	ensures Perm(this.initialised, 1/2) ** this.initialised;
+	Program(Future f, int size, int max) {
+		this.f = f;
+		this.maxvalue = max;
+		this.size = size;
+		this.initialised = true;
+	}
+	
+	
+	/* ** Auxiliary operations */
+
+	requires 0 <= i && i < |xs|;
+	ensures |\result| == |xs|;
+	ensures \result[i] == xs[i] + seq<int> { val };
+	ensures (\forall int j; 0 <= j && j < |xs| && j != i; \result[j] == xs[j]);
+	seq<seq<int>> push(seq<seq<int>> xs, int i, int val) =
+		0 < i ? seq<seq<int>> { head(xs) } + push(tail(xs), i - 1, val) : seq<seq<int>> { head(xs) + seq<int> { val } } + tail(xs);
+	
+	requires 0 <= i && i < |xs|;
+	ensures |\result| == |xs|;
+	ensures \result[i] == tail(xs[i]);
+	ensures (\forall int j; 0 <= j && j < |xs| && j != i; \result[j] == xs[j]);
+	seq<seq<int>> pop(seq<seq<int>> xs, int i) =
+		0 < i ? seq<seq<int>> { head(xs) } + pop(tail(xs), i - 1) : seq<seq<int>> { tail(head(xs)) } + tail(xs);
+
+	requires 0 <= i && i < |xs|;
+	ensures |\result| == |xs|;
+	ensures \result[i] == v;
+	ensures (\forall int j; 0 <= j && j < |xs| && j != i; \result[j] == xs[j]);
+	pure static seq<int> update(seq<int> xs, int i, int v) =
+		0 < i ? seq<int> { head(xs) } + update(tail(xs), i - 1, v) : seq<int> { v } + tail(xs);
+	
+	// @param `xs[i]` is the position that is considered now
+	// @param `xs[j]` is the current highest position
+	// @result the index of the highest value in `xs`
+	requires 0 <= i && i <= |xs|;
+	requires 0 <= j && j < |xs|;
+	requires (\forall int l; 0 <= l && l < i; xs[l] <= xs[j]);
+	ensures 0 <= \result && \result < |xs|;
+	ensures xs[j] <= xs[\result];
+	ensures (\forall int l; i <= l && l < |xs|; xs[l] <= xs[\result]);
+	pure static int maxint(seq<int> xs, int i, int j) =
+		i < |xs| ? (xs[j] <= xs[i] ? maxint(xs, i + 1, i) : maxint(xs, i + 1, j)) : j;
+	
+	
+	/* ** Auxiliary lemmas */
+
+	given frac q;
+	context q != none;
+	context Perm(maxvalue, 1/2);
+	context Perm(size, 1/2) ** 0 <= size;
+	context f != null ** HPerm(f.channel, 1/2);
+	context 0 <= rank && rank < size;
+	requires 0 <= x && x <= w;
+	requires Future(f, q, f.SigmaRecv(rank, size, v, w, maxvalue, n));
+	ensures maxvalue == \old(maxvalue);
+	ensures size == \old(size);
+	ensures f.channel == \old(f.channel);
+	ensures Future(f, q, f.Recv((rank - 1) % size, x) * f.Check(rank, size, v, x, maxvalue, n));
+	void lemma_sigmaRecv_choice(Future f, int rank, int v, int w, int x, int n) {
+		if (x == w) {
+			if (0 < x) {
+				choose f, q, f.SigmaRecv(rank, size, v, w, maxvalue, n), f.Recv((rank - 1) % size, x) * f.Check(rank, size, v, w, maxvalue, n);
+			}
+		}
+		else {
+			choose f, q, f.SigmaRecv(rank, size, v, w, maxvalue, n), f.SigmaRecv(rank, size, v, w - 1, maxvalue, n);
+			lemma_sigmaRecv_choice(f, rank, v, w - 1, x, n) with { q = q; };
+		}
+	}
+	
+	given frac q;
+	context q != none;
+	requires n < size;
+	requires 0 <= rank && rank < size;
+	requires Future(f, q, f.Elect(rank, size, v, maxvalue, n));
+	ensures Future(f, q, f.Send((rank + 1) % size, v) * f.SigmaRecv(rank, size, v, maxvalue - 1, maxvalue, n));
+	void lemma_fut_elect(Future f, int rank, int size, int v, int maxvalue, int n) {
+	}
+	
+	
+	/* ** Message passing primitives */
+	
+	given frac q1; // ownership of the program `p`
+	given frac q2; // ownershow of the future `f`
+	given process P;
+	context_everywhere q1 != none && q2 != none;
+	context_everywhere Perm(size, q1) ** Perm(maxvalue, q1);
+	context_everywhere 0 <= rank && rank < size;
+	context_everywhere 0 <= msg && msg < maxvalue;
+	context_everywhere Perm(initialised, q1) ** initialised;
+	context_everywhere Perm(f, q1) ** f != null;
+	requires Future(f, q2, f.Send(rank, msg) * P);
+	ensures Future(f, q2, P);
+	ensures size == \old(size);
+	ensures maxvalue == \old(maxvalue);
+	ensures f == \old(f);
+	void mpi_send(int rank, int msg) {
+		lock this;
+		action(f, q2, P, f.Send(rank, msg)) {
+			f.channel = push(f.channel, rank, msg);
+		}
+		unlock this;
+	}
+	
+	given int v;
+	given int n;
+	given frac q1; // ownership of the program `p`
+	given frac q2; // ownershow of the future `f`
+	context_everywhere q1 != none && q2 != none;
+	context_everywhere Perm(size, q1) ** Perm(maxvalue, q1);
+	context_everywhere 0 <= rank && rank < size;
+	context_everywhere Perm(initialised, q1) ** initialised;
+	context_everywhere Perm(f, q1) ** f != null;
+	requires Future(f, q2, f.SigmaRecv(rank, size, v, maxvalue - 1, maxvalue, n));
+	ensures 0 <= \result && \result < maxvalue;
+	ensures size == \old(size);
+	ensures maxvalue == \old(maxvalue);
+	ensures f == \old(f);
+	ensures Future(f, q2, f.Check(rank, size, v, \result, maxvalue, n));
+	int mpi_recv(int rank) {
+		boolean stop = false;
+		int res; // going to contain the resulting, received value
+		
+		loop_invariant size == \old(size);
+		loop_invariant maxvalue == \old(maxvalue);
+		loop_invariant f == \old(f);
+		loop_invariant 0 <= rank && rank < size;
+		loop_invariant !stop ==> Future(f, q2, f.SigmaRecv(rank, size, v, maxvalue - 1, maxvalue, n));
+		loop_invariant stop ==> Future(f, q2, f.Check(rank, size, v, res, maxvalue, n));
+		loop_invariant stop ==> (0 <= res && res < maxvalue);
+		while (!stop) {
+			lock this;
+			
+			if (0 < |f.channel[(rank - 1) % size]|) {
+				res = head(f.channel[(rank - 1) % size]); // this is the value we'll receive
+				
+				assert Future(f, q2, f.SigmaRecv(rank, size, v, maxvalue - 1, maxvalue, n));
+				lemma_sigmaRecv_choice(f, rank, v, maxvalue - 1, res, n) with { q = q2; };
+				assert Future(f, q2, f.Recv((rank - 1) % size, res) * f.Check(rank, size, v, res, maxvalue, n));
+				
+				action(f, q2, f.Check(rank, size, v, res, maxvalue, n), f.Recv((rank - 1) % size, res)) {
+					f.channel = pop(f.channel, (rank - 1) % size);
+				}
+				
+				stop = true;
+			}
+			
+			unlock this;
+		}
+		
+		return res;
+	}
+
+	/* ** Leader election protocol implementation */
+	
+	given frac q1; // ownership of the program `p`
+	given frac q2; // ownershow of the future `p.f`
+	context_everywhere q1 != none && q2 != none;
+	context_everywhere Perm(size, q1);
+	context_everywhere 0 <= rank && rank < size;
+	context_everywhere Perm(initialised, q1) ** initialised;
+	context_everywhere Perm(maxvalue, q1);
+	context_everywhere 0 <= v && v < maxvalue;
+	requires Perm(f, q1) ** f != null;
+	requires Future(f, q2, f.Elect(rank, size, v, maxvalue, 0));
+	ensures Perm(f, q1) ** f != null;
+	ensures Future(f, q2, f.Done(rank, \result));
+	ensures 0 <= \result && \result < maxvalue;
+	ensures size == \old(size);
+	ensures maxvalue == \old(maxvalue);
+	ensures f == \old(f);
+	int elect(int rank, int v) {
+		int n = 0;
+		
+		loop_invariant size == \old(size);
+		loop_invariant maxvalue == \old(maxvalue);
+		loop_invariant Perm(f, q1) ** f != null;
+		loop_invariant f == \old(f);
+		loop_invariant 0 <= n && n <= size;
+		loop_invariant Future(f, q2, f.Elect(rank, size, v, maxvalue, n));
+		while (n < size) {
+			lemma_fut_elect(f, rank, size, v, maxvalue, n) with { q = q2; };
+			
+			// sending the current value to the left
+			process Q = f.SigmaRecv(rank, size, v, maxvalue - 1, maxvalue, n); // small workaround for verification purposes..
+			mpi_send((rank + 1) % size, v) with { q1 = q1; q2 = q2; P = Q; };
+			assert Q == f.SigmaRecv(rank, size, v, maxvalue - 1, maxvalue, n);
+			assert Future(f, q2, f.SigmaRecv(rank, size, v, maxvalue - 1, maxvalue, n));
+			
+			// receiving a value from the right
+			int w = mpi_recv(rank) with { v = v; n = n; q1 = q1; q2 = q2; };
+			assert Future(f, q2, f.Check(rank, size, v, w, maxvalue, n));
+			assert Future(f, q2, f.Elect(rank, size, v <= w ? w : v, maxvalue, n + 1));
+			
+			if (v <= w) {
+				v = w;
+			}
+			
+			process R = f.Elect(rank, size, v, maxvalue, n + 1); // small workaround for verification purposes..
+			assert Future(f, q2, R);
+			n = n + 1;
+			assert Future(f, q2, R);
+		}
+		
+		return v;
+	}
+}
+
+class Main {
+	Program pr;
+	int rank;
+	int val;
+	frac r1;
+	frac r2;
+	
+	requires r1 != none && r2 != none;
+	ensures Perm(this.pr, write) ** this.pr == pr;
+	ensures Perm(this.rank, write) ** this.rank == rank;
+	ensures Perm(this.val, write) ** this.val == val;
+	ensures Perm(this.r1, write) ** this.r1 == r1;
+	ensures Perm(this.r2, write) ** this.r2 == r2;
+	Main(Program pr, int rank, int val, frac r1, frac r2) {
+		this.pr = pr;
+		this.rank = rank;
+		this.val = val;
+		this.r1 = r1;
+		this.r2 = r2;
+	}
+	
+	context Perm(rank, 1/2);
+	context Perm(val, 1/2);
+	context Perm(pr, 1/2) ** pr != null;
+	context Perm(r1, 1/2) ** r1 != none;
+	context Perm(r2, 1/2) ** r2 != none;
+	context Perm(pr.f, r1) ** pr.f != null;
+	context Perm(pr.size, r1);
+	context Perm(pr.maxvalue, r1);
+	context Perm(pr.initialised, r1) ** pr.initialised;
+	context 0 <= rank && rank < pr.size;
+	context 0 <= val && val < pr.maxvalue;
+	requires Future(pr.f, r2, pr.f.Elect(rank, pr.size, val, pr.maxvalue, 0));
+	ensures Future(pr.f, r2, empty);
+	void run() {
+		int res = pr.elect(rank, val) with { q1 = r1; q2 = r2; };
+		
+		lock pr;
+		action(pr.f, r2, empty, pr.f.Done(rank, res)) {
+			pr.f.results = Program.update(pr.f.results, rank, res);
+		}
+		unlock pr;
+	}
+	
+	context_everywhere 0 < size;
+	context_everywhere 0 < max;
+	context_everywhere |xs| == size;
+	context_everywhere (\forall int j; 0 <= j && j < |xs|; (\forall int k; 0 <= k && k < |xs| && j != k; xs[j] != xs[k]));
+	context_everywhere (\forall int j; 0 <= j && j < |xs|; 0 <= xs[j] && xs[j] < max);
+	static void main(int size, int max, seq<int> xs) {
+		Future f = new Future();
+		f.channel = seq<seq<int>> { };
+		f.results = seq<int> { };
+
+		// initialise communication channels
+		int i = 0;
+		loop_invariant 0 <= i && i <= size;
+		loop_invariant Perm(f.channel, write);
+		loop_invariant Perm(f.results, write);
+		loop_invariant |f.channel| == i;
+		loop_invariant (\forall int j; 0 <= j && j < i; |f.channel[j]| == 0);
+		loop_invariant |f.results| == i;
+		loop_invariant (\forall int j; 0 <= j && j < i; f.results[j] == 0);
+		while (i < size) {
+			f.channel = f.channel + seq<seq<int>> { seq<int> { } };
+			f.results = f.results + seq<int> { 0 };
+			i = i + 1;
+		}
+		
+		// instantiate the future for the leader election protocol
+		create f, f.Start(size, xs, max);
+		assert Future(f, write, f.Spawn(0, size, xs, max));
+		
+		// run the leader election program
+		Program pr = new Program(f, size, max);
+		spawn(0, pr, xs) with { q1 = 1/2; q2 = 1; };
+		
+		// finalise the future
+		lock pr;
+		pr.initialised = false;
+		unlock pr;
+		destroy f;
+		
+		// postcondition
+		assert (\forall int i; 0 <= i && i < |f.results|; f.results[i] == f.results[Program.maxint(xs, 0, 0)]);
+	}
+	
+	given frac q1; // ownership of the program `p`
+	given frac q2; // ownershow of the future `p.f`
+	context_everywhere q1 != none && q2 != none;
+	context_everywhere pr != null;
+	context_everywhere Perm(pr.size, q1);
+	context_everywhere Perm(pr.f, q1) ** pr.f != null;
+	context_everywhere Perm(pr.maxvalue, q1);
+	context_everywhere Perm(pr.initialised, q1) ** pr.initialised;
+	context_everywhere 0 <= rank && rank <= pr.size;
+	context_everywhere |xs| == pr.size;
+	context_everywhere (\forall int j; 0 <= j && j < |xs|; 0 <= xs[j] && xs[j] < pr.maxvalue);
+	requires Future(pr.f, q2, pr.f.Spawn(rank, pr.size, xs, pr.maxvalue));
+	ensures pr == \old(pr);
+	ensures pr.size == \old(pr.size);
+	ensures pr.maxvalue == \old(pr.maxvalue);
+	ensures pr.f == \old(pr.f);
+	ensures Future(pr.f, q2, empty);
+	static void spawn(int rank, Program pr, seq<int> xs) {
+		if (rank < pr.size) {
+			Main m = new Main(pr, rank, xs[rank], q1/2, q2/2);
+			
+			// split off an `Elect` process
+			assert Future(pr.f, q2, pr.f.Spawn(rank, pr.size, xs, pr.maxvalue));
+			assert Future(pr.f, q2, pr.f.Elect(rank, pr.size, xs[rank], pr.maxvalue, 0) || pr.f.Spawn(rank + 1, pr.size, xs, pr.maxvalue));
+			split pr.f, (q2 / 2), pr.f.Elect(rank, pr.size, xs[rank], pr.maxvalue, 0), (q2 / 2), pr.f.Spawn(rank + 1, pr.size, xs, pr.maxvalue);
+			
+			// spawn and join the remaining threads
+			fork m;
+			spawn(rank + 1, pr, xs) with { q1 = q1/2; q2 = q2/2; };
+			join m;
+			
+			// merge the resulting empty processes
+			merge pr.f, q2/2, empty, q2/2, empty;
+		}
+	}
+}


### PR DESCRIPTION
I am adding this example to VerCors in this stand alone branch since we want it to be included in tomorrow first release of VerCors 1.0.0. I changed invariant for context_everywhere in the example since we are using this new keyword from now on.