### PR TITLE
Parse z3 log in flight (experimental)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,9 +13,9 @@ enablePlugins(DebianPlugin)
 
 /* To update viper, replace the hash with the commit hash that you want to point to. It's a good idea to ask people to
  re-import the project into their IDE, as the location of the viper projects below will change. */
-val silver_url = uri("hg:https://bitbucket.org/viperproject/silver#1a2059df2fc348a6a777e73e00ad10a4c129da0f")
-val carbon_url = uri("hg:https://bitbucket.org/viperproject/carbon#1565055c99f3b07d71f02f99de092d3077491d66")
-val silicon_url = uri("hg:https://bitbucket.org/viperproject/silicon#44fda0b4d7d8fb5c8cb9cd04216bb849003ae8c7")
+val silver_url = uri("git:https://github.com/viperproject/silver.git#822407e2100ef73a9aca3986926b473d21a4205f")
+val carbon_url = uri("git:https://github.com/viperproject/carbon.git#286463549169c4c6c7eacb20db262f5f4955ddb5")
+val silicon_url = uri("git:https://github.com/niomaster/silicon.git#839dd10788eb6484e708544cf8f74a51b5856c60")
 
 /*
 buildDepdendencies.classpath contains the mapping from project to a list of its dependencies. The viper projects silver,
@@ -26,7 +26,7 @@ the relevant project. Instead, we replace those dependencies by a reference to t
 buildDependencies in Global := {
   val log = sLog.value
   val oldDeps = (buildDependencies in Global).value
-  def fixDep(dep: ClasspathDep[ProjectRef]): ClasspathDep[ProjectRef] = dep.project.project match {
+  def fixDep(dep: ClasspathDep[ProjectRef]) = dep.project.project match {
     case "silver" =>
       ResolvedClasspathDependency(ProjectRef(silver_url, "silver"), dep.configuration)
     case "silicon" =>

--- a/hre/src/main/java/hre/io/NamedPipe.scala
+++ b/hre/src/main/java/hre/io/NamedPipe.scala
@@ -1,0 +1,53 @@
+package hre.io
+
+import java.io.File
+
+import scala.io.Source
+
+trait NamedPipeListener {
+  def onNewLine(line: String): Unit
+}
+
+object NamedPipe {
+  def create(listener: NamedPipeListener, prefix: String, suffix: String): NamedPipe = {
+    val os = System.getProperty("os.name")
+
+    if(os startsWith "Windows") {
+      ???
+    } else {
+      new UnixNamedPipe(listener, prefix, suffix)
+    }
+  }
+}
+
+
+/** A named pipe is a special type of file that has no representation on disk. Both a writing and a reading side must
+  * open it before the "open" call completes. Data written to the "file" by the writer can be read from the "file" by
+  * the reader. The "end of file" is reached when the writer closes the file.
+  *
+  * Multiple writers may open a fifo, in which case the behaviour is racy.
+  *
+  * This implementation does the reading side, so that the path may be given to a different process to write to. The
+  * pipe is deleted after the pipe is closed by the writing side.
+  */
+trait NamedPipe {
+  def path: String
+}
+
+class UnixNamedPipe(val listener: NamedPipeListener, prefix: String, suffix: String) extends NamedPipe {
+  val path: String = {
+    val file = File.createTempFile(prefix, suffix)
+    val path = file.getPath
+    file.delete()
+    new ProcessBuilder("mkfifo", path).start().waitFor()
+    path
+  }
+
+  new Thread(() => {
+    val f = new File(path)
+    val source = Source.fromFile(f)
+    source.getLines.foreach(listener.onNewLine)
+    source.close()
+    f.delete()
+  }).start()
+}

--- a/hre/src/main/java/hre/io/NamedPipe.scala
+++ b/hre/src/main/java/hre/io/NamedPipe.scala
@@ -20,7 +20,6 @@ object NamedPipe {
   }
 }
 
