### PR TITLE
Include brief git info in help message

### DIFF
--- a/src/main/java/vct/main/Main.java
+++ b/src/main/java/vct/main/Main.java
@@ -233,6 +233,14 @@ public class Main
       if(version.get()) {
         Output("%s %s", BuildInfo.name(), BuildInfo.version());
         Output("Built by sbt %s, scala %s at %s", BuildInfo.sbtVersion(), BuildInfo.scalaVersion(), Instant.ofEpochMilli(BuildInfo.builtAtMillis()));
+        if (!BuildInfo.currentBranch().equals("master")) {
+          Output(
+                  "On branch %s, commit %s, %s",
+                  BuildInfo.currentBranch(),
+                  BuildInfo.currentShortCommit(),
+                  BuildInfo.gitHasChanges()
+          );
+        }
         return;
       }
 


### PR DESCRIPTION
When not on branch master, git info is printed in help the branch: current branch, abbreviated commit, and whether or not there are changes.