### PR TITLE
Syntax highlighting - Added keywords context_everywhere and for

### DIFF
--- a/util/VercorsPVL.tmbundle/Syntaxes/Vercors PVL.tmLanguage
+++ b/util/VercorsPVL.tmbundle/Syntaxes/Vercors PVL.tmLanguage
@@ -111,7 +111,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>&amp;&amp;|**</string>
+					<string>&amp;&amp;|\*\*</string>
 					<key>name</key>
 					<string>keyword.operator.pvl</string>
 				</dict>

--- a/util/VercorsPVL.tmbundle/Syntaxes/Vercors PVL.tmLanguage
+++ b/util/VercorsPVL.tmbundle/Syntaxes/Vercors PVL.tmLanguage
@@ -93,7 +93,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>\b(class|kernel|global|local|static|thread_local|inline|pure|with|then|in|id|new|unfolding|return|lock|unlock|wait|notify|fork|join|if|else|barrier|par|and|vec|while|goto|void)\b</string>
+					<string>\b(class|kernel|global|local|static|thread_local|inline|pure|with|then|in|id|new|unfolding|return|lock|unlock|wait|notify|fork|join|if|else|barrier|par|and|vec|while|for|goto|void)\b</string>
 					<key>name</key>
 					<string>entity.name.type.pvl</string>
 				</dict>
@@ -161,7 +161,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>\b(resource|modifies|accessible|requires|ensures|given|yields|invariant|context|loop_invariant|create|qed|apply|use|create|destroy|split|merge|choose|fold|unfold|open|close|assert|assume|inhale|exhale|label|refute|witness|ghost|send|recv|transfer|csl_subject|spec_ignore)\b</string>
+					<string>\b(resource|modifies|accessible|requires|ensures|given|yields|invariant|context|context_everywhere|loop_invariant|create|qed|apply|use|create|destroy|split|merge|choose|fold|unfold|open|close|assert|assume|inhale|exhale|label|refute|witness|ghost|send|recv|transfer|csl_subject|spec_ignore)\b</string>
 					<key>captures</key>
 					<dict>
 						<key>1</key>

--- a/util/pvl.grammar
+++ b/util/pvl.grammar
@@ -34,7 +34,7 @@
 		keywords = {
 			patterns = (
 				{	name = 'entity.name.type.pvl';
-					match = '\b(class|kernel|global|local|static|thread_local|inline|pure|with|then|in|id|new|unfolding|return|lock|unlock|wait|notify|fork|join|if|else|barrier|par|and|vec|while|goto|void)\b';
+					match = '\b(class|kernel|global|local|static|thread_local|inline|pure|with|then|in|id|new|unfolding|return|lock|unlock|wait|notify|fork|join|if|else|barrier|par|and|vec|while|for|goto|void)\b';
 					captures = { 1 = { name = 'markup.bold'; }; };
 				},
 				{	name = 'keyword.operator.types.pvl';
@@ -71,7 +71,7 @@
 		specs = {
 			patterns = (
 				{	name = 'support.class.spec.pvl';
-					begin = '\b(resource|modifies|accessible|requires|ensures|given|yields|invariant|context|loop_invariant|create|qed|apply|use|create|destroy|split|merge|choose|fold|unfold|open|close|assert|assume|inhale|exhale|label|refute|witness|ghost|send|recv|transfer|csl_subject|spec_ignore)\b';
+					begin = '\b(resource|modifies|accessible|requires|ensures|given|yields|invariant|context|context_everywhere|loop_invariant|create|qed|apply|use|create|destroy|split|merge|choose|fold|unfold|open|close|assert|assume|inhale|exhale|label|refute|witness|ghost|send|recv|transfer|csl_subject|spec_ignore)\b';
 					end = ';';
 					captures = { 1 = { name = 'markup.bold'; }; };
 					patterns = (

--- a/util/pvl.grammar
+++ b/util/pvl.grammar
@@ -45,7 +45,7 @@
 		operators = {
 			patterns = (
 				{	name = 'keyword.operator.pvl';
-					match = '&&|**';
+					match = '&&|\*\*';
 				},
 			);
 		};


### PR DESCRIPTION
I've added two of our newer keywords (context_everywhere and for) to the syntax highlighting that we provide through the textmate bundle. I also made sure to escape the ** that resulted in some problems if you tried using it with sublime text.