### PR TITLE
Fix imported java std types

### DIFF
--- a/examples/classes/DifferentClassesDifferentTypes1.java
+++ b/examples/classes/DifferentClassesDifferentTypes1.java
@@ -1,0 +1,19 @@
+// -*- tab-width:4 ; indent-tabs-mode:nil -*-
+//:: cases DifferentClassesDifferentTypes1
+//:: tools silicon
+//:: verdict Pass
+
+class A {}
+class B {}
+
+class DifferentClassesDifferentTypes1 {
+    void foo() {
+        A a = new A();
+        B b = new B();
+
+        assert !(a instanceof B);
+        assert !(b instanceof A);
+        assert a instanceof A;
+        assert b instanceof B;
+    }
+}

--- a/examples/classes/DifferentClassesDifferentTypes2.java
+++ b/examples/classes/DifferentClassesDifferentTypes2.java
@@ -1,0 +1,15 @@
+// -*- tab-width:4 ; indent-tabs-mode:nil -*-
+//:: cases DifferentClassesDifferentTypes2
+//:: tools silicon
+//:: verdict Fail
+
+class A {}
+class B {}
+
+class DifferentClassesDifferentTypes2 {
+    void foo() {
+        A a = new A();
+        B b = new B();
+        assert a instanceof B;
+    }
+}

--- a/examples/classes/NewException.java
+++ b/examples/classes/NewException.java
@@ -1,0 +1,5 @@
+class MyClass {	
+	void foo() {
+		new Exception();
+	}
+}

--- a/examples/classes/NewRuntimeException.java
+++ b/examples/classes/NewRuntimeException.java
@@ -1,10 +1,10 @@
 // -*- tab-width:4 ; indent-tabs-mode:nil -*-
-//:: cases NewException
+//:: cases NewRuntimeException
 //:: tools silicon
 //:: verdict Pass
 
 class MyClass {	
 	void foo() {
-		new Exception();
+		new RuntimeException();
 	}
 }

--- a/examples/classes/OnlyClass.java
+++ b/examples/classes/OnlyClass.java
@@ -1,0 +1,7 @@
+// -*- tab-width:4 ; indent-tabs-mode:nil -*-
+//:: cases OnlyClass
+//:: tools silicon
+//:: verdict Pass
+class OnlyClass {
+
+}

--- a/examples/classes/OnlyExtends.java
+++ b/examples/classes/OnlyExtends.java
@@ -1,0 +1,7 @@
+// -*- tab-width:4 ; indent-tabs-mode:nil -*-
+//:: cases OnlyExtends
+//:: tools silicon
+//:: verdict Pass
+class OnlyExtends extends Object {
+
+}

--- a/examples/classes/OnlyInstanceof.java
+++ b/examples/classes/OnlyInstanceof.java
@@ -1,0 +1,12 @@
+// -*- tab-width:4 ; indent-tabs-mode:nil -*-
+//:: cases OnlyInstanceof
+//:: suite skip-travis
+//:: tools silicon
+//:: verdict Pass
+
+class MyClass {
+    void foo() {
+        boolean b = this instanceof MyClass;
+        assert b;
+    }
+}

--- a/examples/classes/OnlyNew.java
+++ b/examples/classes/OnlyNew.java
@@ -1,0 +1,10 @@
+// -*- tab-width:4 ; indent-tabs-mode:nil -*-
+//:: cases OnlyNew
+//:: tools silicon
+//:: verdict Pass
+class MyClass {
+    void foo() {
+        MyClass myClass = new MyClass();
+        assert myClass instanceof MyClass;
+    }
+}

