### PR TITLE
fix generation of empty classpath

### DIFF
--- a/bin/run-class
+++ b/bin/run-class
@@ -6,8 +6,13 @@ set -e
 # refer to this script to run classes from the vercors project.
 
 BIN=$(dirname $0)
-if [ ! -f "$BIN/.classpath" ]; then
-    sbt "export compile:fullClasspath" 2>/dev/null | grep -v "^\\[" > "$BIN/.classpath"
+if [ ! -f "$BIN/.classpath" ] || [ ! -s "$BIN/.classpath" ]; then
+    #    Instruct sbt to export the classpath
+    #    |                               Duplicate stdout to...
+    #    |                               |     grep, filtering _out_ lines starting with "["
+    #    |                               |     |              save that to .classpath
+    #    |                               |     |              |                      display _only_ lines starting with "["
+    sbt "export compile:fullClasspath" | tee >(grep -v "^\\[" > "$BIN/.classpath") | grep "^\\["
 fi
 
 CLASSPATH=$(cat "$BIN/.classpath")


### PR DESCRIPTION
An empty classpath is generated when SBT returns an exit code. Now we re-generate the cached classpath when the file is empty, as well as redirecting SBT log messages to the user instead of discarding them.