### PR TITLE
Add NoSuchElementException to two classes

### DIFF
--- a/hre/src/main/java/hre/util/FilteredIterator.java
+++ b/hre/src/main/java/hre/util/FilteredIterator.java
@@ -1,6 +1,7 @@
 package hre.util;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 /**
  * Filters the given iterator for the elements that must be passed.
@@ -45,7 +46,14 @@ public class FilteredIterator<F,E> implements Iterator<E> {
   }
 
   public E next() {
-    E res=buffer;
+    if (buffer == null) {
+      fill_buffer();
+      if (buffer == null) {
+        throw new NoSuchElementException();
+      }
+    }
+    E res = buffer;
+    buffer = null;
     fill_buffer();
     return res;
   }

--- a/hre/src/main/java/hre/util/MultiNameSpace.java
+++ b/hre/src/main/java/hre/util/MultiNameSpace.java
@@ -3,6 +3,7 @@ package hre.util;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 /**
  * A name space with frame control and multiple definitions per name.
@@ -43,6 +44,9 @@ public class MultiNameSpace <Key,Data> implements FrameControl {
       }
     }
     public Data next(){
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
       Data res=list.item;
       list=list.next;
       return res;


### PR DESCRIPTION
MultiNameSpace and FilteredIterator do not properly use NoSuchElementException when the iterators deplete.