### PR TITLE
fixes #308: Error on unsatisfiable method preconditions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ tmp.*
 vct-tool.jar
 *~
 
+# Vim swap file
+*.swp

--- a/examples/basic/ContractSatisfiable.java
+++ b/examples/basic/ContractSatisfiable.java
@@ -1,0 +1,42 @@
+// -*- tab-width:4 ; indent-tabs-mode:nil -*-
+//:: cases ghi
+//:: suite ContractSatisfiable
+//:: tools silicon
+//:: verdict Pass MyClass.foo
+//:: verdict Fail MyClass.baz MyClass.bar MyClass.qux MyClass.complicated_arguments
+
+class MyClass {
+  // User indicates no checking is desired for this function
+  //@ requires false;
+  void foo() {
+    // Should not be triggered
+    //@ assert 1 == 2;
+  }
+
+  // User makes a mistake here
+  //@ requires 3 == 4;
+  void bar() {
+    // Will not be detected but once the requires is fixed should be
+    //@ assert 5 == 6;
+  }
+
+  // Perfectly fine
+  //@ requires 7 == 7;
+  void baz() {
+    // Obviously would be detected
+    //@ assert 8 == 9;
+  }
+
+  // Should not change the situation
+  void qux() {
+    // Obviously would be detected
+    //@ assert 10 == 11;
+  }
+
+  // User error, should be detected
+  requires a > 0 && a < 0 && b > 10;
+  void complicated_arguments(int a, int b) {
+    // Should not be detected
+    //@ assert b < 10;
+  }
+}

--- a/examples/basic/ContractSatisfiable.pvl
+++ b/examples/basic/ContractSatisfiable.pvl
@@ -1,0 +1,42 @@
+// -*- tab-width:4 ; indent-tabs-mode:nil -*-
+//:: cases abc
+//:: suite ContractSatisfiable
+//:: tools silicon
+//:: verdict Pass MyClass.foo
+//:: verdict Fail MyClass.baz MyClass.bar MyClass.qux MyClass.complicated_arguments
+
+class MyClass {
+  // User indicates no checking is desired for this function
+  requires false;
+  void foo() {
+    // Should not be triggered
+    assert 1 == 2;
+  }
+
+  // User makes a mistake here
+  requires 3 == 4;
+  void bar() {
+    // Will not be detected but once the requires is fixed should be
+    assert 5 == 6;
+  }
+
+  // Perfectly fine
+  requires 7 == 7;
+  void baz() {
+    // Obviously would be detected
+    assert 8 == 9;
+  }
+
+  // Should not change the situation
+  void qux() {
+    // Obviously would be detected
+    assert 10 == 11;
+  }
+
+  // User error, should be detected
+  requires a > 0 && a < 0 && b > 10;
+  void complicated_arguments(int a, int b) {
+    // Should not be detected
+    assert b < 10;
+  }
+}

--- a/examples/basic/TurnOffContractSatisfiable.pvl
+++ b/examples/basic/TurnOffContractSatisfiable.pvl
@@ -1,0 +1,33 @@
+// -*- tab-width:4 ; indent-tabs-mode:nil -*-
+//:: cases def
+//:: suite ContractSatisfiable
+//:: tools silicon
+//:: option --disable-sat
+//:: verdict Pass 
+
+class MyClass {
+  // User indicates no checking is desired for this function
+  requires false;
+  void foo() {
+    // Should not be detected
+    assert 1 == 2;
+  }
+
+  // User makes a mistake here, but should not be triggered
+  requires 3 == 4;
+  void bar() {
+    // Also should not be detected
+    assert 5 == 6;
+  }
+
+  // User error, should not be detected
+  requires a > 0 && a < 0 && b > 10;
+  void complicated_arguments(int a, int b) {
+    // Should not be detected
+    assert b < 10;
+  }
+
+  // Also should be fine
+  void baz() {
+  }
+}

