### PR TITLE
Add type-checking to jspec rules

### DIFF
--- a/examples/basic/par-pointer-simplification.c
+++ b/examples/basic/par-pointer-simplification.c
@@ -1,0 +1,11 @@
+//:: cases ParPointerSimplification
+//:: verdict Pass
+
+//@ context \pointer(ar, len, write);
+void test(int ar[], int len) {
+    for(int i = 0; i < len; i++)
+    //@ context \pointer_index(ar, i, write);
+    {
+
+    }
+}

--- a/parsers/src/main/antlr4/Java7JML.g4
+++ b/parsers/src/main/antlr4/Java7JML.g4
@@ -6,7 +6,7 @@ identifier : javaIdentifier ;
 
 extraIdentifier : valReserved ;
 
-extraType : 'resource' | 'process' | 'frac' | 'zfrac' ;
+extraType : 'resource' | 'process' | 'frac' | 'zfrac' | 'rational' ;
 
 extraAnnotation
     : 'pure'

--- a/src/main/java/vct/col/ast/type/PrimitiveType.java
+++ b/src/main/java/vct/col/ast/type/PrimitiveType.java
@@ -306,6 +306,8 @@ public final class PrimitiveType extends Type {
       return new ConstantExpression(0);
     case Fraction:
       return new ConstantExpression(0);
+    case Rational:
+      return new NameExpression(ASTReserved.NoPerm);
     case Integer:
       return new ConstantExpression(0);
     case Long:

--- a/src/main/java/vct/col/rewrite/RewriteSystem.java
+++ b/src/main/java/vct/col/rewrite/RewriteSystem.java
@@ -1,7 +1,5 @@
 package vct.col.rewrite;
 
-import static hre.lang.System.Debug;
-import static hre.lang.System.Fail;
 import hre.ast.Origin;
 import hre.lang.HREError;
 import hre.lang.Ref;
@@ -26,6 +24,8 @@ import vct.col.ast.type.*;
 import vct.col.util.ASTUtils;
 import vct.util.Configuration;
 
+import static hre.lang.System.*;
+
 class RewriteRule {
   public final String name;
   public final Set<String> vars;
@@ -42,7 +42,7 @@ class RewriteRule {
 class MatchLinear implements ASTMapping1<Boolean,ASTNode> {
   
   public Hashtable<String,Ref<ASTNode>> match=new Hashtable<String, Ref<ASTNode>>();
-  
+
   public MatchLinear(Set<String> vars){
     for(String name:vars){
       match.put(name,new Ref<ASTNode>());

--- a/src/main/java/vct/col/rewrite/RewriteSystem.java
+++ b/src/main/java/vct/col/rewrite/RewriteSystem.java
@@ -456,7 +456,7 @@ class MatchSubstitution extends AbstractRewriter {
     if (e.binder== Binder.Let){
       HashMap<NameExpression, ASTNode> map=new HashMap<NameExpression, ASTNode>();
       for(int i=0;i<decls.length;i++){
-        map.put(create.local_name(decls[i].name()), rewrite(decls[i].initJava()));
+        map.put(create.local_name(decls[i].name()), decls[i].initJava());
       }
       Substitution sigma=new Substitution(source(),map);
       ASTNode tmp=rewrite(e.main);

--- a/src/main/java/vct/col/rewrite/RewriteSystem.java
+++ b/src/main/java/vct/col/rewrite/RewriteSystem.java
@@ -100,6 +100,10 @@ class MatchLinear implements ASTMapping1<Boolean,ASTNode> {
 
   @Override
   public Boolean map(NameExpression e, ASTNode a) {
+    if(a == null || a.getType() == null || !e.getType().supertypeof(null, a.getType())) {
+      return false;
+    }
+
     String name=e.getName();
     Ref<ASTNode> ref=match.get(name);
     if(ref==null){
@@ -426,7 +430,7 @@ class MatchSubstitution extends AbstractRewriter {
           // variable used in rewrite system, but not in LHS? 
           super.visit(e);
         } else {
-          result=copy_rw.rewrite(n);
+          result = n;
         }
       }
     }
@@ -462,6 +466,15 @@ class MatchSubstitution extends AbstractRewriter {
       result=create.binder(e.binder,rewrite(e.result_type),decls,rewrite(e.triggers),rewrite(e.select),rewrite(e.main));
     }
   }
+
+  @Override
+  public void post_visit(ASTNode node) {
+    if(result.getType() == null) {
+      result.setType(node.getType());
+    }
+
+    super.post_visit(node);
+  }
    
 }
 
@@ -476,6 +489,7 @@ class Normalizer extends AbstractRewriter {
   
   @Override
   public void post_visit(ASTNode node){
+    result.setType(node.getType());
     Ref<ASTNode> ref=new Ref<ASTNode>(result);
     boolean again=(node instanceof ExpressionNode) && trs.step(ref);
     super.post_visit(node);

--- a/src/main/java/vct/col/syntax/JavaSyntax.java
+++ b/src/main/java/vct/col/syntax/JavaSyntax.java
@@ -184,7 +184,7 @@ public class JavaSyntax extends Syntax {
     syntax.addPrimitiveType(PrimitiveSort.Short,"short");
     syntax.addPrimitiveType(PrimitiveSort.Process,"process");
     syntax.addPrimitiveType(PrimitiveSort.String,"String");
-    syntax.addPrimitiveType(PrimitiveSort.Rational, "Perm");
+    syntax.addPrimitiveType(PrimitiveSort.Rational, "rational");
     
 
     syntax.addReserved(Public,"public");

--- a/src/main/java/vct/col/util/AbstractTypeCheck.java
+++ b/src/main/java/vct/col/util/AbstractTypeCheck.java
@@ -1493,6 +1493,7 @@ public class AbstractTypeCheck extends RecursiveVisitor<Type> {
     && !arg.isa(StandardOperator.Subscript)
     && !((arg instanceof NameExpression) && (((NameExpression)arg).getKind()==Kind.Field))
     && !arg.getType().isPrimitive(PrimitiveSort.Location)
+    && !arg.isa(StandardOperator.IndependentOf) // Ignore this check in jspec rules
     ){
       Fail("%s is not a heap location",what);
     }

--- a/src/main/java/vct/main/Main.java
+++ b/src/main/java/vct/main/Main.java
@@ -401,17 +401,21 @@ public class Main
           if (features.usesIterationContracts()||features.usesParallelBlocks()||features.usesCSL()||features.usesPragma("omp")){
             passes.add("parallel_blocks"); // pvl parallel blocks are put in separate methods that can be verified seperately. Method call replaces the contract of this parallel block.
             passes.add("standardize");
-            passes.add("check");
           }
           // passes.add("recognize_multidim"); // translate matrices as a flat array (like c does in memory)
+          passes.add("check");
           passes.add("simplify_quant"); // reduce nesting of quantifiers
-          if (features.usesSummation()||features.usesIterationContracts()) passes.add("simplify_sums"); // set of rewrite rules for removing summations
+          if (features.usesSummation()||features.usesIterationContracts()) {
+            passes.add("check");
+            passes.add("simplify_sums"); // set of rewrite rules for removing summations
+          }
           passes.add("standardize");
           passes.add("check");
         }
 
         if (features.usesKernels()){// 8 feb 2018: is this now dead code (to be)? (SB)
           passes.add("kernel-split");
+          passes.add("check");
           passes.add("simplify_quant");
           passes.add("standardize");
           passes.add("check");
@@ -479,8 +483,8 @@ public class Main
         passes.add("assign");
         passes.add("reorder");
         passes.add("standardize");
-        passes.add("check");
 
+        passes.add("check");
         passes.add("simplify_quant");
         passes.add("standardize");
         passes.add("check");
@@ -543,7 +547,9 @@ public class Main
 
         if (silver.used()) {
           passes.add("scale-always"); // syntax: in silicon [p]predicate() is mandatory, so change pred() to [1]pred()
+          passes.add("check"); // the rewrite system needs a type check
           passes.add("silver-optimize"); // rewrite to things that silver likes better
+          passes.add("check"); // the rewrite system needs a type check
           passes.add("quant-optimize"); // some illegal-quantifier constructions need to be written differently (plus optimize)
           passes.add("standardize-functions"); // pure methods do not need to be 'methods', try turning them into functions so silver and chalice can reason more intelligently about them. Pure methods can be used in specifications through this.
           passes.add("standardize");
@@ -551,6 +557,7 @@ public class Main
 
           passes.add("silver");
         } else { //CHALICE
+          passes.add("check"); // rewrite system needs a type check
           passes.add("chalice-optimize");
           passes.add("standardize-functions");
           passes.add("standardize");

--- a/src/main/java/vct/main/RewriteSystems.java
+++ b/src/main/java/vct/main/RewriteSystems.java
@@ -7,6 +7,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import vct.antlr4.parser.Parsers;
 import vct.col.ast.stmt.decl.ProgramUnit;
 import vct.col.rewrite.RewriteSystem;
+import vct.col.util.AbstractTypeCheck;
 import vct.util.Configuration;
 
 public class RewriteSystems {
@@ -23,6 +24,7 @@ public class RewriteSystems {
       unit=systems.get(f);
       if (unit==null){
         unit=Parsers.getParser("jspec").parse(f);
+        new AbstractTypeCheck(unit).check();
         systems.put(f, unit);
       }
     }

--- a/src/main/universal/res/config/simplify_quant_pass1.jspec
+++ b/src/main/universal/res/config/simplify_quant_pass1.jspec
@@ -63,6 +63,12 @@ class simplify_quant_pass1 {
     e2 < e3 && e1 <= e2 == (e2 \memberof [e1..e3))
   }
 
+  axiom starall_bool {
+    (\forall* int i; b1; b2)
+      ==
+    (\forall int i; b1; b2)
+  }
+
   axiom A3 {
     (\forall int i; b1 ; (\forall int j; (b2!j) && b3 ; b4 ) )
       ==
@@ -170,7 +176,7 @@ class simplify_quant_pass1 {
    axiom constant { (\forall* int i;( i \memberof [ e1 .. e2 )) ; Perm( (e3!i) , (e4!i) ) )
                  ==
                    e1 < e2 ==> Perm(e3,e4*(e2-e1)) }
-   
+
    axiom right_plus { (\forall* int i;( i \memberof [ e1 .. e2 )) ; Perm( ar [ i+(e3!i) ] , (e4!i) ) )
                  ==
                  (\forall* int i;  ( i \memberof [ e1+e3 .. e2+e3 )) ; Perm( ar [ i ] , e4 ) ) }
@@ -369,15 +375,15 @@ class simplify_quant_pass1 {
     }
 
     axiom split1 {
-       (\forall* int i;e1;e2**e3)
+       (\forall* int i;b1;r1**r2)
          ==
-       (\forall* int i;e1;e2) ** (\forall* int i;e1;e3)
+       (\forall* int i;b1;r1) ** (\forall* int i;b1;r2)
     }
 
     axiom split2 {
-       (\forall* int i;e1;PointsTo(e2,e3,e4))
+       (\forall* int i;b1;PointsTo(e2,e3,e4))
          ==
-       (\forall* int i;e1;Perm(e2,e3)) ** (\forall int i;e1;e2==e4)
+       (\forall* int i;b1;Perm(e2,e3)) ** (\forall int i;b1;e2==e4)
     }
 
     /* // SJ: unfortunately, this introduces an existential quantifier which is not always a good thing...

--- a/src/main/universal/res/config/simplify_quant_pass1.jspec
+++ b/src/main/universal/res/config/simplify_quant_pass1.jspec
@@ -5,6 +5,7 @@ class simplify_quant_pass1 {
   boolean b1,b2,b3,b4;
   resource r1,r2;
   int i,j,k;
+  rational p1,p2;
 
   axiom aunitr { e1+0 == e1 }
   axiom aunitl { 0+e1 == e1 }
@@ -63,11 +64,13 @@ class simplify_quant_pass1 {
     e2 < e3 && e1 <= e2 == (e2 \memberof [e1..e3))
   }
 
+  /*
   axiom starall_bool {
     (\forall* int i; b1; b2)
       ==
     (\forall int i; b1; b2)
   }
+  */
 
   axiom A3 {
     (\forall int i; b1 ; (\forall int j; (b2!j) && b3 ; b4 ) )
@@ -75,9 +78,9 @@ class simplify_quant_pass1 {
     (\forall int i; b1 && b2 ; (\forall int j; b3 ; b4 ) )
   }
   axiom A3r {
-    (\forall* int i; b1 ; (\forall* int j; (b2!j) && b3 ; b4 ) )
+    (\forall* int i; b1 ; (\forall* int j; (b2!j) && b3 ; r1 ) )
       ==
-    (\forall* int i; b1 && b2 ; (\forall* int j; b3 ; b4 ) )
+    (\forall* int i; b1 && b2 ; (\forall* int j; b3 ; r1 ) )
   }
 
   axiom single_r { (\forall* int i; b1 ; (i == (e1!i)) ==> r1 )
@@ -85,9 +88,9 @@ class simplify_quant_pass1 {
                  (\let int i=e1 ; b1 ==> r1 ) }
 
   axiom A4 {
-    (\forall* int i; b1 ; b2 ==> b4 )
+    (\forall* int i; b1 ; b2 ==> r1 )
       ==
-    (\forall* int i; b1 && b2 ; b4 )
+    (\forall* int i; b1 && b2 ; r1 )
   }
 
   axiom A4b {
@@ -161,9 +164,9 @@ class simplify_quant_pass1 {
                  ==
                  (\forall int i;  ( i \memberof [ e1 .. e2 )) ; b1 ) }
 */
-   axiom LEFTPLUS { (\forall* int i;( i \memberof [ e1 .. e2 )) ; Perm( ar [ (e3!i)+i ] , (e4!i) ) )
+   axiom LEFTPLUS { (\forall* int i;( i \memberof [ e1 .. e2 )) ; Perm( ar [ (e3!i)+i ] , (p1!i) ) )
                  ==
-                 (\forall* int i;  ( i \memberof [ e3+e1 .. e3+e2 )) ; Perm( ar [ i ] , e4 ) ) }
+                 (\forall* int i;  ( i \memberof [ e3+e1 .. e3+e2 )) ; Perm( ar [ i ] , p1 ) ) }
 
    axiom LEFTPLUS2 { (\forall* int i;( i \memberof [ e1 .. e2 )) ;
                         (\forall* int j ; (j \memberof [(e5!i)..(e6!i))) ;
@@ -177,9 +180,9 @@ class simplify_quant_pass1 {
                  ==
                    e1 < e2 ==> Perm(e3,e4*(e2-e1)) }
 
-   axiom right_plus { (\forall* int i;( i \memberof [ e1 .. e2 )) ; Perm( ar [ i+(e3!i) ] , (e4!i) ) )
+   axiom right_plus { (\forall* int i;( i \memberof [ e1 .. e2 )) ; Perm( ar [ i+(e3!i) ] , (p1!i) ) )
                  ==
-                 (\forall* int i;  ( i \memberof [ e1+e3 .. e2+e3 )) ; Perm( ar [ i ] , e4 ) ) }
+                 (\forall* int i;  ( i \memberof [ e1+e3 .. e2+e3 )) ; Perm( ar [ i ] , p1 ) ) }
 
    axiom minus { (\forall* int i;( i \memberof [ e1 .. e2 )) ; Perm( ar [ i-(e3!i) ] , (e4!i) ) )
                  ==

--- a/src/main/universal/res/config/simplify_quant_pass1.jspec
+++ b/src/main/universal/res/config/simplify_quant_pass1.jspec
@@ -64,13 +64,11 @@ class simplify_quant_pass1 {
     e2 < e3 && e1 <= e2 == (e2 \memberof [e1..e3))
   }
 
-  /*
   axiom starall_bool {
     (\forall* int i; b1; b2)
       ==
     (\forall int i; b1; b2)
   }
-  */
 
   axiom A3 {
     (\forall int i; b1 ; (\forall int j; (b2!j) && b3 ; b4 ) )

--- a/src/main/universal/res/config/simplify_quant_pass2.jspec
+++ b/src/main/universal/res/config/simplify_quant_pass2.jspec
@@ -6,6 +6,7 @@ class simplify_quant_pass2 {
   boolean b1,b2,b3,b4;
   resource r1,r2;
   int i,j,k;
+  rational p1,p2;
   
   int ar[];
   
@@ -25,9 +26,9 @@ class simplify_quant_pass2 {
   // simplify x*a+b index.
   // PROBLEM: this is wrong if e3 < 0!
   axiom simplify_linear_ab {
-    (\forall* int i;( i \memberof [ e1 .. e2 )) ; Perm( ar [ i*(e3!i) +(e4!i) ] , (e5!i) ))
+    (\forall* int i;( i \memberof [ e1 .. e2 )) ; Perm( ar [ i*(e3!i) +(e4!i) ] , (p1!i) ))
      ==
-    (\forall* int i;( i \memberof [ e1*e3+e4 .. e2*e3+e4 )) && (i - e4) % e3 == 0 ; Perm( ar [ i ] , e5 ))
+    (\forall* int i;( i \memberof [ e1*e3+e4 .. e2*e3+e4 )) && (i - e4) % e3 == 0 ; Perm( ar [ i ] , p1 ))
   }
   
   // completion for b==0.
@@ -57,9 +58,9 @@ class simplify_quant_pass2 {
   }
   
   axiom simplify_shift_3 {
-    (\forall* int i; b1 ; Perm( ar [ i - (e1!i) ] , (e2!i) ))
+    (\forall* int i; b1 ; Perm( ar [ i - (e1!i) ] , (p1!i) ))
       ==
-    (\forall* int k_fresh ; (\let int i=k_fresh+e1;b1) ; Perm( ar [ k_fresh ] , e2 ))
+    (\forall* int k_fresh ; (\let int i=k_fresh+e1;b1) ; Perm( ar [ k_fresh ] , p1 ))
   }
   
   axiom simplify_shift_scale_1 {

--- a/src/main/universal/res/config/summation.jspec
+++ b/src/main/universal/res/config/summation.jspec
@@ -5,28 +5,29 @@ class summation {
 
     int i,j,v;
     seq<int> ar;
+    seq<seq<int>> ar2;
     int e1,e2,e3,e4,e5;
- 
+
     axiom sum1 {
         (\sum int i ; ( i \memberof [ e1 .. e2 )) ; ar[i])
           ==
         \sum([ e1 .. e2 ) , ar)
     }
-    
+
 /*
     axiom sum2 {
         (\sum int i ; ( i \memberof [ e1 .. e2 )) ; (ar[i]==(v!i))?1:0)
           ==
         \sum([ e1 .. e2),\vcmp(ar,\vrep(v)))
     }
-    
+
     axiom sum2b {
         (\sum int i ; true ;
           (\sum int j ; ( i \memberof [ 0 .. e1 )) && (j \memberof [ 0 .. e2 )) ; (ar[i*e2 + j]==(v!i))?1:0))
           ==
         \sum([ 0 .. e1*e2),\vcmp(ar,\vrep(v)))
     }
-    
+
     axiom sum2c {
         (\sum int i ; ( i \memberof [ 0 .. e1 )) ;
           (\sum int j ; ( j \memberof [ 0 .. e2 )) ; (ar[i*e2 + j]==(v!i))?1:0))
@@ -39,19 +40,17 @@ class summation {
     axiom sum3a {
         (\sum int i ; true ;
           (\sum int j ; ( i \memberof [ 0 .. e1 )) && (j \memberof [ 0 .. e2 )) ;
-                        (ar[i][j]==((v!i)!j))?1:0))
+                        (ar2[i][j]==((v!i)!j))?1:0))
           ==
-        \msum([ 0 .. e1) * [ 0 .. e2),\mcmp(ar,\mrep(v)))
+        \msum([ 0 .. e1) * [ 0 .. e2),\mcmp(ar2,\mrep(v)))
     }
     
     axiom sum3b {
         (\sum int i ; ( i \memberof [ 0 .. e1 )) ;
           (\sum int j ; (j \memberof [ 0 .. e2 )) ;
-                        (ar[i][j]==((v!i)!j))?1:0))
+                        (ar2[i][j]==((v!i)!j))?1:0))
           ==
-        \msum([ 0 .. e1) * [ 0 .. e2),\mcmp(ar,\mrep(v)))
+        \msum([ 0 .. e1) * [ 0 .. e2),\mcmp(ar2,\mrep(v)))
     }
 
 }
-
-

--- a/viper/hre/src/main/java/hre/io/MessageProcess.java
+++ b/viper/hre/src/main/java/hre/io/MessageProcess.java
@@ -7,6 +7,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import static hre.lang.System.Debug;
+import static hre.lang.System.Warning;
 
 /**
  * Provides communication with a interactive external process.


### PR DESCRIPTION
This fixes #309. I've added type-checking to the rewrite rules (simplify_quant etc.). The rules used to be applied structurally without checking type, but now whenever a generic expression occurs, the true AST must be typed, and be a subtype of the denoted type in the rule. This now admits a rule:

```
axiom starall_bool {
  (\forall* int i; b1; b2)
    ==
  (\forall int i; b1; b2)
}
```

where b1, b2 are booleans, which solves the \pointer_index simplification. I've made rules more general that were no longer applied due to the type being too strict, but there's still plenty of (non-applied) low-hanging fruit there I think.

Lastly, I'd like to draw attention to a change I've made in RewriteSystem, i'll comment once I can view the changes...

