### PR TITLE
Add Ambigious operators for languages that use the same operators for different data types

### DIFF
--- a/col/src/main/java/vct/col/ast/expr/StandardOperator.java
+++ b/col/src/main/java/vct/col/ast/expr/StandardOperator.java
@@ -31,7 +31,13 @@ public enum StandardOperator {
   /** Bitwise eXclusive OR. */
   BitXor(2),
   /** Bitwise negation or complement. */
-  BitNot(2),
+  BitNot(2), //TODO change arity to 1
+  /** And for languages where boolean and bitwise and have the same operator name **/
+  AmbiguousAnd(2),
+  /** Or for languages where boolean and bitwise and have the same operator name **/
+  AmbiguousOr(2),
+  /** Xor for languages where boolean and bitwise and have the same operator name **/
+  AmbiguousXor(2),
   /** Logical and. May or may not mean 'and also' */
   And(2),
   /** Logical or. May or may not mean 'or else' */

--- a/col/src/main/java/vct/col/ast/expr/StandardOperator.java
+++ b/col/src/main/java/vct/col/ast/expr/StandardOperator.java
@@ -31,7 +31,7 @@ public enum StandardOperator {
   /** Bitwise eXclusive OR. */
   BitXor(2),
   /** Bitwise negation or complement. */
-  BitNot(2), //TODO change arity to 1
+  BitNot(1),
   /** And for languages where boolean and bitwise and have the same operator name **/
   AmbiguousAnd(2),
   /** Or for languages where boolean and bitwise and have the same operator name **/

--- a/col/src/main/java/vct/col/ast/syntax/JavaSyntax.java
+++ b/col/src/main/java/vct/col/ast/syntax/JavaSyntax.java
@@ -146,11 +146,11 @@ public class JavaSyntax extends Syntax {
     syntax.addInfix(EQ,"==",80);
     syntax.addInfix(NEQ,"!=",80);
     //  7 bitwise AND   &
-    syntax.addInfix(BitAnd,"&",70);
+    syntax.addInfix(AmbiguousAnd,"&",70);
     //  6 bitwise exclusive OR  ^
-    syntax.addInfix(BitXor,"^",60);
+    syntax.addInfix(AmbiguousXor,"^",60);
     //  5 bitwise inclusive OR  |
-    syntax.addInfix(BitOr,"|",50);
+    syntax.addInfix(AmbiguousOr,"|",50);
     //  4 logical AND   &&
     syntax.addLeftFix(And,"&&",40);
     //  3 logical OR  ||

--- a/examples/basic/BooleanOperators.java
+++ b/examples/basic/BooleanOperators.java
@@ -1,3 +1,6 @@
+//:: cases AmbiguousBooleanOperators
+//:: tools silicon
+//:: verdict Pass
 class BooleanOperators {
     boolean xor() {
         return true ^ false;

--- a/examples/basic/BooleanOperators.java
+++ b/examples/basic/BooleanOperators.java
@@ -1,0 +1,13 @@
+class BooleanOperators {
+    boolean xor() {
+        return true ^ false;
+    }
+
+    boolean and() {
+        return true & false;
+    }
+
+    boolean or() {
+        return true | false;
+    }
+}

--- a/parsers/src/main/java/vct/parsers/JavaJMLtoCOL.scala
+++ b/parsers/src/main/java/vct/parsers/JavaJMLtoCOL.scala
@@ -661,11 +661,11 @@ case class JavaJMLtoCOL(fileName: String, tokens: CommonTokenStream, parser: Jav
     case Expression19(left, "!=", right) =>
       create expression(NEQ, expr(left), expr(right))
     case Expression20(left, "&", right) =>
-      create expression(BitAnd, expr(left), expr(right))
+      create expression(AmbiguousAnd, expr(left), expr(right))
     case Expression21(left, "^", right) =>
-      create expression(BitXor, expr(left), expr(right))
+      create expression(AmbiguousXor, expr(left), expr(right))
     case Expression22(left, "|", right) =>
-      create expression(BitOr, expr(left), expr(right))
+      create expression(AmbiguousOr, expr(left), expr(right))
     case Expression23(left, AndOp0("&&"), right) =>
       create expression(And, expr(left), expr(right))
     case Expression23(left, AndOp1(valOp), right) =>

--- a/src/main/java/vct/col/rewrite/ArrayNullValues.java
+++ b/src/main/java/vct/col/rewrite/ArrayNullValues.java
@@ -47,6 +47,9 @@ public class ArrayNullValues extends AbstractRewriter {
             case BitOr:
             case BitXor:
             case BitNot:
+            case AmbiguousAnd:
+            case AmbiguousOr:
+            case AmbiguousXor:
             case And:
             case Or:
             case Not:

--- a/src/main/java/vct/col/util/AbstractTypeCheck.java
+++ b/src/main/java/vct/col/util/AbstractTypeCheck.java
@@ -1243,6 +1243,21 @@ public class AbstractTypeCheck extends RecursiveVisitor<Type> {
         }
         break;
       }
+      case AmbiguousOr:
+      case AmbiguousAnd:
+      case AmbiguousXor: {
+        // bitwise case
+        if (tt[0].equalSize(tt[1])) {
+          e.setType(tt[0]);
+        }
+        // boolean case
+        else if (tt[0].isBoolean() && tt[1].isBoolean()) {
+          e.setType(new PrimitiveType(PrimitiveSort.Boolean));
+          break;
+        } else {
+          Fail("Types of left and right-hand side argument are different (%s/%s).", tt[0], tt[1]);
+        }
+      }
       case RightShift:
       case LeftShift:
       case UnsignedRightShift: {

--- a/viper/src/main/java/viper/api/SilverExpressionMap.java
+++ b/viper/src/main/java/viper/api/SilverExpressionMap.java
@@ -27,16 +27,16 @@ import vct.col.ast.type.*;
 
 public class SilverExpressionMap<T,E> implements ASTMapping<E> {
 
-  public boolean failure=false;
-  
-  private ExpressionFactory<Origin,T,E> create;
+  public boolean failure = false;
+
+  private ExpressionFactory<Origin, T, E> create;
   private TypeFactory<T> tf;
   private SilverTypeMap<T> type;
 
-  public SilverExpressionMap(ViperAPI<Origin, T,E,?,?,?,?> backend, SilverTypeMap<T> type){
-    this.create=backend.expr;
-    tf=backend._type;
-    this.type=type;
+  public SilverExpressionMap(ViperAPI<Origin, T, E, ?, ?, ?, ?> backend, SilverTypeMap<T> type) {
+    this.create = backend.expr;
+    tf = backend._type;
+    this.type = type;
   }
 
   @Override
@@ -45,9 +45,9 @@ public class SilverExpressionMap<T,E> implements ASTMapping<E> {
 
   @Override
   public E post_map(ASTNode n, E res) {
-    if (res==null){
-      Origin o=n.getOrigin();
-      throw new HREError("cannot map %s to expression (%s)",n.getClass(),o!=null?o:"without origin");
+    if (res == null) {
+      Origin o = n.getOrigin();
+      throw new HREError("cannot map %s to expression (%s)", n.getClass(), o != null ? o : "without origin");
     }
     return res;
   }
@@ -59,119 +59,180 @@ public class SilverExpressionMap<T,E> implements ASTMapping<E> {
 
   @Override
   public E map(ConstantExpression e) {
-    if (e.value() instanceof IntegerValue){
-      int v = ((IntegerValue)e.value()).value();
-      if (e.getType().isPrimitive(PrimitiveSort.Rational)){
-        switch(v){
-          case 0 : return create.no_perm(e.getOrigin());
-          case 1 : return create.write_perm(e.getOrigin());
-          default: return create.frac(e.getOrigin(), create.Constant(e.getOrigin(), v), create.Constant(e.getOrigin(), 1));
+    if (e.value() instanceof IntegerValue) {
+      int v = ((IntegerValue) e.value()).value();
+      if (e.getType().isPrimitive(PrimitiveSort.Rational)) {
+        switch (v) {
+          case 0:
+            return create.no_perm(e.getOrigin());
+          case 1:
+            return create.write_perm(e.getOrigin());
+          default:
+            return create.frac(e.getOrigin(), create.Constant(e.getOrigin(), v), create.Constant(e.getOrigin(), 1));
         }
       } else {
-        return create.Constant(e.getOrigin(),v);
+        return create.Constant(e.getOrigin(), v);
       }
     } else if (e.value() instanceof BooleanValue) {
-      return create.Constant(e.getOrigin(),((BooleanValue)e.value()).value());
+      return create.Constant(e.getOrigin(), ((BooleanValue) e.value()).value());
     } else {
-      throw new HREError("cannot map constant value %s",e.value().getClass());
+      throw new HREError("cannot map constant value %s", e.value().getClass());
     }
   }
 
   @Override
   public E map(OperatorExpression e) {
     Origin o = e.getOrigin();
-    E e1=null;
-    E e2=null;
-    E e3=null;
+    E e1 = null;
+    E e2 = null;
+    E e3 = null;
     switch (e.operator().arity()) {
-    case 3:
-      e3=e.arg(2).apply(this);
-    case 2:
-      e2=e.arg(1).apply(this);
-    case 1:
-      e1=e.arg(0).apply(this);
+      case 3:
+        e3 = e.arg(2).apply(this);
+      case 2:
+        e2 = e.arg(1).apply(this);
+      case 1:
+        e1 = e.arg(0).apply(this);
     }
-    switch(e.operator()){
-    case PointsTo:{
-      return create.and(o,create.field_access(o,e1,e2),create.eq(o, e1, e3));
-    }
-    case CurrentPerm: return create.current_perm(o,e1);
-    case ITE: return create.cond(o,e1,e2,e3);
-    case Perm: return create.field_access(o,e1,e2);
-    case Value: return create.field_access(o,e1,create.read_perm(o));
-    case Star: return create.and(o,e1,e2);
-    case And: return create.and(o,e1,e2);
-    case Or: return create.or(o,e1,e2);
-    case Implies: return create.implies(o,e1,e2);
-    case Not: return create.not(o,e1);
-    case Unfolding: return create.unfolding_in(o,e1,e2);
-    case Old: return create.old(o,e1);
-    
-    case Size: return create.size(o,e1);
-    case Head: return create.index(o, e1, create.Constant(o,0));
-    case Tail: return create.drop(o, e1, create.Constant(o,1));
-    case Drop: return create.drop(o, e1, e2);
-    case Take: return create.take(o, e1, e2);
-    case Slice: return create.slice(o, e1, e2, e3);
-    case SeqUpdate: return create.seq_update(o, e1, e2, e3);
-    case Member: {
-      if (e.arg(1).getType().isPrimitive(PrimitiveSort.Sequence)){
-        return create.seq_contains(o,e1,e2);
-      } else {
-        return create.any_set_contains(o,e1,e2);
+    switch (e.operator()) {
+      case PointsTo: {
+        return create.and(o, create.field_access(o, e1, e2), create.eq(o, e1, e3));
       }
-    }
-    case RangeSeq: return create.range(o,e1,e2);
-      
-    case Subscript: return create.index(o,e1,e2);
-    
-    case GT: return create.gt(o,e1,e2);
-    case LT: return create.lt(o,e1,e2);
-    case GTE: return create.gte(o,e1,e2);
-    case LTE: return create.lte(o,e1,e2);
-    case EQ: return create.eq(o,e1,e2);
-    case NEQ: return create.neq(o,e1,e2);
+      case CurrentPerm:
+        return create.current_perm(o, e1);
+      case ITE:
+        return create.cond(o, e1, e2, e3);
+      case Perm:
+        return create.field_access(o, e1, e2);
+      case Value:
+        return create.field_access(o, e1, create.read_perm(o));
+      case Star:
+        return create.and(o, e1, e2);
+      case And:
+        return create.and(o, e1, e2);
+      case Or:
+        return create.or(o, e1, e2);
+      case Implies:
+        return create.implies(o, e1, e2);
+      case Not:
+        return create.not(o, e1);
+      case Unfolding:
+        return create.unfolding_in(o, e1, e2);
+      case Old:
+        return create.old(o, e1);
 
-    case Mult:{
-      if (e.getType().isPrimitive(PrimitiveSort.Set) || e.getType().isPrimitive(PrimitiveSort.Bag)){
-        return create.any_set_intersection(o,e1,e2);
-      } else {
-        return create.mult(o,e1,e2);
+      case AmbiguousAnd: {
+        if (e.arg(1).getType().isBoolean()) {
+          return create.and(o, e1, e2);
+        }
+//        } else if (e.arg(1).getType().isPrimitive(PrimitiveSort.Byte)) {
+//          break;
+//        }
+        // fall through
       }
-    }
-    case FloorDiv:
-      return create.floor_div(o, e1, e2);
-    case Div:
-      return create.frac(o, e1, e2);
-    case Mod: return create.mod(o,e1,e2);
-    case Plus:{
-      if (e.getType().isPrimitive(PrimitiveSort.Sequence)){
-        return create.append(o,e1,e2);
-      } else if (e.getType().isPrimitive(PrimitiveSort.Set) || e.getType().isPrimitive(PrimitiveSort.Bag)){
-        return create.union(o,e1,e2);
-      } else if(e.getType().isPrimitive(PrimitiveSort.Rational)) {
-        return create.perm_add(o, e1, e2);
-      } else {
-        return create.add(o,e1,e2);
+
+      case AmbiguousXor: {
+        if (e.arg(1).getType().isBoolean()) {
+          return create.neq(o, e1, e2);
+        }
+//        } else if (e.arg(1).getType().isPrimitive(PrimitiveSort.Byte)) {
+//          break;
+//        }
+        // fall through
       }
-    }
-    case Minus: {
-      if (e.getType().isPrimitive(PrimitiveSort.Set) || e.getType().isPrimitive(PrimitiveSort.Bag)){
-        return create.any_set_minus(o,e1,e2);
-      } else {
-        return create.sub(o,e1,e2);
+
+      case AmbiguousOr: {
+        if (e.arg(1).getType().isBoolean()) {
+          return create.or(o, e1, e2);
+        }
+//        } else if (e.arg(1).getType().isPrimitive(PrimitiveSort.Byte)) {
+//
+//        }
+        // fall through
       }
-    }
-    case UMinus: return create.neg(o,e1);
-    case Scale:{
-      return create.scale_access(o,e2, e1);
-    }
-    case Append:
-      return create.append(o, e1,e2);
-    default:
+      case Size:
+        return create.size(o, e1);
+      case Head:
+        return create.index(o, e1, create.Constant(o, 0));
+      case Tail:
+        return create.drop(o, e1, create.Constant(o, 1));
+      case Drop:
+        return create.drop(o, e1, e2);
+      case Take:
+        return create.take(o, e1, e2);
+      case Slice:
+        return create.slice(o, e1, e2, e3);
+      case SeqUpdate:
+        return create.seq_update(o, e1, e2, e3);
+      case Member: {
+        if (e.arg(1).getType().isPrimitive(PrimitiveSort.Sequence)) {
+          return create.seq_contains(o, e1, e2);
+        } else {
+          return create.any_set_contains(o, e1, e2);
+        }
+      }
+      case RangeSeq:
+        return create.range(o, e1, e2);
+
+      case Subscript:
+        return create.index(o, e1, e2);
+
+      case GT:
+        return create.gt(o, e1, e2);
+      case LT:
+        return create.lt(o, e1, e2);
+      case GTE:
+        return create.gte(o, e1, e2);
+      case LTE:
+        return create.lte(o, e1, e2);
+      case EQ:
+        return create.eq(o, e1, e2);
+      case NEQ:
+        return create.neq(o, e1, e2);
+
+      case Mult: {
+        if (e.getType().isPrimitive(PrimitiveSort.Set) || e.getType().isPrimitive(PrimitiveSort.Bag)) {
+          return create.any_set_intersection(o, e1, e2);
+        } else {
+          return create.mult(o, e1, e2);
+        }
+      }
+      case FloorDiv:
+        return create.floor_div(o, e1, e2);
+      case Div:
+        return create.frac(o, e1, e2);
+      case Mod:
+        return create.mod(o, e1, e2);
+      case Plus: {
+        if (e.getType().isPrimitive(PrimitiveSort.Sequence)) {
+          return create.append(o, e1, e2);
+        } else if (e.getType().isPrimitive(PrimitiveSort.Set) || e.getType().isPrimitive(PrimitiveSort.Bag)) {
+          return create.union(o, e1, e2);
+        } else if (e.getType().isPrimitive(PrimitiveSort.Rational)) {
+          return create.perm_add(o, e1, e2);
+        } else {
+          return create.add(o, e1, e2);
+        }
+      }
+      case Minus: {
+        if (e.getType().isPrimitive(PrimitiveSort.Set) || e.getType().isPrimitive(PrimitiveSort.Bag)) {
+          return create.any_set_minus(o, e1, e2);
+        } else {
+          return create.sub(o, e1, e2);
+        }
+      }
+      case UMinus:
+        return create.neg(o, e1);
+      case Scale: {
+        return create.scale_access(o, e2, e1);
+      }
+      case Append:
+        return create.append(o, e1, e2);
+      default:
         throw new HREError("cannot map operator %s", e.operator());
     }
   }
+
 
   @Override
   public E map(NameExpression e) {
@@ -248,7 +309,7 @@ public class SilverExpressionMap<T,E> implements ASTMapping<E> {
         type.domain_type(dpars,(ClassType)e.object);
         return create.domain_call(o, name, args, dpars, rt, adt.name());
       } else {
-        
+
         ArrayList<Triple<Origin,String,T>> pars=new ArrayList<Triple<Origin,String,T>>();
         for(DeclarationStatement decl:m.getArgs()){
           pars.add(new Triple<Origin,String,T>(decl.getOrigin(),decl.name(),decl.getType().apply(type)));
@@ -423,7 +484,7 @@ public class SilverExpressionMap<T,E> implements ASTMapping<E> {
   public E map(TupleType tupleType) {
     return null;
   }
-  
+
   @Override
   public E map(TypeExpression t) {
     return null;


### PR DESCRIPTION
Fixes [issue 442](https://github.com/utwente-fmt/vercors/issues/442). For example, AmbigiousXor can be used to tokenize a `^` in Java to later determine whether it should be a bitwise xor or logical xor.