### PR TITLE
Add throws modifier to Abort and Fail

### DIFF
--- a/hre/src/main/java/hre/lang/System.java
+++ b/hre/src/main/java/hre/lang/System.java
@@ -192,8 +192,9 @@ public class System {
      *
      * @param format The formatting of the message.
      * @param args   The arguments to be formatted.
+     * @throws HREExitException This exception is always thrown.
      */
-    public static void Abort(String format, Object... args) {
+    public static void Abort(String format, Object... args) throws HREExitException {
         log(LogLevel.Abort, errorStreams, format, args);
         throw new HREExitException(1);
     }
@@ -203,8 +204,10 @@ public class System {
      * <p>
      * This function is meant to be used for external error conditions,
      * such as bad input.
+     *
+     * @throws HREExitException This exception is always thrown.
      */
-    public static void Fail(String format, Object... args) {
+    public static void Fail(String format, Object... args) throws HREExitException {
         Verdict(format, args);
         throw new HREExitException(1);
     }


### PR DESCRIPTION
By adding throws to System.Abort and System.Fail Sonarcloud might be able to deduce that these methods never return, eliminating several false positives from Sonarcloud's analysis.