--- a/examples/witnesses/ListAppendASyncDef.java
+++ b/examples/witnesses/ListAppendASyncDef.java
@@ -18,7 +18,7 @@ final class List {
   public List next;
   
   /*@
-    public resource state()=
+    public final resource state()=
       Perm(val,1)**Perm(next,1)**next->state();
 
     requires state();
@@ -26,7 +26,7 @@ final class List {
         ((next==null)?(seq<int>{val})
                     :(seq<int>{val}+next.contents()));
 
-    public resource list(seq<int> c)=state() ** contents()==c;
+    public final resource list(seq<int> c)=state() ** contents()==c;
   @*/
 
   /*@
@@ -38,7 +38,7 @@ final class List {
     //@ fold state();
     //@ fold list(seq<int>{v});
   }
-  
+
   /*@
     given    seq<int> L1;
     given    seq<int> L2;

--- a/examples/witnesses/ListAppendASyncDefInline.java
+++ b/examples/witnesses/ListAppendASyncDefInline.java
@@ -11,9 +11,9 @@ final class List {
 
   public int val;
   public List next;
-  
+
   /*@
-    public resource state()=
+    public final resource state()=
       Perm(val,1)**Perm(next,1)**next->state();
 
     requires state();
@@ -32,7 +32,7 @@ final class List {
     next=null;
     //@ fold state();
   }
-  
+
   /*@
     given    seq<int> L1;
     given    seq<int> L2;

--- a/src/main/java/vct/antlr4/parser/Java7JMLtoCol.java
+++ b/src/main/java/vct/antlr4/parser/Java7JMLtoCol.java
@@ -134,7 +134,8 @@ public class Java7JMLtoCol extends ANTLRtoCOL implements Java7JMLVisitor<ASTNode
 
   public ASTClass getClassOrIntefaceDeclaration(ParserRuleContext ctx) {
     int N=ctx.getChildCount()-1;
-    ClassType[]bases=null;
+    // https://docs.oracle.com/javase/specs/jls/se7/html/jls-4.html#jls-4.10 4.10.2
+    ClassType[] bases = new ClassType[]{create.class_type(new String[]{"java", "lang", "Object"})};
     ClassType[]supports=null;
     ContractBuilder cb=new ContractBuilder();
     DeclarationStatement parameters[]=null;
@@ -180,6 +181,7 @@ public class Java7JMLtoCol extends ANTLRtoCOL implements Java7JMLVisitor<ASTNode
     } else {
       return null;
     }
+
     ASTClass cl=create.ast_class(getIdentifier(ctx,1), kind ,parameters, bases , supports );
     scan_body(cl,(ParserRuleContext)ctx.getChild(N));
     cl.setContract(cb.getContract());

--- a/src/main/java/vct/antlr4/parser/JavaResolver.java
+++ b/src/main/java/vct/antlr4/parser/JavaResolver.java
@@ -362,17 +362,6 @@ public class JavaResolver extends AbstractRewriter {
   
   @Override
   public ProgramUnit rewriteAll(){
-    // TODO (Bob): Temporary workaround to ensure Object is resolved for java programs. Preferably this is enforced somehow in language
-    // specific passes so we don't have to scan for keywords.
-    FeatureScanner features=new FeatureScanner();
-    source().accept(features);
-    if (features.usesOperator(StandardOperator.Instance)
-          || features.usesInheritance()
-          || features.usesOperator(StandardOperator.TypeOf)
-    ){
-      ensures_loaded("java", "lang", "Object");
-    }
-
     for(ASTDeclaration n:source().get()){
       queue.add(n);
     }

--- a/src/main/java/vct/antlr4/parser/JavaResolver.java
+++ b/src/main/java/vct/antlr4/parser/JavaResolver.java
@@ -99,7 +99,8 @@ public class JavaResolver extends AbstractRewriter {
     		  args[i]=create.field_decl("x"+i, convert_type(pars[i]));
     	  }
     	  // Use class name here to uphold convention that constructor name == class name.
-    	  Method ast = create.method_kind(Kind.Constructor, null, null, res.getName(), args, null);
+          // Constructors return void, since an out parameter is added later.
+    	  Method ast = create.method_kind(Kind.Constructor, create.primitive_type(PrimitiveSort.Void), null, res.getName(), args, null);
     	  res.add(ast);
       }
       for(java.lang.reflect.Field field:cl.getFields()){

--- a/src/main/java/vct/antlr4/parser/JavaResolver.java
+++ b/src/main/java/vct/antlr4/parser/JavaResolver.java
@@ -61,7 +61,6 @@ public class JavaResolver extends AbstractRewriter {
       create.enter();
       create.setOrigin(new MessageOrigin("library class %s",cl_name));
       ASTClass res=create.new_class(ClassName.toString(name,FQN_SEP),null,null);
-      target().library_add(new ClassName(cln.toString(FQN_SEP)),res);
       // Temporarily switch off including methods
       // TODO (Bob): We want these methods around if they are used in the rest of the program! So figure out a way to include them but also prune the added imports
       // We use getDeclaredMethods to exclude inherited methods. Inherited methods should be added by a proper inheritance pass.

--- a/src/main/java/vct/antlr4/parser/JavaResolver.java
+++ b/src/main/java/vct/antlr4/parser/JavaResolver.java
@@ -367,6 +367,9 @@ public class JavaResolver extends AbstractRewriter {
         target().add(tmp);
       }
     }
+
+    ensures_loaded("java", "lang", "Object");
+
     target().index_classes();
     return target();
   }

--- a/src/main/java/vct/antlr4/parser/JavaResolver.java
+++ b/src/main/java/vct/antlr4/parser/JavaResolver.java
@@ -368,8 +368,6 @@ public class JavaResolver extends AbstractRewriter {
       }
     }
 
-    ensures_loaded("java", "lang", "Object");
-
     target().index_classes();
     return target();
   }

--- a/src/main/java/vct/antlr4/parser/JavaResolver.java
+++ b/src/main/java/vct/antlr4/parser/JavaResolver.java
@@ -12,6 +12,7 @@ import hre.ast.MessageOrigin;
 import hre.ast.Origin;
 import hre.lang.HREError;
 import vct.col.ast.expr.NameExpression;
+import vct.col.ast.expr.StandardOperator;
 import vct.col.ast.stmt.decl.Method.Kind;
 import vct.col.ast.stmt.decl.NameSpace.Import;
 import vct.col.ast.generic.ASTNode;
@@ -20,6 +21,7 @@ import vct.col.ast.type.ClassType;
 import vct.col.ast.type.PrimitiveSort;
 import vct.col.ast.type.Type;
 import vct.col.rewrite.AbstractRewriter;
+import vct.col.util.FeatureScanner;
 import vct.col.util.Parser;
 import vct.util.ClassName;
 
@@ -367,6 +369,17 @@ public class JavaResolver extends AbstractRewriter {
   
   @Override
   public ProgramUnit rewriteAll(){
+    // TODO (Bob): Temporary workaround to ensure Object is resolved for java programs. Preferably this is enforced somehow in language
+    // specific passes so we don't have to scan for keywords.
+    FeatureScanner features=new FeatureScanner();
+    source().accept(features);
+    if (features.usesOperator(StandardOperator.Instance)
+          || features.usesInheritance()
+          || features.usesOperator(StandardOperator.TypeOf)
+    ){
+      ensures_loaded("java", "lang", "Object");
+    }
+
     for(ASTDeclaration n:source().get()){
       queue.add(n);
     }

--- a/src/main/java/vct/antlr4/parser/JavaResolver.java
+++ b/src/main/java/vct/antlr4/parser/JavaResolver.java
@@ -61,16 +61,10 @@ public class JavaResolver extends AbstractRewriter {
       create.enter();
       create.setOrigin(new MessageOrigin("library class %s",cl_name));
       ASTClass res=create.new_class(ClassName.toString(name,FQN_SEP),null,null);
-      // TODO (Bob): Is this the right design decision?
-      // Do not add the original class name to the library, as the class is renamed anyway!
-      // This way we keep a single name of the class in the program consistently
-      // Whenever it breaks we'll just have to fix it with the "real" name
-//      target().library_add(cln,res);
       target().library_add(new ClassName(cln.toString(FQN_SEP)),res);
-      // TODO (Bob): We use getDeclaredMethods to exclude inherited methods. Inherited methods should be added by a proper inheritance pass, ideally. But maybe that's wrong, and then that stuff should be handled right here.
-      // However another possibility is to also pull in the extends/implements keywords here and make vercors understand them so flattening can happen whenever we want.
       // Temporarily switch off including methods
       // TODO (Bob): We want these methods around if they are used in the rest of the program! So figure out a way to include them but also prune the added imports
+      // We use getDeclaredMethods to exclude inherited methods. Inherited methods should be added by a proper inheritance pass.
 //      for(java.lang.reflect.Method m:cl.getDeclaredMethods()){
 //        // Only public methods are allowed since protected is only accesible from the same package (and we're not std) and private is not accesible altogether
 //        if (!Modifier.isPublic(m.getModifiers())) {

--- a/src/main/java/vct/antlr4/parser/JavaResolver.java
+++ b/src/main/java/vct/antlr4/parser/JavaResolver.java
@@ -83,7 +83,8 @@ public class JavaResolver extends AbstractRewriter {
     	  for(int i=0;i<pars.length;i++){
     		  args[i]=create.field_decl("x"+i, convert_type(pars[i]));
     	  }
-    	  Method ast = create.method_kind(Kind.Constructor, null, null, m.getName(), args, null);
+    	  // Use class name here to uphold convention that constructor name == class name.
+    	  Method ast = create.method_kind(Kind.Constructor, null, null, res.getName(), args, null);
     	  res.add(ast);
       }
       for(java.lang.reflect.Field field:cl.getFields()){

--- a/src/main/java/vct/col/ast/stmt/decl/ASTFlags.java
+++ b/src/main/java/vct/col/ast/stmt/decl/ASTFlags.java
@@ -20,4 +20,6 @@ public interface ASTFlags {
 
   public final int EXTERN = 0x0100;
 
+  public final int UNIQUE = 0x0200;
+
 }

--- a/src/main/java/vct/col/ast/stmt/decl/AxiomaticDataType.scala
+++ b/src/main/java/vct/col/ast/stmt/decl/AxiomaticDataType.scala
@@ -6,6 +6,7 @@ import scala.collection.JavaConverters._
 import vct.col.ast.util.ASTVisitor
 import vct.col.util.{ASTMapping, ASTMapping1, VisitorHelper}
 import vct.util.ClassName
+import hre.lang.System.Abort
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -38,6 +39,16 @@ case class AxiomaticDataType(override val name:String, val parameters:List[Decla
 
   def add_cons(m:Method) : Unit = {
     m.setFlag(ASTFlags.STATIC, true)
+    m.setParent(this)
+    constructors += m
+  }
+
+  def add_unique_cons(m:Method) : Unit = {
+    if (m.getArgs.length != 0) {
+      Abort("Unique constructors cannot have any formal parameters");
+    }
+
+    m.setFlag(ASTFlags.UNIQUE, true);
     m.setParent(this)
     constructors += m
   }

--- a/src/main/java/vct/col/ast/stmt/decl/ProgramUnit.java
+++ b/src/main/java/vct/col/ast/stmt/decl/ProgramUnit.java
@@ -52,7 +52,7 @@ public class ProgramUnit implements ASTSequence<ProgramUnit>, DebugNode {
     return format;
   }
   
-  private static HashMap<ClassName, ASTClass> library=new HashMap<ClassName, ASTClass>();
+  public static HashMap<ClassName, ASTClass> library=new HashMap<ClassName, ASTClass>();
   
   static {
     ASTFactory<?> create=new ASTFactory<Object>();

--- a/src/main/java/vct/col/ast/stmt/decl/ProgramUnit.java
+++ b/src/main/java/vct/col/ast/stmt/decl/ProgramUnit.java
@@ -52,23 +52,6 @@ public class ProgramUnit implements ASTSequence<ProgramUnit>, DebugNode {
     return format;
   }
   
-  public static HashMap<ClassName, ASTClass> library=new HashMap<ClassName, ASTClass>();
-  
-  static {
-    ASTFactory<?> create=new ASTFactory<Object>();
-    create.setOrigin(new MessageOrigin("<<ProgramUnit>>"));
-    ASTClass seq=create.ast_class("seq", ClassKind.Plain, null,null, null);
-    Method len=create.function_decl(create.primitive_type(PrimitiveSort.Integer), null, "length", new DeclarationStatement[0], null);
-    seq.add_dynamic(len);
-    library.put(new ClassName("seq"),seq);
-    //ASTClass var=create.ast_class("var", ClassKind.Plain, null, null);
-    
-  }
-
-  public void library_add(ClassName name,ASTClass cl){
-    library.put(name,cl);
-  }
-
   private EnumMap<LanguageFlag, Boolean> languageFlags = new EnumMap<>(LanguageFlag.class);
 
   /**
@@ -120,7 +103,7 @@ public class ProgramUnit implements ASTSequence<ProgramUnit>, DebugNode {
   public void addClass(String name[],ASTClass cl){
     addClass(new ClassName(name),cl);
   }
-  
+
   public void addClass(ClassType type,ASTClass cl){
     addClass(type.getNameFull(),cl);
   }
@@ -234,9 +217,6 @@ public class ProgramUnit implements ASTSequence<ProgramUnit>, DebugNode {
         cl=base.find(name.name,1);
       }
     }
-    if (cl==null){
-      cl=library.get(name);
-    }
     return cl;
   }
 
@@ -261,9 +241,6 @@ public class ProgramUnit implements ASTSequence<ProgramUnit>, DebugNode {
   public ASTDeclaration find_decl(String[] nameFull) {
     ClassName class_name=new ClassName(nameFull);
     ASTDeclaration res=decl_map.get(class_name);
-    if (res==null){
-      res=library.get(class_name);
-    }
     return res;
   }
   

--- a/src/main/java/vct/col/print/JavaPrinter.java
+++ b/src/main/java/vct/col/print/JavaPrinter.java
@@ -752,6 +752,9 @@ public class JavaPrinter extends AbstractPrinter {
           case ASTFlags.EXTERN:
             out.printf("/*@ extern @*/ ");
             break;
+          case ASTFlags.UNIQUE:
+            out.printf("unique ");
+            break;
           default:
             throw new HREError("unknown flag %04x",i);
           }

