### PR TITLE
Print warning when sonar is not executed in CI check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_cache:
   - rm -fv $HOME/.ivy2/.sbt.ivy.lock
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
   - find $HOME/.sbt        -name "*.lock"               -print -delete
+  - rm -rf $HOME/.sbt/boot
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,10 @@ matrix:
       - SPLIT=4/5 ./.travis/build.sh
     - script:
       - ./.travis/travis_fold.sh build "Build Vercors" "sbt compile"
+      - echo "TRAVIS_SECURE_ENV_VARS=${TRAVIS_SECURE_ENV_VARS}";
+      - >
+        if [ "${TRAVIS_SECURE_ENV_VARS}" == "false" ]; then
+        echo;
+        echo "The check is running for a pull request for an external repo. At the moment Travis does not support running Sonar for external repositories. The build will fail.";
+        fi;
       - ./.travis/travis_fold.sh sonar "Sonar" "sonar-scanner"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_cache:
   - rm -fv $HOME/.ivy2/.sbt.ivy.lock
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
   - find $HOME/.sbt        -name "*.lock"               -print -delete
-  - rm -rf $HOME/.sbt/boot
+  - rm -rf $HOME/.sbt/boot  # Needed to fix the "nsc.Global not found" error.
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ before_cache:
   - rm -fv $HOME/.ivy2/.sbt.ivy.lock
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
   - find $HOME/.sbt        -name "*.lock"               -print -delete
-  - rm -rf $HOME/.sbt/boot  # Needed to fix the "nsc.Global not found" error.
 
 matrix:
   include:


### PR DESCRIPTION
Ensure a warning is printed if sonar will fail because the environment is not secure.

Info:
https://travis-ci.community/t/pull-request-builds-fail-with-sonar/3473
https://docs.travis-ci.com/user/environment-variables/ (Look for `TRAVIS_SECURE_ENV_VARS`)