### PR TITLE
Labeled while contract

### DIFF
--- a/examples/goto/BadLabeledIfWithContract.java
+++ b/examples/goto/BadLabeledIfWithContract.java
@@ -1,0 +1,11 @@
+// -*- tab-width:2 ; indent-tabs-mode:nil -*-
+//:: cases BadLabeledContract
+//:: tools silicon
+//:: verdict Error
+
+class C {
+    void m() {
+        //@ loop_invariant true;
+        l: if (true) { }
+    }
+}

--- a/examples/goto/LabeledIf.java
+++ b/examples/goto/LabeledIf.java
@@ -1,0 +1,10 @@
+// -*- tab-width:2 ; indent-tabs-mode:nil -*-
+//:: cases LabeledIf
+//:: tools silicon
+//:: verdict Pass
+
+class C {
+    void m() {
+        l: if (true) { }
+    }
+}

--- a/examples/goto/LabeledWhile.java
+++ b/examples/goto/LabeledWhile.java
@@ -1,3 +1,8 @@
+// -*- tab-width:2 ; indent-tabs-mode:nil -*-
+//:: cases LabeledWhile
+//:: tools silicon
+//:: verdict Pass
+
 class C {
     void m1() {
         int i = 0;

--- a/examples/goto/LabeledWhile.java
+++ b/examples/goto/LabeledWhile.java
@@ -1,0 +1,46 @@
+class C {
+    void m1() {
+        int i = 0;
+        //@ loop_invariant 0 <= i && i <= 5;
+        l: while (i < 5) {
+            i += 1;
+        }
+        assert i == 5;
+    }
+
+    void m2() {
+        int i = 100;
+        //@ loop_invariant 100 <= i && i <=110;
+        l1: l2: while (i < 110) {
+            i += 1;
+        }
+        assert i == 110;
+    }
+
+    void m3() {
+        int i = 200;
+        //@ loop_invariant 200 <= i;
+        l1: l2:
+        //@ loop_invariant i <= 230;
+        while (i < 230) {
+            i += 1;
+        }
+        assert i == 230;
+    }
+
+    void m4() {
+        int i = -7;
+        //@ loop_invariant -7 <= i;
+        l1:
+        //@ loop_invariant i != 0;
+        l2:
+        //@ loop_invariant i <= 7;
+        while (i < 7) {
+            i += 1;
+            if (i == 0) {
+                i += 1;
+            }
+        }
+        assert i == 7;
+    }
+}

--- a/examples/goto/LabeledWhile.java
+++ b/examples/goto/LabeledWhile.java
@@ -4,48 +4,55 @@
 //:: verdict Pass
 
 class C {
+    int i;
+
+    //@ requires Perm(i, write);
     void m1() {
-        int i = 0;
-        //@ loop_invariant 0 <= i && i <= 5;
+        i = 0;
+        //@ loop_invariant Perm(i, write) ** 0 <= i ** i <= 5;
         l: while (i < 5) {
             i += 1;
         }
-        assert i == 5;
+        //@ assert i == 5;
+        //@ assert Perm(i, write);
     }
 
+    //@ requires Perm(i, write);
     void m2() {
-        int i = 100;
-        //@ loop_invariant 100 <= i && i <=110;
+        i = 100;
+        //@ loop_invariant Perm(i, write) ** 100 <= i ** i <=110;
         l1: l2: while (i < 110) {
             i += 1;
         }
-        assert i == 110;
+        //@ assert i == 110;
+        //@ assert Perm(i, write);
     }
 
+    //@ requires Perm(i, write);
     void m3() {
-        int i = 200;
-        //@ loop_invariant 200 <= i;
+        i = 200;
+        //@ loop_invariant Perm(i, write);
         l1: l2:
         //@ loop_invariant i <= 230;
         while (i < 230) {
             i += 1;
         }
-        assert i == 230;
+        //@ assert i == 230;
+        //@ assert Perm(i, write);
     }
 
+    //@ requires Perm(i, write);
     void m4() {
-        int i = -7;
-        //@ loop_invariant -7 <= i;
+        i = -7;
+        //@ loop_invariant Perm(i, 1\2);
         l1:
-        //@ loop_invariant i != 0;
+        //@ loop_invariant Perm(i, 1\2);
         l2:
         //@ loop_invariant i <= 7;
         while (i < 7) {
             i += 1;
-            if (i == 0) {
-                i += 1;
-            }
         }
-        assert i == 7;
+        //@ assert i == 7;
+        //@ assert Perm(i, write);
     }
 }

--- a/parsers/lib/antlr4/LangJavaParser.g4
+++ b/parsers/lib/antlr4/LangJavaParser.g4
@@ -472,7 +472,7 @@ statement
     |   'continue' javaIdentifier? ';'
     |   ';'
     |   statementExpression ';'
-    |   javaIdentifier ':' statement
+    |   valEmbedContract? javaIdentifier ':' statement
     |   {specLevel>0}? valStatement
     ;
 

--- a/parsers/src/main/java/vct/parsers/JavaJMLtoCOL.scala
+++ b/parsers/src/main/java/vct/parsers/JavaJMLtoCOL.scala
@@ -507,6 +507,10 @@ case class JavaJMLtoCOL(fileName: String, tokens: CommonTokenStream, parser: Jav
       create block() //nop
     case Statement16(exp, _) =>
       expr(exp)
+    case Statement17(None, label, ":", stat) =>
+      val res = convertStat(stat)
+      res.addLabel(create label convertID(label))
+      res
     case s@Statement17(_, _, _, _) =>
       convertStatWithContract(s, Seq())
     case Statement18(valStatement) =>


### PR DESCRIPTION
This pull request extends the parser to allow labeled while loops to have contracts. For example, the following now parses:

``` java
//@ loop_invariant true;
l: while (false) {
    // ...
}
```