--- a/src/main/java/vct/col/rewrite/AddTypeADT.java
+++ b/src/main/java/vct/col/rewrite/AddTypeADT.java
@@ -104,7 +104,7 @@ public class AddTypeADT extends AbstractRewriter {
   private void addDirectSuperclassAxiom(ASTClass cl) {
     String cl_adt_constructor = "class_" + cl.name();
     String type_var = "t";
-    // Axiom: forall t: TYPE :: (t != ct || t == cl) ? instanceof(cl, t) : !instanceof(cl, t)
+    // Axiom: forall t: TYPE :: (t == Object || t == cl) ? instanceof(cl, t) : !instanceof(cl, t)
     // In other words: cl is only an instance of object and cl, and nothing else
     // This will need to be significantly enhanced to allow for a type system with a partial order/inheritance
     adt.add_axiom(create.axiom(cl.name() + "_direct_superclass",

--- a/src/main/java/vct/col/rewrite/CurrentThreadRewriter.java
+++ b/src/main/java/vct/col/rewrite/CurrentThreadRewriter.java
@@ -98,7 +98,7 @@ public class CurrentThreadRewriter extends AbstractRewriter {
    */
   private boolean affected(Method m){
     Type returnType = m.getReturnType();
-    if (returnType != null && returnType.isPrimitive(PrimitiveSort.Process)) return false;
+    if (returnType.isPrimitive(PrimitiveSort.Process)) return false;
     switch(m.kind){
       case Constructor:
       case Plain:

--- a/src/main/java/vct/col/rewrite/CurrentThreadRewriter.java
+++ b/src/main/java/vct/col/rewrite/CurrentThreadRewriter.java
@@ -97,7 +97,8 @@ public class CurrentThreadRewriter extends AbstractRewriter {
    * @param m
    */
   private boolean affected(Method m){
-    if (m.getReturnType().isPrimitive(PrimitiveSort.Process)) return false;
+    Type returnType = m.getReturnType();
+    if (returnType != null && returnType.isPrimitive(PrimitiveSort.Process)) return false;
     switch(m.kind){
       case Constructor:
       case Plain:

--- a/src/main/java/vct/col/rewrite/JavaEncoder.java
+++ b/src/main/java/vct/col/rewrite/JavaEncoder.java
@@ -98,7 +98,7 @@ public class JavaEncoder extends AbstractRewriter {
       prefix="procedure_";
     } else {
       String name[]=cls.getFullName();
-      if (m.name().equals(cls.name())){
+      if (m.name().equals(cls.name()) || m.getKind() == Kind.Constructor){
         prefix="constructor_";
       } else {
         prefix="method_";

--- a/src/main/java/vct/main/Main.java
+++ b/src/main/java/vct/main/Main.java
@@ -900,44 +900,6 @@ public class Main
       public ProgramUnit apply(ProgramUnit arg,String ... args){
         arg=new JavaEncoder(arg).rewriteAll();
 
-        // Squash ALL the libraries!!
-        HashMap<ClassName, ASTClass> library = ProgramUnit.library;
-        ProgramUnit.library = new HashMap<>();
-        HashMap<ASTClass, ASTClass> transformedMapping = new HashMap<>();
-        for (ClassName className : library.keySet()) {
-          ASTClass javaClass = library.get(className);
-
-          if (!transformedMapping.containsKey(javaClass)) {
-            ProgramUnit programUnit = new ProgramUnit();
-            programUnit.add(javaClass);
-            programUnit = new JavaEncoder(programUnit).rewriteAll();
-
-            if (programUnit.size() != 2) {
-              Abort("Encoding somehow produced more than 2 classes");
-            }
-
-            ASTClass option1 = (ASTClass) programUnit.get(0);
-            ASTClass option2 = (ASTClass) programUnit.get(1);
-
-            ASTClass encodedClass = null;
-            if (option1.name().equals("EncodedGlobalVariables")) {
-              // 2 is our guy
-              encodedClass = option2;
-            } else if (option2.name().equals("EncodedGlobalVariables")) {
-              // 1 is our gal
-              encodedClass = option1;
-            } else {
-              Abort("Encoding should have produced 1 global var class and 1 other class");
-            }
-
-            transformedMapping.put(javaClass, encodedClass);
-          }
-
-          ASTClass encodedClass = transformedMapping.get(javaClass);
-          ProgramUnit.library.put(className, encodedClass);
-          ProgramUnit.library.put(new ClassName(encodedClass.name()), encodedClass);
-        }
-
         return arg;
       }
     });

--- a/src/main/java/vct/silver/SilverTypeMap.java
+++ b/src/main/java/vct/silver/SilverTypeMap.java
@@ -88,6 +88,12 @@ public class SilverTypeMap<T> implements TypeMapping<T> {
   @Override
   public T map(PrimitiveType t) {
     switch(t.sort){
+      /* Hacky types to make Java standard library support work: */
+      case Long:
+      case Byte:
+      case Char:
+      case Short:
+      /* End of hacky types. */
       case Integer:
         return create.Int();
       case Boolean:

--- a/src/main/java/vct/silver/VerCorsProgramFactory.java
+++ b/src/main/java/vct/silver/VerCorsProgramFactory.java
@@ -151,9 +151,10 @@ public class VerCorsProgramFactory implements
 
   @Override
   public Method dfunc(Origin o, String name,
-      List<Triple<Origin,String,Type>> args, Type t, String domain) {
+      List<Triple<Origin,String,Type>> args, Type t, String domain, boolean unique) {
     enter(o);
     Method res=create.function_decl(t,null, name,create.to_decls(args),null);
+    res.setFlag(ASTFlags.UNIQUE, true);
     leave();
     return res;
   }
@@ -297,14 +298,14 @@ public class VerCorsProgramFactory implements
           for(DeclarationStatement decl:m.getArgs()){
             args.add(new Triple<Origin,String,T>(decl.getOrigin(),decl.name(),decl.getType().apply(type)));
           }
-          funcs.add(api.prog.dfunc(m.getOrigin(), m.name(), args,m.getReturnType().apply(type), adt.name()));
+          funcs.add(api.prog.dfunc(m.getOrigin(), m.name(), args,m.getReturnType().apply(type), adt.name(), m.isValidFlag(ASTFlags.UNIQUE) && m.getFlag(ASTFlags.UNIQUE)));
         }
         for(Method m:adt.mappingsJava()){
           List<Triple<Origin,String,T>> args=new ArrayList<Triple<Origin,String,T>>();
           for(DeclarationStatement decl:m.getArgs()){
             args.add(new Triple<Origin,String,T>(decl.getOrigin(),decl.name(),decl.getType().apply(type)));
           }
-          funcs.add(api.prog.dfunc(m.getOrigin(), m.name(), args, m.getReturnType().apply(type), adt.name()));
+          funcs.add(api.prog.dfunc(m.getOrigin(), m.name(), args, m.getReturnType().apply(type), adt.name(), m.isValidFlag(ASTFlags.UNIQUE) && m.getFlag(ASTFlags.UNIQUE)));
         }
         ArrayList<DAxiom> axioms=new ArrayList<DAxiom>();
         for (Axiom axiom : adt.axiomsJava()) {

--- a/src/main/java/vct/silver/VerCorsProgramFactory.java
+++ b/src/main/java/vct/silver/VerCorsProgramFactory.java
@@ -154,7 +154,7 @@ public class VerCorsProgramFactory implements
       List<Triple<Origin,String,Type>> args, Type t, String domain, boolean unique) {
     enter(o);
     Method res=create.function_decl(t,null, name,create.to_decls(args),null);
-    res.setFlag(ASTFlags.UNIQUE, true);
+    res.setFlag(ASTFlags.UNIQUE, unique);
     leave();
     return res;
   }

--- a/src/main/scala/vct/col/rewrite/PointersToArrays.scala
+++ b/src/main/scala/vct/col/rewrite/PointersToArrays.scala
@@ -11,9 +11,7 @@ import scala.collection.JavaConverters._
 
 class PointersToArrays(source: ProgramUnit) extends AbstractRewriter(source) {
   def visitType(t: Type): Type = {
-    if (t == null) {
-      t
-    } else if(t.isPrimitive(PrimitiveSort.Pointer)) {
+    if(t.isPrimitive(PrimitiveSort.Pointer)) {
       create.primitive_type(PrimitiveSort.Option,
         create.primitive_type(PrimitiveSort.Array,
           create.primitive_type(PrimitiveSort.Cell,

--- a/src/main/scala/vct/col/rewrite/PointersToArrays.scala
+++ b/src/main/scala/vct/col/rewrite/PointersToArrays.scala
@@ -11,7 +11,9 @@ import scala.collection.JavaConverters._
 
 class PointersToArrays(source: ProgramUnit) extends AbstractRewriter(source) {
   def visitType(t: Type): Type = {
-    if(t.isPrimitive(PrimitiveSort.Pointer)) {
+    if (t == null) {
+      t
+    } else if(t.isPrimitive(PrimitiveSort.Pointer)) {
       create.primitive_type(PrimitiveSort.Option,
         create.primitive_type(PrimitiveSort.Array,
           create.primitive_type(PrimitiveSort.Cell,

--- a/viper/src/main/java/viper/api/ProgramFactory.java
+++ b/viper/src/main/java/viper/api/ProgramFactory.java
@@ -39,7 +39,7 @@ public interface ProgramFactory<O,Err,T,E,S,DFunc,DAxiom,P> {
   
   public DAxiom daxiom(O o,String name,E expr,String domain);
   
-  public DFunc dfunc(O o,String name,List<Triple<O,String,T>> args,T t,String domain);
+  public DFunc dfunc(O o,String name,List<Triple<O,String,T>> args,T t,String domain, boolean unique);
   
   public void add_adt(P p,O o,String name,List<DFunc> funs,List<DAxiom> axioms,List<String> pars);
 

--- a/viper/src/main/scala/viper/api/SilverProgramFactory.scala
+++ b/viper/src/main/scala/viper/api/SilverProgramFactory.scala
@@ -61,8 +61,8 @@ class SilverProgramFactory[O,Err] extends ProgramFactory[O,Err,Type,Exp,Stmt,
     )(NoPosition, new OriginInfo(o), NoTrafos))
   }
   
-  override def dfunc(o:O,name:String,args:List[Triple[O,String,Type]],t:Type,domain:String)={
-    DomainFunc(name,to_decls(o,args),t,false)(NoPosition,new OriginInfo(o),domain)
+  override def dfunc(o:O,name:String,args:List[Triple[O,String,Type]],t:Type,domain:String,unique:Boolean)={
+    DomainFunc(name,to_decls(o,args),t,unique)(NoPosition,new OriginInfo(o),domain)
   }
   
   override def daxiom(o:O,name:String,expr:Exp,domain:String)={
@@ -118,7 +118,7 @@ class SilverProgramFactory[O,Err] extends ProgramFactory[O,Err,Type,Exp,Stmt,
             val o=get_info(x.info,x.pos,api.origin)
             val pars=map_decls(api, x.formalArgs)
             val res=map_type(api,x.typ)
-            api.prog.dfunc(o,x.name,pars,res,d.name)
+            api.prog.dfunc(o,x.name,pars,res,d.name, x.unique)
           }
         }).asJava
         val axioms:java.util.List[DAxiom2]=d.axioms.map {


### PR DESCRIPTION
This pull request endeavors to make java standard library types (such as Exception, RuntimeException and Throwable) usable again in Vercors. From my early tests this approach seems to work pretty well but it makes debugging with `--debug vct.main.Main` 100x slower and also it makes the Silver output enormous (200+ methods). But it's a start!