### PR TITLE
Fixed ListAppend example

### DIFF
--- a/examples/witnesses/ListAppend.java
+++ b/examples/witnesses/ListAppend.java
@@ -22,7 +22,7 @@ final class List {
   public List next;
   
   /*@
-    public resource list(seq<int> c)=Perm(val,1)**Perm(next,1)**
+    public final resource list(seq<int> c)=Perm(val,1)**Perm(next,1)**
       ((next==null)?(c==seq<int>{val}):(|c| > 0 ** head(c)==val ** next.list(tail(c))));
   @*/
 


### PR DESCRIPTION
examples/witnesses/ListAppend.java no longer verified with the current dev-branch. This PR solves this by adding the "final" keyword to the resource as suggested by @bobismijnnaam . Fixes issue #431 