### PR TITLE
Move language specific passes to parsers

### DIFF
--- a/src/main/java/vct/antlr4/parser/ColJavaParser.java
+++ b/src/main/java/vct/antlr4/parser/ColJavaParser.java
@@ -137,7 +137,10 @@ public class ColJavaParser implements vct.col.util.Parser {
         //Progress("resolving library calls took %dms",tk.show());        
 
         pu=new FilterSpecIgnore(pu).rewriteAll();
-        Progress("filtering spec_ignore took %dms",tk.show()); 
+        Progress("filtering spec_ignore took %dms",tk.show());
+
+        pu = new JavaResolver(pu).rewriteAll();
+        Progress("resolving java types took %dms", tk.show());
 
         return pu;
       } catch (FileNotFoundException e) {

--- a/src/main/java/vct/main/Main.java
+++ b/src/main/java/vct/main/Main.java
@@ -345,7 +345,6 @@ public class Main
         passes.add("dafny"); // run backend
       } else if (silver.used()||chalice.get()) {
         passes=new LinkedBlockingDeque<String>();
-        passes.add("java_resolve");
 
         if (silver.used() &&
            (features.usesSpecial(ASTSpecial.Kind.Lock)

--- a/src/main/java/vct/main/Main.java
+++ b/src/main/java/vct/main/Main.java
@@ -346,17 +346,6 @@ public class Main
       } else if (silver.used()||chalice.get()) {
         passes=new LinkedBlockingDeque<String>();
 
-        if (silver.used() &&
-           (features.usesSpecial(ASTSpecial.Kind.Lock)
-          ||features.usesSpecial(ASTSpecial.Kind.Unlock)
-          ||features.usesSpecial(ASTSpecial.Kind.Fork)
-          ||features.usesSpecial(ASTSpecial.Kind.Join)
-          ||features.usesOperator(StandardOperator.PVLidleToken)
-          ||features.usesOperator(StandardOperator.PVLjoinToken)
-        )){
-          passes.add("pvl-encode"); // translate built-in statements into methods and fake method calls.
-        }
-
         passes.add("standardize");
         passes.add("java-check"); // marking function: stub
 


### PR DESCRIPTION
There are a few passes that are language specific, such as `java_resolve` and `pvl_encode`. Since they are language specific, if possible they should take place in the respective language specific parsers, i.e. `ColJavaParser` and `ColPVLParser`. 