### PR TITLE
fixes #332: contract origin null

### DIFF
--- a/examples/basic/ContractSatisfiable.java
+++ b/examples/basic/ContractSatisfiable.java
@@ -34,7 +34,7 @@ class MyClass {
   }
 
   // User error, should be detected
-  requires a > 0 && a < 0 && b > 10;
+  //@ requires a > 0 && a < 0 && b > 10;
   void complicated_arguments(int a, int b) {
     // Should not be detected
     //@ assert b < 10;

--- a/examples/manual/loop.pvl
+++ b/examples/manual/loop.pvl
@@ -2,6 +2,11 @@
 //:: cases LoopPVL
 //:: tools silicon
 //begin(all)
+
+class Counter {
+  int x;
+}
+
 class Loop {
   requires c!=null ** Perm(c.x,1);
   requires y>=0;

--- a/src/main/java/vct/antlr4/parser/PVLtoCOL.java
+++ b/src/main/java/vct/antlr4/parser/PVLtoCOL.java
@@ -130,7 +130,9 @@ public class PVLtoCOL extends ANTLRtoCOL implements PVFullVisitor<ASTNode> {
       }
       throw new HREError("missing case %s",ctx2.toStringTree(parser));
     }
-    return cb.getContract(false);
+    Contract contract = cb.getContract(false);
+    contract.setOrigin(origin(ctx.start,ctx.stop));
+    return contract;
   }
 
   @Override

--- a/src/main/java/vct/col/ast/stmt/decl/Contract.java
+++ b/src/main/java/vct/col/ast/stmt/decl/Contract.java
@@ -156,23 +156,6 @@ public class Contract extends ASTNode {
     }
   }
 
-  /*
-   * Infers origin of the contract based on the minimum and maximum origin
-   * bounds of all the constituent clauses.
-   */
-  public Origin inferOrigin() {
-//    this.invariant=inv;
-//    this. pre_condition= pre_condition;
-//    this.post_condition=post_condition;
-//    this.given=given;
-//    this.yields=yields;
-//    this.modifies=modifies;
-//    this.accesses=accesses;
-//    this.signals=signals;
-
-    new FileOrigin()
-  }
-
   @Override
   public Iterable<String> debugTreeChildrenFields() {
     return JavaConverters.iterableAsScalaIterable(Arrays.asList("invariant", "pre_condition", "post_condition", "given", "yields", "signals", "modifies", "accesses"));

--- a/src/main/java/vct/col/ast/stmt/decl/Contract.java
+++ b/src/main/java/vct/col/ast/stmt/decl/Contract.java
@@ -1,6 +1,7 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 package vct.col.ast.stmt.decl;
 
+import hre.ast.FileOrigin;
 import hre.ast.MessageOrigin;
 import hre.ast.Origin;
 
@@ -155,6 +156,22 @@ public class Contract extends ASTNode {
     }
   }
 