--- a/src/main/java/vct/col/rewrite/SatCheckRewriter.java
+++ b/src/main/java/vct/col/rewrite/SatCheckRewriter.java
@@ -17,11 +17,6 @@ import vct.col.ast.stmt.decl.ProgramUnit;
 import vct.col.ast.type.Type;
 import vct.col.util.OriginWrapper;
 
-// Encountered bugs:
-// TODO: (In SilverBackend.java) This bad boy swallows exceptions without a sound?
-// TODO: Contract.getOrigin() is null below?
-// TODO: pass/fail is not adhered to in test?
-
 // Still need to do:
 // TODO: Java tests
 

--- a/src/main/java/vct/col/rewrite/SatCheckRewriter.java
+++ b/src/main/java/vct/col/rewrite/SatCheckRewriter.java
@@ -17,9 +17,6 @@ import vct.col.ast.stmt.decl.ProgramUnit;
 import vct.col.ast.type.Type;
 import vct.col.util.OriginWrapper;
 
-// Still need to do:
-// TODO: Java tests
-
 public class SatCheckRewriter extends AbstractRewriter {
     public static class AssertOrigin extends BranchOrigin {
         public AssertOrigin(String branch, Origin base){

--- a/src/main/java/vct/col/rewrite/SatCheckRewriter.java
+++ b/src/main/java/vct/col/rewrite/SatCheckRewriter.java
@@ -1,10 +1,15 @@
 package vct.col.rewrite;
 
 import hre.ast.BranchOrigin;
+import hre.ast.Origin;
+import scala.reflect.internal.Trees;
 import vct.col.ast.generic.ASTNode;
-import vct.col.ast.stmt.decl.ASTSpecial;
+import vct.col.ast.generic.ASTSequence;
 import vct.col.ast.stmt.composite.BlockStatement;
+import vct.col.ast.stmt.decl.ASTSpecial;
 import vct.col.ast.stmt.decl.Contract;
+import vct.col.ast.type.PrimitiveSort;
+import vct.col.ast.type.PrimitiveType;
 import vct.col.ast.util.ContractBuilder;
 import vct.col.ast.stmt.decl.DeclarationStatement;
 import vct.col.ast.stmt.decl.Method;
@@ -13,6 +18,7 @@ import vct.col.ast.type.Type;
 import vct.col.util.OriginWrapper;
 
 public class SatCheckRewriter extends AbstractRewriter {
+    static int i = 0;
 
     public SatCheckRewriter(ProgramUnit source) {
         super(source);
@@ -20,40 +26,36 @@ public class SatCheckRewriter extends AbstractRewriter {
 
     @Override
     public void visit(Method m) {
-        //checkPermission(m);
-        String name = m.getName();
-        if (currentContractBuilder == null) {
-            currentContractBuilder = new ContractBuilder();
+        // Find out if contract is intentionally false
+        // Since if it is marked as false intentionally we do not have to check it
+        Contract contract = m.getContract();
+        boolean intentional_false = contract != null && contract.pre_condition.isConstant(false);;
+
+        // If the contract is not intentionally false and the method is not abstract,
+        // create a proof obligation that shows the contract is satisfiable
+        if (m.getBody() != null && !intentional_false && (m.kind == Method.Kind.Plain || m.kind == Method.Kind.Constructor)) {
+            // Create { assert false; } block
+            ASTNode my_assert = create.special(ASTSpecial.Kind.Assert, create.constant(false));
+            BranchOrigin my_branch = new BranchOrigin("contract satisfiability check", null);
+            OriginWrapper.wrap(null, my_assert, my_branch);
+            BlockStatement blockStatement = create.block(my_assert);
+
+            // Create an extra method containing it
+            Method assert_method = create.method_kind(
+                    m.getKind(),
+                    rewrite(m.getReturnType()),
+                    rewrite(m.getContract()),
+                    "__contract_unsatisfiable__" + m.name(),
+                    rewrite(m.getArgs()),
+                    m.usesVarArgs(),
+                    blockStatement
+            );
+
+            currentTargetClass.add(assert_method);
         }
-        DeclarationStatement args[] = rewrite(m.getArgs());
-        Contract mc = m.getContract();
-        boolean intentional_false = false;
-        if (mc != null) {
-            rewrite(mc, currentContractBuilder);
-            intentional_false = mc.pre_condition.isConstant(false);
-        }
-        Method.Kind kind = m.kind;
-        Type rt = rewrite(m.getReturnType());
-        Contract c = currentContractBuilder.getContract();
-        currentContractBuilder = null;
-        ASTNode body = rewrite(m.getBody());
-        if (body != null && !intentional_false) {
-            switch (kind) {
-                case Plain:
-                case Constructor:
-                    ASTNode refute = create.special(ASTSpecial.Kind.Refute, create.constant(false));
-                    BranchOrigin branch = new BranchOrigin("Contract Unsatisfiability Check", null);
-                    OriginWrapper.wrap(null, refute, branch);
-                    if (body instanceof BlockStatement) {
-                        ((BlockStatement) body).prepend(refute);
-                    } else {
-                        body = create.block(refute, body);
-                    }
-                default:
-                    break;
-            }
-        }
-        result = create.method_kind(kind, rt, c, name, args, m.usesVarArgs(), body);
+
+        // After visit, result should be equal to the rewritten version of m, i.e. nicely deep cloned
+        super.visit(m);
     }
 
 }

--- a/src/main/java/vct/col/rewrite/SatCheckRewriter.java
+++ b/src/main/java/vct/col/rewrite/SatCheckRewriter.java
@@ -21,7 +21,6 @@ import vct.col.util.OriginWrapper;
 // TODO: (In SilverBackend.java) This bad boy swallows exceptions without a sound?
 // TODO: Contract.getOrigin() is null below?
 // TODO: pass/fail is not adhered to in test?
-// TODO: Add vim temporary files to gitignore?
 
 // Still need to do:
 // TODO: Java tests

--- a/src/main/java/vct/col/rewrite/SatCheckRewriter.java
+++ b/src/main/java/vct/col/rewrite/SatCheckRewriter.java
@@ -14,42 +14,46 @@ import vct.col.util.OriginWrapper;
 
 public class SatCheckRewriter extends AbstractRewriter {
 
-	public SatCheckRewriter(ProgramUnit source) {
-	  super(source);
-  }
+    public SatCheckRewriter(ProgramUnit source) {
+        super(source);
+    }
 
-  @Override
-  public void visit(Method m) {
-    //checkPermission(m);
-    String name=m.getName();
-    if (currentContractBuilder==null) currentContractBuilder=new ContractBuilder();
-    DeclarationStatement args[]=rewrite(m.getArgs());
-    Contract mc=m.getContract();
-    boolean intentional_false=false;
-    if (mc!=null){
-      rewrite(mc,currentContractBuilder);
-      intentional_false=mc.pre_condition.isConstant(false);
+    @Override
+    public void visit(Method m) {
+        //checkPermission(m);
+        String name = m.getName();
+        if (currentContractBuilder == null) {
+            currentContractBuilder = new ContractBuilder();
+        }
+        DeclarationStatement args[] = rewrite(m.getArgs());
+        Contract mc = m.getContract();
+        boolean intentional_false = false;
+        if (mc != null) {
+            rewrite(mc, currentContractBuilder);
+            intentional_false = mc.pre_condition.isConstant(false);
+        }
+        Method.Kind kind = m.kind;
+        Type rt = rewrite(m.getReturnType());
+        Contract c = currentContractBuilder.getContract();
+        currentContractBuilder = null;
+        ASTNode body = rewrite(m.getBody());
+        if (body != null && !intentional_false) {
+            switch (kind) {
+                case Plain:
+                case Constructor:
+                    ASTNode refute = create.special(ASTSpecial.Kind.Refute, create.constant(false));
+                    BranchOrigin branch = new BranchOrigin("Contract Unsatisfiability Check", null);
+                    OriginWrapper.wrap(null, refute, branch);
+                    if (body instanceof BlockStatement) {
+                        ((BlockStatement) body).prepend(refute);
+                    } else {
+                        body = create.block(refute, body);
+                    }
+                default:
+                    break;
+            }
+        }
+        result = create.method_kind(kind, rt, c, name, args, m.usesVarArgs(), body);
     }
-    Method.Kind kind=m.kind;
-    Type rt=rewrite(m.getReturnType());
-    Contract c=currentContractBuilder.getContract();
-    currentContractBuilder=null;
-    ASTNode body=rewrite(m.getBody());
-    if (body!=null && !intentional_false) switch(kind){
-    case Plain:
-    case Constructor:
-      ASTNode refute=create.special(ASTSpecial.Kind.Refute,create.constant(false));
-    	BranchOrigin branch=new BranchOrigin("Contract Unsatisfiability Check",null);
-      OriginWrapper.wrap(null,refute, branch);
-	    if (body instanceof BlockStatement){
-	    	((BlockStatement)body).prepend(refute);
-	    } else {
-	    	body=create.block(refute,body);
-	    }
-    default:
-      break;
-    }
-    result=create.method_kind(kind, rt, c, name, args, m.usesVarArgs(), body);
-  }
 
 }

--- a/src/main/java/vct/logging/VerCorsError.java
+++ b/src/main/java/vct/logging/VerCorsError.java
@@ -27,13 +27,14 @@ public class VerCorsError extends AbstractMessage {
     InvariantNotPreserved,
     InvariantBroken,
     PostConditionFailed,
-    UnspecifiedError,
     MagicWandUnproven,
     MagicWandPreCondition,
     NotWellFormed,
     ApplicationPreCondition,
     CallPreCondition,
-    AssignmentFailed
+    AssignmentFailed,
+    MethodPreConditionUnsound,
+    UnspecifiedError
   }
   
   /**
@@ -46,6 +47,7 @@ public class VerCorsError extends AbstractMessage {
     AssertionFalse,
     DivisionByZero,
     InsufficientPermission,
+    MethodPreConditionFalse,
     UnspecifiedCause
   }
   
@@ -93,6 +95,9 @@ public class VerCorsError extends AbstractMessage {
     case "call.precondition":
       code=CallPreCondition;
       break;
+    case "method.precondition.unsound":
+      code=MethodPreConditionUnsound;
+      break;
     default:
       hre.lang.System.Warning("unspecified error %s",err[0]);
       code=UnspecifiedError;
@@ -110,6 +115,9 @@ public class VerCorsError extends AbstractMessage {
       break;
     case "receiver.not.injective":
       sub=InsufficientPermission;
+      break;
+    case "method.precondition.false":
+      sub = MethodPreConditionFalse;
       break;
     default:
       hre.lang.System.Warning("unspecified cause %s",err[1]);

--- a/src/main/java/vct/silver/SilverStatementMap.java
+++ b/src/main/java/vct/silver/SilverStatementMap.java
@@ -10,6 +10,7 @@ import hre.lang.HREError;
 import vct.col.ast.expr.*;
 import vct.col.ast.expr.constant.ConstantExpression;
 import vct.col.ast.expr.constant.StructValue;
+import vct.col.rewrite.SatCheckRewriter;
 import vct.col.util.ASTMapping;
 import vct.col.ast.generic.ASTNode;
 import vct.col.ast.stmt.composite.*;
@@ -19,6 +20,8 @@ import vct.col.ast.stmt.terminal.ReturnStatement;
 import vct.col.ast.type.*;
 import vct.col.util.ASTUtils;
 import static hre.lang.System.Abort;
+import static hre.lang.System.Output;
+
 import viper.api.*;
 
 public class SilverStatementMap<T,E,S> implements ASTMapping<S> {
@@ -31,6 +34,7 @@ public class SilverStatementMap<T,E,S> implements ASTMapping<S> {
   private SilverExpressionMap<T,E> expr;
 
   public HashSet<Origin> refuted=null;
+  public HashSet<Origin> satCheckAsserts = new HashSet<>();
   
   public SilverStatementMap(ViperAPI<Origin,?,T,E,S,?,?,?> backend,SilverTypeMap<T> type,SilverExpressionMap<T,E> expr){
     this.create = backend.stat;
@@ -274,6 +278,9 @@ public class SilverStatementMap<T,E,S> implements ASTMapping<S> {
     case Exhale:
       return create.exhale(special.getOrigin(),special.args[0].apply(expr));
     case Assert:
+      if (special.getOrigin() instanceof SatCheckRewriter.AssertOrigin) {
+        satCheckAsserts.add(special.getOrigin());
+      }
       return create.assert_(special.getOrigin(),special.args[0].apply(expr));
     case Refute: {
       refuted.add(special.getOrigin());

--- a/src/main/java/vct/silver/VerCorsProgramFactory.java
+++ b/src/main/java/vct/silver/VerCorsProgramFactory.java
@@ -1,5 +1,6 @@
 package vct.silver;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Hashtable;
@@ -42,7 +43,8 @@ public class VerCorsProgramFactory implements
   }
   
   public Hashtable<String,Set<Origin>> refuted;
-  
+  public HashSet<Origin> satCheckAsserts = new HashSet<>();
+
   private ASTFactory<?> create;
    
   @Override
@@ -327,6 +329,10 @@ public class VerCorsProgramFactory implements
         throw new HREError("bad entry: %s",entry.getClass());
       }
     }
+
+    // Save the encountered sat check assert origins for later
+    satCheckAsserts = stat.satCheckAsserts;
+
     long end=System.currentTimeMillis();
     hre.lang.System.Progress("conversion took %dms",end-base);
     return program;

--- a/src/main/java/vct/silver/VerCorsViperAPI.java
+++ b/src/main/java/vct/silver/VerCorsViperAPI.java
@@ -5,10 +5,7 @@ import hre.ast.Origin;
 
 import java.io.PrintWriter;
 import java.nio.file.Path;
-import java.util.Hashtable;
-import java.util.List;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 
 import vct.col.ast.generic.ASTNode;
 import vct.col.ast.stmt.decl.Axiom;
@@ -26,11 +23,18 @@ public class VerCorsViperAPI extends ViperAPI<
     Method, Axiom, ProgramUnit> {
 
   public Hashtable<String,Set<Origin>> refuted=new Hashtable<String,Set<Origin>>();
+
+  private VerCorsProgramFactory programFactory;
+
+  HashSet<Origin> getSatCheckAsserts() {
+    return new HashSet<>(programFactory.satCheckAsserts);
+  }
   
   private VerCorsViperAPI(HREOrigins origin, VerCorsTypeFactory type,
       VerCorsExpressionFactory expr, VerCorsStatementFactory stat,
       VerCorsProgramFactory prog) {
     super(origin, type, expr, stat, prog);
+    programFactory = prog;
   }
 
   public static VerCorsViperAPI get() {
@@ -48,7 +52,7 @@ public class VerCorsViperAPI extends ViperAPI<
 
   @Override
   public List<? extends ViperError<Origin>> verify(Path z3Path,
-      Properties z3Settings, ProgramUnit program, Set<Origin> reachable,
+      Properties z3Settings, ProgramUnit program,
       VerificationControl<Origin> control) {
     throw new Error("Using VerCors backends for Viper is not implemented.");
   }

--- a/viper/src/main/java/viper/api/ViperAPI.java
+++ b/viper/src/main/java/viper/api/ViperAPI.java
@@ -36,7 +36,6 @@ public abstract class ViperAPI<O,Err,T,E,S,DFunc,DAxiom,P> {
       Path z3Path,
       Properties z3Settings,
       P program,
-      java.util.Set<O> reachable,
       VerificationControl<O> control);
   
   public abstract void write_program(PrintWriter pw,P program);

--- a/viper/src/main/scala/viper/api/SilverImplementation.scala
+++ b/viper/src/main/scala/viper/api/SilverImplementation.scala
@@ -76,9 +76,8 @@ class SilverImplementation[O,Err](o:OriginFactory[O])
     //println("verifier output: "+ res);
     res match {
       case Success =>
-        Output("Success!")
+        ()
       case Failure(errors) =>
-        Output("Errors! (%d)", errors.length.asInstanceOf[java.lang.Integer])
         errors foreach { e =>
           if (detail) show("error", e)
           e match {
@@ -104,11 +103,8 @@ class SilverImplementation[O,Err](o:OriginFactory[O])
                 //ve match {
                 case in: viper.silver.ast.Infoed =>
                   //show("offending node's info", in.info)
-                  
                   in.info match {
                     case in: OriginInfo[O] => {
-                      // TODO: Maybe we can test this loc for message string, or set it to SatisfiableCheckOrigin type or something so we can test it with types?
-                      // And then if so, not show the error?
                       val loc = in.loc;
                       //report.add(error_factory.generic_error(loc,err))
                       error.add_extra(loc,because);

--- a/viper/src/main/scala/viper/api/SilverImplementation.scala
+++ b/viper/src/main/scala/viper/api/SilverImplementation.scala
@@ -53,7 +53,7 @@ class SilverImplementation[O,Err](o:OriginFactory[O])
     }
   }
  
-  override def verify(z3Path:Path,z3Settings:Properties,prog:Prog,reachable:java.util.Set[O],
+  override def verify(z3Path:Path,z3Settings:Properties,prog:Prog,
       control:VerificationControl[O]) : List[viper.api.ViperError[O]] = {
     val program = Program(prog.domains.asScala.toList,
               prog.fields.asScala.toList,
@@ -68,7 +68,6 @@ class SilverImplementation[O,Err](o:OriginFactory[O])
     val detail = Reachable.gonogo.detail();
     
     val report = new java.util.ArrayList[viper.api.ViperError[O]]()
-    Reachable.reachable.clear()
     val verifier=createVerifier(z3Path,z3Settings)
     //println("verifier: "+ verifier);
     //Progress("running verify");
@@ -134,9 +133,7 @@ class SilverImplementation[O,Err](o:OriginFactory[O])
          }
        
     }
-    Reachable.reachable.map(
-      o => reachable.add(o.asInstanceOf[OriginInfo[O]].loc)
-    )
+
     report
   }
  

--- a/viper/src/main/scala/viper/api/SilverImplementation.scala
+++ b/viper/src/main/scala/viper/api/SilverImplementation.scala
@@ -92,7 +92,6 @@ class SilverImplementation[O,Err](o:OriginFactory[O])
               val error = ve.offendingNode match {
                 //ve match {
                  case in: viper.silver.ast.Infoed =>
-                  //show("offending node's info", in.info)
                   locFromInfo(in.info) match {
                     case Some(loc) => new viper.api.ViperErrorImpl[O](loc,err)
                     case None => new viper.api.ViperErrorImpl[O](in.pos+": "+err)
@@ -109,8 +108,9 @@ class SilverImplementation[O,Err](o:OriginFactory[O])
                   
                   in.info match {
                     case in: OriginInfo[O] => {
-                      val loc=in.asInstanceOf[OriginInfo[O]].loc
-                      
+                      // TODO: Maybe we can test this loc for message string, or set it to SatisfiableCheckOrigin type or something so we can test it with types?
+                      // And then if so, not show the error?
+                      val loc = in.loc;
                       //report.add(error_factory.generic_error(loc,err))
                       error.add_extra(loc,because);
                     }


### PR DESCRIPTION
This pull request repairs satisfiability checking for method preconditions. I also cleaned up SilverImplementation.scala (results were printed there, as well as in SilverBackend.java. Moved it all to SilverBackend.java) and ViperAPI.java (this api claimed to do reachability checking, but it never did such thing - it only copied a few empty arrays. Removed this parameter to signify absence of this feature in the backend). Lastly I added vim swap files to the gitignore list, to prevent me from accidentally committing them.

It can be turned off by supplying the flag `--disable-sat`.