-
 /** A named pipe is a special type of file that has no representation on disk. Both a writing and a reading side must
   * open it before the "open" call completes. Data written to the "file" by the writer can be read from the "file" by
   * the reader. The "end of file" is reached when the writer closes the file.
@@ -37,7 +36,7 @@ trait NamedPipe {
 class UnixNamedPipe(val listener: NamedPipeListener, prefix: String, suffix: String) extends NamedPipe {
   val path: String = {
     val file = File.createTempFile(prefix, suffix)
-    val path = file.getPath
+    val path = "/tmp/vercors-01.log" // file.getPath
     file.delete()
     new ProcessBuilder("mkfifo", path).start().waitFor()
     path

--- a/loop.smt2
+++ b/loop.smt2
@@ -1,0 +1,7 @@
+(set-option :smt.MBQI false)
+(declare-fun f (Int) Int)
+(assert (forall ((i Int)) (!
+  (= (f (+ i 1)) (f (f i))) :pattern ((f i)))))
+(assert (= (f 0) 1))
+(check-sat)
+(get-model)

--- a/loop2.smt2
+++ b/loop2.smt2
@@ -1,0 +1,7 @@
+(declare-fun f (Bool) Bool)
+(assert (forall ((x Bool)) (!
+    (f x)
+    :pattern (f x)
+	)))
+(assert (not (f true)))
+(check-sat)

--- a/src/main/java/vct/main/Main.java
+++ b/src/main/java/vct/main/Main.java
@@ -149,7 +149,7 @@ public class Main
       clops.add(learn.getEnable("Learn unit times for AST nodes."), "learn");
       
       Configuration.add_options(clops);
-      viper.api.util.Configuration.addOptions(clops);
+      viper.api.config.Configuration.addOptions(clops);
 
       String input[]=clops.parse(args);
 

--- a/src/main/java/vct/main/Main.java
+++ b/src/main/java/vct/main/Main.java
@@ -149,6 +149,7 @@ public class Main
       clops.add(learn.getEnable("Learn unit times for AST nodes."), "learn");
       
       Configuration.add_options(clops);
+      viper.api.util.Configuration.addOptions(clops);
 
       String input[]=clops.parse(args);
 

--- a/test.c
+++ b/test.c
@@ -1,0 +1,11 @@
+/*@
+requires \pointer(a, 10, write);
+*/
+void test(int *a) {
+    //@ assert \pointer(a, 10, write);
+    //@ assert \pointer(a, 8, write);
+    //@ assert (\forall* int i; 0 <= i && i < 10; \pointer_index(a, i, write));
+    int *b = a+5;
+    //@ assert a[5] == b[0];
+    //@ assert \pointer(b, 5, write);
+}

--- a/test.sil
+++ b/test.sil
@@ -1,0 +1,20 @@
+function sorted(s: Seq[Int]): Bool
+{
+  (forall i: Int, j: Int ::{s[i], s[j]} 0 <= i && i < |s| && i < j && j < |s| ==> s[i] <= s[j])
+}
+
+function smaller(s1: Seq[Int], s2: Seq[Int]): Bool
+{
+  (forall i: Int, j: Int ::{s1[i], s2[j]} 0 <= i && i < |s1| && 0 <= j && j < |s2| ==> s1[i] <= s2[j])
+}
+
+
+method sortedLemma(s: Seq[Int], s1: Seq[Int], s2: Seq[Int], larger: Seq[Int])
+  requires sorted(s)
+  requires smaller(s,larger)
+  requires s == s1++s2
+  ensures sorted(s2)
+  ensures smaller(s2,larger)
+  {
+    assert forall i: Int :: {s2[i]} 0<=i && i<|s2| ==> s[i+|s1|] == s2[i]
+  }

