### PR TITLE
Reduce scope of sonarcloud analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,6 +8,7 @@ sonar.projectVersion=1.0
 # This property is optional if sonar.modules is set.
 sonar.sources=src,viper/src,hre/src,col/src
 sonar.java.binaries=target,viper/target,hre/target,col/target
+sonar.exclusions=src/main/universal
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Sonarcloud also analyzes code in the `universal` dir, which is not VerCors code. Therefore it should be ignored.