+  /*
+   * Infers origin of the contract based on the minimum and maximum origin
+   * bounds of all the constituent clauses.
+   */
+  public Origin inferOrigin() {
+//    this.invariant=inv;
+//    this. pre_condition= pre_condition;
+//    this.post_condition=post_condition;
+//    this.given=given;
+//    this.yields=yields;
+//    this.modifies=modifies;
+//    this.accesses=accesses;
+//    this.signals=signals;
+
+    new FileOrigin()
+  }
 
   @Override
   public Iterable<String> debugTreeChildrenFields() {

--- a/src/main/java/vct/col/ast/util/ContractBuilder.java
+++ b/src/main/java/vct/col/ast/util/ContractBuilder.java
@@ -126,7 +126,7 @@ public class ContractBuilder {
     if (pre_condition==default_true) {
       pre_condition=condition;
     } else {
-      ASTNode tmp=post_condition;
+      ASTNode tmp=pre_condition;
       if (at_end){
         pre_condition = new OperatorExpression(StandardOperator.Star, new ASTNode[] { pre_condition, condition });
       } else {

--- a/src/main/java/vct/col/rewrite/AbstractRewriter.java
+++ b/src/main/java/vct/col/rewrite/AbstractRewriter.java
@@ -223,7 +223,9 @@ public class AbstractRewriter extends AbstractVisitor<ASTNode> {
     ContractBuilder cb=new ContractBuilder();
     rewrite(c,cb);
     Contract contract = cb.getContract();
-    contract.setOrigin(c.getOrigin());
+    if (contract.getOrigin() == null) {
+      contract.setOrigin(c.getOrigin());
+    }
     return contract;
   }
 
@@ -484,7 +486,7 @@ public class AbstractRewriter extends AbstractVisitor<ASTNode> {
     Method.Kind kind=m.kind;
     Type rt=rewrite(m.getReturnType());
     Contract c=currentContractBuilder.getContract();
-    if (mc != null) {
+    if (mc != null && c.getOrigin() == null) {
       c.setOrigin(mc.getOrigin());
     }
     currentContractBuilder=null;

--- a/src/main/java/vct/col/rewrite/AnnotationInterpreter.java
+++ b/src/main/java/vct/col/rewrite/AnnotationInterpreter.java
@@ -4,14 +4,11 @@ import hre.lang.HREError;
 
 import java.util.ArrayList;
 
-import vct.col.ast.stmt.decl.ASTFlags;
+import vct.col.ast.stmt.decl.*;
 import vct.col.ast.generic.ASTNode;
 import vct.col.ast.type.ASTReserved;
 import vct.col.ast.util.ContractBuilder;
-import vct.col.ast.stmt.decl.DeclarationStatement;
-import vct.col.ast.stmt.decl.Method;
 import vct.col.ast.expr.NameExpression;
-import vct.col.ast.stmt.decl.ProgramUnit;
 import vct.col.ast.type.Type;
 
 public class AnnotationInterpreter extends AbstractRewriter {
@@ -27,6 +24,10 @@ public class AnnotationInterpreter extends AbstractRewriter {
     Type returns=rewrite(m.getReturnType());
     ContractBuilder cb=new ContractBuilder();
     rewrite(m.getContract(),cb);
+    Contract contract = cb.getContract();
+    if (contract != null && contract.getOrigin() == null) {
+      contract.setOrigin(m.getContract().getOrigin());
+    }
     String name=m.getName();
     DeclarationStatement args[]=rewrite(m.getArgs());
     ASTNode body=rewrite(m.getBody());
@@ -43,7 +44,7 @@ public class AnnotationInterpreter extends AbstractRewriter {
         ann.add(rewrite(a));
       }
     }
-    Method res=create.method_kind(kind, returns, cb.getContract(), name, args, varArgs, body);
+    Method res=create.method_kind(kind, returns, contract, name, args, varArgs, body);
     if (m.annotated()) {
       res.attach();
       for (ASTNode a : ann){

--- a/viper/hre/src/main/java/hre/ast/FileOrigin.java
+++ b/viper/hre/src/main/java/hre/ast/FileOrigin.java
@@ -26,7 +26,7 @@ public class FileOrigin extends Origin {
   }
 
   private static Hashtable<String,FileContext> data=new Hashtable<String,FileContext>();
-  
+
   public void printContext(int before,int after){
     String file=getName();
     FileContext fc=data.get(file);
@@ -103,6 +103,42 @@ public class FileOrigin extends Origin {
 
     public FileOrigin merge(FileOrigin origin){
       return new FileOrigin(file_name,first_line,first_col,origin.last_line,origin.last_col);
+    }
+
+  /**
+   * Merges this and origin into the combined area they represent.
+   * ensures \return == FileOrigin(Math.min(this, origin), Math.max(this, origin))
+   * @param origin
+   * @return
+   */
+    public FileOrigin maximumMerge(FileOrigin origin) {
+      assert file_name == origin.file_name;
+
+      int new_first_line, new_first_col, new_last_line, new_last_col;
+
+      if (first_line < origin.first_line) {
+        new_first_line = first_line;
+        new_first_col = first_col;
+      } else if (first_line == origin.first_line) {
+        new_first_line = first_line;
+        new_first_col = Math.min(first_col, origin.first_col);
+      } else {
+        new_first_line = origin.first_line;
+        new_first_col = origin.first_col;
+      }
+
+      if (last_line < origin.last_line) {
+        new_last_line = origin.last_line;
+        new_last_col = origin.last_col;
+      } else if (last_line == origin.last_line) {
+        new_last_line = last_line;
+        new_last_col = Math.max(last_col, origin.last_col);
+      } else {
+        new_last_line = last_line;
+        new_last_col = last_col;
+      }
+
+      return new FileOrigin(file_name, new_first_line, new_first_col, new_last_line, new_last_col);
     }
 
     public FileOrigin(String file_name,int first_line, int first_col){


### PR DESCRIPTION
This fixes #332 by:

- making sure when contracts are rewritten the origin is preserved (which happens in quite a few places)
- when contracts are collected by SpecificationCollector, the individual regions from the ASTNodes are combined into one region when contract parts are collected into a contract

I thought about making ContractBuilder aware of origins, as this was mostly caused by that. However, this would result in an incomplete view of the complete origin on the contract. Since given a `requires P` clause, a ContractBuilder is only given the `P` part of the requires clause, not the whole `requires P` ASTNode. Hence, if ContractBuilder would track the origins, the `requires` part would disappear from the origin, which is ugly.

Also, it seems not something ContractBuilder should concern itself with - it seems like more of a parser problem. The approach added to SpecificationCollector seems to be in harmony with how SpecificationCollector works at the moment.