### PR TITLE
Prevent demo4.pvl from combining --check-history and --check-defined

### DIFF
--- a/examples/demo/demo4.pvl
+++ b/examples/demo/demo4.pvl
@@ -1,7 +1,7 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 //:: cases demo4
 //:: tools silicon
-//:: options --check-history --check-defined
+//:: options --check-history
 //:: verdict Pass
 
 // for analysing the models' contract, run: `vct --silicon --check-defined demo4.pvl`


### PR DESCRIPTION
Remove --check-defined since it is not intended to be used together with --check-history. Using --check-defined hides the failure of --check-history. There should be a fix later on in #374 that reinstates this flag such that further regressions will be detected.