--- a/viper/src/main/java/vct/z3/LogParser.scala
+++ b/viper/src/main/java/vct/z3/LogParser.scala
@@ -20,7 +20,7 @@ object LogParser {
 
 class LogParser extends NamedPipeListener {
   val log = new Z3Log
-  val f = new PrintWriter("/home/pieter/z3.log")
+  val f = new PrintWriter("/home/bobe/z3.log")
 
   override def onNewLine(line: String): Unit = {
     f.println(line)

--- a/viper/src/main/java/vct/z3/LogParser.scala
+++ b/viper/src/main/java/vct/z3/LogParser.scala
@@ -1,0 +1,306 @@
+package vct.z3
+
+import java.io.PrintWriter
+
+import hre.io.NamedPipeListener
+import hre.lang.System._
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+class LogParser extends NamedPipeListener {
+  val log = new Z3Log
+  val f = new PrintWriter("/home/pieter/z3.log")
+
+  override def onNewLine(line: String): Unit = {
+    f.println(line)
+    f.flush()
+    log.addLine(line)
+  }
+}
+
+class Z3Log {
+  sealed trait Expr {
+    def precedence: Int
+    def asUnicode: String = asUnicodeImpl(Seq())
+    def asUnicodeImpl(scope: Binder.VarInfo): String
+    def asUnicodeParen(scope: Binder.VarInfo, maxPrecedence: Int, assoc: Boolean): String =
+      if(precedence < maxPrecedence || (precedence == maxPrecedence && assoc))
+        asUnicodeImpl(scope) else "(" + asUnicodeImpl(scope) + ")"
+  }
+
+  object App {
+    val OPS: Map[String, Op] = Map(
+      "~" -> BinaryOp(leftAssoc = false, rightAssoc = false, 80, "~sat~"),
+      "=>" -> BinaryOp(leftAssoc = false, rightAssoc = true, 60, "⇒"),
+      "if" -> CustomOp(55, (args, scope) => {
+        if(args.size == 3) {
+          args(0).asUnicodeParen(scope, 55, assoc = false) + " ? " +
+            args(1).asUnicodeParen(scope, 55, assoc = false) + " : " +
+            args(2).asUnicodeParen(scope, 55, assoc = true)
+        } else {
+          ???
+        }
+      }),
+      "and" -> BinaryOp(leftAssoc = true, rightAssoc = true, 50, "⋀"),
+      "or" -> BinaryOp(leftAssoc = true, rightAssoc = true, 40, "⋁"),
+      "=" -> BinaryOp(leftAssoc = false, rightAssoc = false, 30, "="),
+      "Set_equal" -> BinaryOp(leftAssoc = false, rightAssoc = false, 30, "="),
+      "Set_subset" -> BinaryOp(leftAssoc = false, rightAssoc = false, 28, "⊂"),
+      "Set_in" -> BinaryOp(leftAssoc = false, rightAssoc = false, 28, "∈"),
+      ">" -> BinaryOp(leftAssoc = false, rightAssoc = false, 25, ">"),
+      ">=" -> BinaryOp(leftAssoc = false, rightAssoc = false, 25, "≥"),
+      "<" -> BinaryOp(leftAssoc = false, rightAssoc = false, 25, "<"),
+      "<=" -> BinaryOp(leftAssoc = false, rightAssoc = false, 25, "≤"),
+      "Set_intersection" -> BinaryOp(leftAssoc = true, rightAssoc = false, 23, "∩"),
+      "Set_union" -> BinaryOp(leftAssoc = true, rightAssoc = false, 23, "∪"),
+      "Set_difference" -> BinaryOp(leftAssoc = true, rightAssoc = false, 23, "\\"),
+      "+" -> BinaryOp(leftAssoc = true, rightAssoc = true, 20, "+"),
+      "-" -> BinaryOp(leftAssoc = true, rightAssoc = false, 20, "-"),
+      "*" -> BinaryOp(leftAssoc = true, rightAssoc = true, 15, "⋅"),
+      "/" -> BinaryOp(leftAssoc = true, rightAssoc = false, 15, "/"),
+      "not" -> UnaryOp("¬"),
+      "true" -> ConstOp("⊤"),
+      "false" -> ConstOp("⊥"),
+      "pi" -> ConstOp("π"),
+      "euler" -> ConstOp("e"),
+      "Set_empty" -> ConstOp("∅"),
+    )
+
+    val SUBSCRIPTS: Map[Char, Char] = "0123456789".zip("₀₁₂₃₄₅₆₇₈₉").toMap
+
+    def niceName(x: String): String = {
+      val parts = x.split("@")
+      if(parts.length == 3) {
+        parts(0) + Integer.parseInt(parts(1)).toString.map(App.SUBSCRIPTS)
+      } else {
+        x
+      }
+    }
+  }
+
+  case class App(var func: String, args: Seq[Expr]) extends Expr {
+    override def precedence: Int = App.OPS.get(func) match {
+      case Some(op) => op.precedence
+      case None => 0
+    }
+
+    override def asUnicodeImpl(scope: Binder.VarInfo): String = App.OPS.get(func) match {
+      case Some(op) => op.asUnicode(args, scope)
+      case None => if (args.isEmpty) {
+        App.niceName(func)
+      } else {
+        App.niceName(func) + "(" + args.map(_.asUnicodeImpl(scope)).mkString(", ") + ")"
+      }
+    }
+  }
+
+  case class QuantVar(index: Int) extends Expr {
+    override def precedence: Int = 0
+    override def asUnicodeImpl(scope: Binder.VarInfo): String = {
+      val (name, _) = scope(index)
+      App.niceName(name.getOrElse(s"?$index?"))
+    }
+  }
+
+  object Binder {
+    type VarInfo = Seq[(Option[String], Option[String])]
+  }
+
+  abstract sealed class Binder extends Expr {
+    def var_count: Int
+    def body: Expr
+    var var_desc: Binder.VarInfo = (0 until var_count).map(_ => (None, None))
+
+    def bindingsAsUnicode: String = {
+      var_desc.zipWithIndex.map {
+        case ((name, t), index) =>
+          val nameText = name.map(App.niceName).getOrElse(s"?$index?")
+          val typeText = t.getOrElse("?")
+          s"$nameText: $typeText"
+      }.mkString(", ")
+    }
+  }
+
+  case class Quantifier(var_count: Int, triggers: Seq[Expr], body: Expr)(var name: String) extends Binder {
+    override def precedence: Int = 70
+    override def asUnicodeImpl(scope: Binder.VarInfo): String = {
+      "∀" + bindingsAsUnicode + " " + triggers.map(_.asUnicodeImpl(var_desc)).mkString(" ") +
+        " :: " + body.asUnicodeParen(var_desc, precedence, assoc = false)
+    }
+  }
+
+  case class Lambda(var_count: Int, body: Expr) extends Binder {
+    override def precedence: Int = 70
+    override def asUnicodeImpl(scope: Binder.VarInfo): String = {
+      "λ" + bindingsAsUnicode + " . " + body.asUnicodeParen(var_desc, precedence, assoc = false)
+    }
+  }
+
+  trait Op {
+    def precedence: Int
+    def asUnicode(args: Seq[Expr], scope: Binder.VarInfo): String
+  }
+
+  case class BinaryOp(leftAssoc: Boolean, rightAssoc: Boolean, precedence: Int, text: String) extends Op {
+    override def asUnicode(args: Seq[Expr], scope: Binder.VarInfo): String = {
+      if(leftAssoc && rightAssoc) {
+        args.map(_.asUnicodeParen(scope, precedence, assoc=true)).mkString(" " + text + " ")
+      } else if(args.size == 2) {
+        args(0).asUnicodeParen(scope, precedence, leftAssoc) +
+          " " + text + " " + args(1).asUnicodeParen(scope, precedence, rightAssoc)
+      } else {
+        ???
+      }
+    }
+  }
+
+  case class UnaryOp(text: String) extends Op {
+    override def precedence: Int = 10
+    override def asUnicode(args: Seq[Expr], scope: Binder.VarInfo): String = args match {
+      case Seq(arg) => text + arg.asUnicodeParen(scope, precedence, assoc=true)
+      case _ => ???
+    }
+  }
+
+  case class ConstOp(text: String) extends Op {
+    override def precedence: Int = 0
+    override def asUnicode(args: Seq[Expr], scope: Binder.VarInfo): String = args match {
+      case Seq() => text
+      case _ => ???
+    }
+  }
+
+  case class CustomOp(precedence: Int, f: (Seq[Expr], Binder.VarInfo) => String) extends Op {
+    override def asUnicode(args: Seq[Expr], scope: Binder.VarInfo): String = f(args, scope)
+  }
+
+  case class Proof(prereqs: Seq[Proof], rule: String, result: Expr)
+
+  var toolVersion: Option[String] = None
+
+  var defs: mutable.Map[String, Expr] = mutable.Map()
+  var proofs: mutable.Map[String, Proof] = mutable.Map()
+  var instantiations: mutable.Map[String, Int] = mutable.Map()
+
+  def readLine(text: String): Seq[String] = {
+    var sb = new StringBuilder()
+    val elements = new ArrayBuffer[String]()
+    var stack = 0
+
+    text.replace("<no position>", "").foreach {
+      case ' ' if stack == 0 =>
+        elements += sb.toString
+        sb.clear
+      case '(' =>
+        stack += 1
+        sb.append('(')
+      case ')' =>
+        stack -= 1
+        sb.append(')')
+      case other => sb.append(other)
+    }
+
+    elements += sb.toString
+    elements
+  }
+
+  def makeApp(args: Seq[String]): Unit = {
+    defs += args(0) -> App(args(1), args.drop(2).map(defs(_)))
+  }
+
+  def makeVar(args: Seq[String]): Unit = {
+    defs += args(0) -> QuantVar(Integer.parseInt(args(1)))
+  }
+
+  def makeQuant(args: Seq[String]): Unit = {
+    val quantifier = Quantifier(
+      var_count=Integer.parseInt(args(2)),
+      triggers=args.drop(3).init.map(defs(_)),
+      body=defs(args.last))(name=args(1))
+    defs += args(0) -> quantifier
+  }
+
+  def makeProof(args: Seq[String]): Unit = {
+    // The proof ID in an expression refers to the result
+    defs += args(0) -> defs(args.last)
+    proofs += args(0) -> Proof(args.drop(2).init.map(proofs(_)), args(1), defs(args.last))
+  }
+
+  def makeLambda(args: Seq[String]): Unit = {
+    // args(1) is always "null", not sure why. Maybe an unused name?
+    defs += args(0) -> Lambda(Integer.parseInt(args(2)), defs(args(3)))
+  }
+
+  def parseVarDescPart(part: String): Option[String] = {
+    val stripPart = part.strip
+    if(stripPart.isEmpty) {
+      None
+    } else if(stripPart.startsWith("|") && stripPart.endsWith("|")) {
+      Some(stripPart.init.tail)
+    } else {
+      Some(stripPart)
+    }
+  }
+
+  def parseVarDesc(varDesc: String): (Option[String], Option[String]) = {
+    assert(varDesc.startsWith("("))
+    assert(varDesc.endsWith(")"))
+    val parts = varDesc.tail.init.split(";")
+    assert(parts.size == 2)
+    val name = parts(0)
+    val `type` = parts(1)
+
+    (parseVarDescPart(name), parseVarDescPart(`type`))
+  }
+
+  def attachVarNames(args: Seq[String]): Unit = {
+    val quantifier = defs(args.head).asInstanceOf[Binder]
+    assert(args.size-1 == quantifier.var_count)
+    quantifier.var_desc = args.tail.map(parseVarDesc)
+  }
+
+  def newMatch(args: Seq[String]): Unit = {
+    val id = args(0)
+    val quant = defs(args(1))
+    val trigger = defs(args(2))
+    val sepIndex = args.indexOf(";")
+    val bindings = args.slice(3, sepIndex).map(defs(_))
+    instantiations(args(1)) = instantiations.getOrElse(args(1), 0) + 1
+    if(instantiations(args(1)) % 10000 == 0) {
+      Output("%d instantiations: %s", Int.box(instantiations(args(1))), quant.asUnicode)
+    }
+  }
+
+  def addLine(line: String): Unit = {
+    this.synchronized {
+      val vals = readLine(line)
+      vals.head match {
+        case "[tool-version]" => toolVersion match {
+          case None => toolVersion = Some(vals(2))
+          case Some(other) => assert(false)
+        }
+        case "[push]" | "[pop]" => // push/pop doesn't match defs, but probably the input push/pop
+        case "[assign]" | "" => // assign is followed by lines starting with a space
+
+        case "[mk-app]" => makeApp(vals.tail)
+        case "[mk-var]" => makeVar(vals.tail)
+        case "[mk-quant]" => makeQuant(vals.tail)
+        case "[mk-proof]" => makeProof(vals.tail)
+        case "[mk-lambda]" => makeLambda(vals.tail)
+
+        case "[new-match]" =>
+          newMatch(vals.tail)
+
+        case "[attach-meaning]" =>
+          defs(vals(1)).asInstanceOf[App].func = vals(3)
+
+        case "[attach-var-names]" =>
+          attachVarNames(vals.tail)
+
+        case other =>
+//           Output("Kind %s: %s", other, vals.tail)
+      }
+    }
+  }
+}

--- a/viper/src/main/java/viper/api/config/Configuration.scala
+++ b/viper/src/main/java/viper/api/config/Configuration.scala
@@ -1,4 +1,4 @@
-package viper.api.util
+package viper.api.config
 
 import hre.config.{BooleanSetting, OptionParser}
 

--- a/viper/src/main/java/viper/api/util/Configuration.scala
+++ b/viper/src/main/java/viper/api/util/Configuration.scala
@@ -1,0 +1,11 @@
+package viper.api.util
+
+import hre.config.{BooleanSetting, OptionParser}
+
+object Configuration {
+  val z3Progress = new BooleanSetting(false)
+
+  def addOptions(parser: OptionParser): Unit = {
+    parser.add(z3Progress.getEnable("Monitor progress of z3 (Unix only). Also causes --numberOfParallelVerifiers 1 in silicon, as well as trace=true and proof=true in z3."), "progress-z3")
+  }
+}

--- a/viper/src/main/scala/viper/api/SiliconVerifier.scala
+++ b/viper/src/main/scala/viper/api/SiliconVerifier.scala
@@ -4,8 +4,10 @@ import java.nio.file.Path
 import java.util.Properties
 
 import hre.ast.OriginFactory
+import viper.api.util.Configuration
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
 
 class SiliconVerifier[O](o:OriginFactory[O]) extends SilverImplementation[O](o) {
 
@@ -17,19 +19,19 @@ class SiliconVerifier[O](o:OriginFactory[O]) extends SilverImplementation[O](o) 
       entry => z3_config=z3_config+sep+(entry._1)+"="+(entry._2) ; sep=" "
     }
     z3_config+="\"";
-    //println(z3_config);
-    silicon.parseCommandLine(Seq(
-        "--z3Exe", z3Path.toString(),
-        "--z3ConfigArgs",z3_config,
-        "-"))
-				
-	  /*
-    silicon.config.initialize {
-    	case _ => silicon.config.initialized = true
+
+    val options = ArrayBuffer[String]()
+    options ++= Seq("--z3Exe", z3Path.toString)
+    options ++= Seq("--z3ConfigArgs", z3_config)
+
+    if(Configuration.z3Progress.get) {
+      options ++= Seq("--numberOfParallelVerifiers", "1")
     }
-		*/
-		
-    silicon.start()
+
+    options += "-"
+
+    silicon.parseCommandLine(options)
+	  silicon.start()
     silicon
   }
 

--- a/viper/src/main/scala/viper/api/SiliconVerifier.scala
+++ b/viper/src/main/scala/viper/api/SiliconVerifier.scala
@@ -4,7 +4,7 @@ import java.nio.file.Path
 import java.util.Properties
 
 import hre.ast.OriginFactory
-import viper.api.util.Configuration
+import viper.api.config.Configuration
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer

--- a/viper/src/main/scala/viper/api/SiliconVerifier.scala
+++ b/viper/src/main/scala/viper/api/SiliconVerifier.scala
@@ -13,16 +13,11 @@ class SiliconVerifier[O](o:OriginFactory[O]) extends SilverImplementation[O](o) 
 
   override def createVerifier(z3Path: Path, z3Settings: Properties):viper.silver.verifier.Verifier = {
     val silicon = new viper.silicon.Silicon(HREViperReporter(), Seq("startedBy" -> "example", "fullCmd" -> "dummy"))
-    var z3_config="\"";
-    var sep="";
-    z3Settings.asScala.foreach {
-      entry => z3_config=z3_config+sep+(entry._1)+"="+(entry._2) ; sep=" "
-    }
-    z3_config+="\"";
+    val z3Config = "\"" + z3Settings.asScala.map{case (key, vl) => s"$key=$vl"}.mkString(" ") + "\""
 
     val options = ArrayBuffer[String]()
     options ++= Seq("--z3Exe", z3Path.toString)
-    options ++= Seq("--z3ConfigArgs", z3_config)
+    options ++= Seq("--z3ConfigArgs", z3Config)
 
     if(Configuration.z3Progress.get) {
       options ++= Seq("--numberOfParallelVerifiers", "1")

--- a/viper/src/main/scala/viper/api/SilverImplementation.scala
+++ b/viper/src/main/scala/viper/api/SilverImplementation.scala
@@ -21,7 +21,7 @@ import viper.silver.parser.PLocalVarDecl
 
 import scala.collection.mutable.WrappedArray
 import hre.lang.System.Output
-import viper.api.util.Configuration
+import viper.api.config.Configuration
 
 class SilverImplementation[O](o:OriginFactory[O])
   extends viper.api.ViperAPI[O,Type,Exp,Stmt,DomainFunc,DomainAxiom,Prog](o,

--- a/viper/src/main/scala/viper/api/SilverImplementation.scala
+++ b/viper/src/main/scala/viper/api/SilverImplementation.scala
@@ -9,15 +9,19 @@ import java.util.List
 import java.util.Properties
 import java.util.SortedMap
 
+import vct.z3
+
 import scala.math.BigInt.int2bigInt
 import viper.silver.ast.SeqAppend
 import java.nio.file.Path
 
 import hre.ast.OriginFactory
+import hre.io.NamedPipe
 import viper.silver.parser.PLocalVarDecl
 
 import scala.collection.mutable.WrappedArray
 import hre.lang.System.Output
+import viper.api.util.Configuration
 
 class SilverImplementation[O](o:OriginFactory[O])
   extends viper.api.ViperAPI[O,Type,Exp,Stmt,DomainFunc,DomainAxiom,Prog](o,
@@ -73,6 +77,14 @@ class SilverImplementation[O](o:OriginFactory[O])
     val detail = Reachable.gonogo.detail();
     
     val report = new java.util.ArrayList[viper.api.ViperError[O]]()
+
+    if(Configuration.z3Progress.get) {
+      val logOutput = NamedPipe.create(new z3.LogParser, "vercors-z3-log-", "-01.log")
+      z3Settings.setProperty("proof", "true")
+      z3Settings.setProperty("trace", "true")
+      z3Settings.setProperty("trace-file-name", logOutput.path.replace("-01", ""))
+    }
+
     val verifier=createVerifier(z3Path,z3Settings)
     //println("verifier: "+ verifier);
     //Progress("running verify");


### PR DESCRIPTION
This PR has z3 log its proofs and actions to a UNIX pipe, so vercors may monitor it while working. This generates live while proving, among other things:

* formal (though unreadable) proofs for assertions
* quantifier instantiations

The log file format was largely taken from [axiom-profiler](https://github.com/viperproject/axiom-profiler/tree/master/LogDocumentation) and [an article](http://www21.in.tum.de/~boehmes/proofrec.pdf) about z3 proof reconstruction in isabelle.