### PR TITLE
Fixes several Java examples

### DIFF
--- a/examples/dafny/DafnyIncr.java
+++ b/examples/dafny/DafnyIncr.java
@@ -1,23 +1,22 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
-//:: cases DafnySuccess
-//:: tools dafny
+//:: cases Increment
+//:: tools silicon
 
 class Incr {
 
-  /*@
-    ensures \result==\old(x)+1;
-  @*/
+  /*
+    @ ensures \result==\old(x)+1;
+  */
   public int incr(int x){
     return x+1;
   }
 
   int y;
 
-  /*@
-    requires true;
-    modifies this;
-    ensures y == \old(y)+1;
-  @*/
+  /*
+    @ context Perm(y, write);
+    @ ensures y == \old(y)+1;
+  */
   public void incry(){
     y = y + 1;
   }

--- a/examples/dafny/DafnyIncrE1.java
+++ b/examples/dafny/DafnyIncrE1.java
@@ -1,6 +1,6 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
-//:: cases DafnyError
-//:: tools dafny
+//:: cases IncrementError
+//:: tools silicon
 //:: verdict Fail
 class Incr {
 

--- a/examples/layers/Java6Lock.java
+++ b/examples/layers/Java6Lock.java
@@ -1,13 +1,13 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 //:: cases Java6LockImplementation
-//:: suite problem-fail
 //:: tools silicon
+//:: verdict Pass
 
 /*
     vct --silver=silicon Java6Lock.java
  */
 //begin(all)
-class AtomicInteger {
+final class AtomicInteger {
 
   int dummy;
 
@@ -32,7 +32,7 @@ class AtomicInteger {
 
 }
 
-class Subject {
+final class Subject {
 
   /*@
     resource inv();
@@ -41,7 +41,7 @@ class Subject {
 }
 
 
-class Thread {
+final class Thread {
 
   Thread(){
     //@ assume false;
@@ -54,9 +54,9 @@ class Thread {
   Lock locks[];
 
   /*@
-    inline resource APerm(loc<AtomicInteger> ref,frac p)=
+    inline resource MyMyAPerm(loc<AtomicInteger> ref,frac p)=
       Value(ref)**Perm(ref.val,p);
-    inline resource APointsTo(loc<AtomicInteger> ref,frac p,int v)=
+    inline resource MyMyAPointsTo(loc<AtomicInteger> ref,frac p,int v)=
       Value(ref)**PointsTo(ref.val,p,v);
     
     inline thread_local resource common()= Value(T) **
@@ -99,7 +99,7 @@ thread_local resource lockset(bag<int> S)=
     boolean res;
     //@ unfold lockset(S);
     res=locks[lock_id].trylock();
-    /*@
+    /*@ ghost
       if (res) {
         fold lockset(S+bag<int>{lock_id});
       } else {
@@ -112,16 +112,16 @@ thread_local resource lockset(bag<int> S)=
 
 
 
-class Lock {
+final class Lock {
 
-  /*@ 
-    int T; // Maximum number of threads.
+  /*@
+    ghost int T; // Maximum number of threads.
 
-    int held[];
+    ghost int held[];
   
-    int holder;
+    ghost int holder;
     
-    Subject subject;
+    ghost Subject subject;
   @*/
   
   AtomicInteger count;
@@ -135,9 +135,9 @@ class Lock {
       Value(held) ** held != null **
       Value(subject);
       
-    inline resource APerm(loc<AtomicInteger> ref,frac p)=
+    inline resource MyAPerm(loc<AtomicInteger> ref,frac p)=
       Value(ref)**Perm(ref.val,p);
-    inline resource APointsTo(loc<AtomicInteger> ref,frac p,int v)=
+    inline resource MyAPointsTo(loc<AtomicInteger> ref,frac p,int v)=
       Value(ref)**PointsTo(ref.val,p,v);
   @*/
   
@@ -145,9 +145,9 @@ class Lock {
 // begin(context_everywhere)
 resource csl_invariant()= Value(T) ** T > 0 **
    Value(held) ** held != null ** Value(subject) **
-   APerm(count,1\2) ** APerm(owner,1\2) **
+   MyAPerm(count,1\2) ** MyAPerm(owner,1\2) **
    (count.val == 0 ==> subject.inv() **
-           APerm(count,1\2) ** APerm(owner,1\2)) **
+           MyAPerm(count,1\2) ** MyAPerm(owner,1\2)) **
    Perm(holder,1) ** -1 <= holder < T **
    (holder == -1) == (count.val == 0) **
    (\forall* int i; 0 <= i < T ;
@@ -163,8 +163,8 @@ resource csl_invariant()= Value(T) ** T > 0 **
     resource lockset_part()= held!=null **
        Perm(held[\current_thread],1\2) **
        (held[\current_thread] > 0 ==>
-          APointsTo(count,1\2,held[\current_thread]) **
-          APointsTo(owner,1\2,\current_thread));
+          MyAPointsTo(count,1\2,held[\current_thread]) **
+          MyAPointsTo(owner,1\2,\current_thread));
 // end(context_everywhere)
   @*/
 

--- a/examples/permissions/BadLoop1.java
+++ b/examples/permissions/BadLoop1.java
@@ -1,16 +1,20 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 //:: cases BadLoop1
-//:: tools chalice
+//:: tools silicon
 //:: verdict Fail
 class Counter {
   private int val;
-  /*@ requires Perm(val,100) ** n>=0; */
-  /*@ ensures Perm(val,100) ** val==\old(val)+n; */
+  /*@ 
+    requires Perm(val,1) ** n>=0;
+    ensures Perm(val,1) ** val==\old(val)+n; 
+  @*/
   void incr(int n)
   {
     int tmp=n;
-    /*@ loop_invariant val+tmp==\old(val)+n && tmp>0; */
-    /*@ loop_invariant Perm(val,100); */
+    /*@ 
+      loop_invariant val+tmp==\old(val)+n && tmp>0;
+      loop_invariant Perm(val,1); 
+	@*/
     while(tmp>0)
     {
       val=val+1;

--- a/examples/permissions/BadLoop2.java
+++ b/examples/permissions/BadLoop2.java
@@ -1,15 +1,19 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
-//:: cases BaddLoop2
-//:: tools chalice
+//:: cases BadLoop2
+//:: tools silicon
 //:: verdict Fail
 class Counter {
   private int val;
-  /*@ requires Perm(val,100) ** n>=0; */
-  /*@ ensures Perm(val,100) ** val==\old(val)+n; */
+  /*@ 
+    requires Perm(val,1) ** n>=0;
+    ensures Perm(val,1) ** val==\old(val)+n; 
+  @*/
   void incr(int n)
   {
     int tmp=n;
-    /*@ loop_invariant val+tmp==\old(val)+n && tmp>=0; */
+    /*@ 
+      loop_invariant val+tmp==\old(val)+n && tmp>=0; 
+	@*/
     while(tmp>0)
     {
       val=val+1;

--- a/examples/permissions/Counter.java
+++ b/examples/permissions/Counter.java
@@ -1,26 +1,32 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 //:: cases Counter
-//:: tools chalice
+//:: tools silicon
+//:: verdict Pass
 /*
-check with vct --chalice Counter.java
+check with vct --silicon Counter.java
 */
 class Counter {
   private int val;
 
-  /*@ requires Perm(val,100);
-      ensures  Perm(val,100) ** val==\old(val)+1;
-   */
+  /*@ 
+    requires Perm(val,1);
+    ensures  Perm(val,1) ** val==\old(val)+1;
+  @*/
   void incr(){
     val = val+1;
   }
   
-  /*@ requires Perm(val,100) ** n>=0; */
-  /*@ ensures Perm(val,100) ** val==\old(val)+n; */
+  /*@ 
+	requires Perm(val,1) ** n>=0;
+    ensures Perm(val,1) ** val==\old(val)+n; 
+  @*/
   void incr_by_n(int n)
   {
     int tmp=n;
-    /*@ loop_invariant Perm(val,100); */
-    /*@ loop_invariant val+tmp==\old(val)+n ** tmp>=0; */
+    /*@ 
+      loop_invariant Perm(val,1);
+      loop_invariant val+tmp==\old(val)+n ** tmp>=0; 
+    @*/
     while(tmp>0)
     {
       val=val+1;
@@ -28,13 +34,17 @@ class Counter {
     }
   }
 
-  /*@ requires Perm(c.val,100) ** n>=0; */
-  /*@ ensures Perm(c.val,100) ** c.val==\old(c.val)+n; */
+  /*@ 
+    requires Perm(c.val,1) ** n>=0;
+    ensures Perm(c.val,1) ** c.val==\old(c.val)+n; 
+  @*/
   static void incr_static(Counter c,int n)
   {
     int tmp=n;
-    /*@ loop_invariant Perm(c.val,100); */
-    /*@ loop_invariant c.val+tmp==\old(c.val)+n ** tmp>=0; */
+    /*@ 
+      loop_invariant Perm(c.val,1);
+      loop_invariant c.val+tmp==\old(c.val)+n ** tmp>=0; 
+    @*/
     while(tmp>0)
     {
       c.incr();

--- a/examples/permissions/Incr.java
+++ b/examples/permissions/Incr.java
@@ -1,8 +1,4 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
-//:: case IncrChalice
-//:: tools chalice
-//:: verdict Fail
-
 //:: case IncrSilicon
 //:: tools silicon
 //:: verdict Pass Incr.incr_n_ok Incr.incr_ok
@@ -11,22 +7,27 @@
 class Incr {
   int val;
   
-  /*@ requires Perm(val,1);
-      ensures Perm(val,1) ** val==\old(val)+1;
-   */
+  /*@ 
+    requires Perm(val,1);
+    ensures Perm(val,1) ** val == \old(val)+1;
+  @*/
   void incr_ok()
   {
     val = val+1;
   }
 
-  /*@ requires Perm(val,1) **  n>=0; */
-  /*@ ensures Perm(val,1) ** val==\old(val)+n; */
+  /*@ 
+    requires Perm(val,1) **  n>=0;
+    ensures Perm(val,1) ** val == \old(val)+n; 
+  @*/
   void incr_n_ok(int n)
   {
     int tmp;
     tmp=n;
-    /*@ loop_invariant Perm(val,1); */
-    /*@ loop_invariant val+tmp==\old(val)+n && tmp>=0; */
+    /*@ 
+      loop_invariant Perm(val,1);
+      loop_invariant val+tmp == \old(val)+n && tmp>=0; 
+	@*/
     while(tmp>0)
     {
       val=val+1;
@@ -34,14 +35,18 @@ class Incr {
     }
   }
 
-  /*@ requires Perm(val,1) ** n>=0; */
-  /*@ ensures Perm(val,1) ** val==\old(val)+n; */
+  /*@ 
+    requires Perm(val,1) ** n>=0;
+    ensures Perm(val,1) ** val==\old(val)+n; 
+  @*/
   void incr_n_badinv(int n)
   {
     int tmp;
     tmp=n;
-    /*@ loop_invariant val+tmp==\old(val)+n && tmp>0; */
-    /*@ loop_invariant Perm(val,1); */
+    /*@ 
+      loop_invariant val+tmp == \old(val)+n && tmp>0;
+      loop_invariant Perm(val,1); 
+	@*/
     while(tmp>0)
     {
       val=val+1;

--- a/examples/permissions/MultiIncrement.java
+++ b/examples/permissions/MultiIncrement.java
@@ -1,6 +1,7 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 //:: cases MultiIncrement
-//:: tools chalice
+//:: tools silicon
+//:: verdict Pass
 
 public class MultiIncrement {
 
@@ -9,32 +10,32 @@ public class MultiIncrement {
   public int owned;
   
   /*@
-    requires Perm(owned,100);
-    ensures  Perm(owned,100)**owned==\old(owned)+1;
+    requires Perm(owned,1);
+    ensures  Perm(owned,1) ** owned == \old(owned)+1;
   @*/
   public void incr_this_one(){
     owned=owned+1;
   }
 
   /*@
-    requires Perm(shared,100);
-    ensures  Perm(shared,100)**shared==\old(shared)+1;
+    requires Perm(shared,1);
+    ensures  Perm(shared,1) ** shared == \old(shared)+1;
   @*/
   public void incr_shared_one(){
     shared=shared+1;
   } 
 
   /*@
-    requires Perm(obj.owned,100);
-    ensures  Perm(obj.owned,100)**obj.owned==\old(obj.owned)+1;
+    requires Perm(obj.owned,1);
+    ensures  Perm(obj.owned,1) ** obj.owned == \old(obj.owned)+1;
   @*/
   public static void static_incr_this_one(MultiIncrement obj){
     obj.owned=obj.owned+1;
   }
 
   /*@
-    requires Perm(shared,100);
-    ensures  Perm(shared,100)**shared==\old(shared)+1;
+    requires Perm(shared,1);
+    ensures  Perm(shared,1) ** shared == \old(shared)+1;
   @*/
   public static void static_incr_shared_one(){
     shared=shared+1;
@@ -42,12 +43,12 @@ public class MultiIncrement {
 
 
   /*@
-    requires Perm(owned,100)**N>=0;
-    ensures  Perm(owned,100)**owned==\old(owned)+N;
+    requires Perm(owned,1) ** N>=0;
+    ensures  Perm(owned,1) ** owned == \old(owned)+N;
   @*/
   public void incr_this_many(int N){
     int i=N;
-    //@ loop_invariant Perm(owned,100) ** owned+i==\old(owned)+N ** i>=0;
+    //@ loop_invariant Perm(owned,1) ** owned+i == \old(owned)+N ** i>=0;
     while(i>0){
         owned=owned+1;
         i=i-1;
@@ -55,12 +56,12 @@ public class MultiIncrement {
   }
 
   /*@
-    requires Perm(shared,100)**N>=0;
-    ensures  Perm(shared,100)**shared==\old(shared)+N;
+    requires Perm(shared,1) ** N>=0;
+    ensures  Perm(shared,1) ** shared == \old(shared)+N;
   @*/
   public void incr_shared_many(int N){
     int i=N;
-    //@ loop_invariant Perm(shared,100) ** shared+i==\old(shared)+N ** i>=0;
+    //@ loop_invariant Perm(shared,1) ** shared+i == \old(shared)+N ** i>=0;
     while(i>0){
         shared=shared+1;
         i=i-1;
@@ -68,12 +69,12 @@ public class MultiIncrement {
   } 
 
   /*@
-    requires Perm(obj.owned,100)**N>=0;
-    ensures  Perm(obj.owned,100)**obj.owned==\old(obj.owned)+N;
+    requires Perm(obj.owned,1) ** N>=0;
+    ensures  Perm(obj.owned,1) ** obj.owned == \old(obj.owned)+N;
   @*/
   public static void static_incr_this_many(MultiIncrement obj,int N){
     int i=N;
-    //@ loop_invariant Perm(obj.owned,100) ** obj.owned+i==\old(obj.owned)+N ** i>=0;
+    //@ loop_invariant Perm(obj.owned,1) ** obj.owned+i == \old(obj.owned)+N ** i>=0;
     while(i>0){
         obj.owned=obj.owned+1;
         i=i-1;
@@ -81,12 +82,12 @@ public class MultiIncrement {
   }
 
   /*@
-    requires Perm(shared,100)**N>=0;
-    ensures  Perm(shared,100)**shared==\old(shared)+N;
+    requires Perm(shared,1) ** N>=0;
+    ensures  Perm(shared,1) ** shared == \old(shared)+N;
   @*/
   public static void static_incr_shared_many(int N){
     int i=N;
-    //@ loop_invariant Perm(shared,100) ** shared+i==\old(shared)+N ** i>=0;
+    //@ loop_invariant Perm(shared,1) ** shared+i == \old(shared)+N ** i>=0;
     while(i>0){
         shared=shared+1;
         i=i-1;

--- a/examples/permissions/RosterFixed.java
+++ b/examples/permissions/RosterFixed.java
@@ -1,29 +1,30 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 //:: cases RosterFixed
-//:: tools chalice
+//:: tools silicon
+//:: verdict Pass
 
 /* See pg 42, phd Hurlin. */
 
-class Roster {
+final class Roster {
   int id;
   int grade;
   Roster next;
 
 /*@
-  resource ids_and_links()=Perm(id,100) ** Perm(next,50) ** next->ids_and_links();
+  resource ids_and_links()=Perm(id,1) ** Perm(next,1\2) ** next->ids_and_links();
  
-  resource grades_and_links()=Perm(grade,100) ** Perm(next,50) ** next->grades_and_links() ;
+  resource grades_and_links()=Perm(grade,1) ** Perm(next,1\2) ** next->grades_and_links() ;
 
   resource state()= ids_and_links() ** grades_and_links();
  */
  
   //@ requires n->state();
-  //@ ensures  this.state();
+  //@ ensures this.state();
   Roster(int i, int g, Roster n) {
     id = i;
     grade = g;
     next = n;
-    /*@
+    /*@ ghost
       if (n!=null) { unfold n.state(); }
     */
     //@ fold ids_and_links();
@@ -32,7 +33,7 @@ class Roster {
   }
 
   //@ requires state();
-  //@ ensures  state();
+  //@ ensures state();
   void updateGrade(int id, int grade) {
     /*@
       unfold state();
@@ -54,7 +55,7 @@ class Roster {
   }
 
   //@ requires ids_and_links();
-  //@ ensures  ids_and_links();
+  //@ ensures ids_and_links();
   boolean contains(int id) {
     //@ unfold ids_and_links();
     boolean b = this.id==id;

--- a/examples/permissions/SwapInteger.java
+++ b/examples/permissions/SwapInteger.java
@@ -1,16 +1,18 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 //:: cases SwapInteger
-//:: tools chalice
-//:: verdict Fail
+//:: tools silicon
+//:: verdict Pass SwapInteger.n SwapInteger.twice
+//:: verdict Fail SwapInteger.wrong
 
 public class SwapInteger {
 
   int F;
   int G;
-  /*@ requires Perm(F,100) ** Perm(G,100);
-      ensures Perm(F,100) ** Perm(G,100);
-      ensures F == \old(G) && G == \old(F);
-   */
+  /*@ 
+    requires Perm(F,1) ** Perm(G,1);
+    ensures Perm(F,1) ** Perm(G,1);
+    ensures F == \old(G) && G == \old(F);
+  @*/
   void n()
   {
     int tmp;
@@ -20,20 +22,22 @@ public class SwapInteger {
   }
 
 
-  /*@ requires Perm(F,100) ** Perm(G,100);
-      ensures Perm(F,100) ** Perm(G,100);
-      ensures F == \old(F) && G == \old(G);
-   */
+  /*@ 
+    requires Perm(F,1) ** Perm(G,1);
+    ensures Perm(F,1) ** Perm(G,1);
+    ensures F == \old(F) && G == \old(G);
+  @*/
   void twice()
   {
     n();
     n();
   }
   
-  /*@ requires Perm(F,100) ** Perm(G,100);
-      ensures Perm(F,100) ** Perm(G,100);
-      ensures F == \old(F) && G == \old(G);
-   */
+  /*@ 
+    requires Perm(F,1) ** Perm(G,1);
+    ensures Perm(F,1) ** Perm(G,1);
+    ensures F == \old(F) && G == \old(G);
+  @*/
   void wrong()
   {
     n();

--- a/examples/permissions/SwapLong.java
+++ b/examples/permissions/SwapLong.java
@@ -1,16 +1,21 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 //:: cases SwapLong
-//:: tools chalice
-//:: verdict Fail
+//:: suite skip-travis
+// tools silicon
+// verdict Pass SwapLong.n SwapLong.twice
+// verdict Fail SwapLong.wrong
+
+// Issue with Long things in VerCors
 
 public class SwapLong {
 
   long F;
   long G;
-  /*@ requires Perm(F,100) ** Perm(G,100);
-      ensures Perm(F,100) ** Perm(G,100);
-      ensures F == \old(G) && G == \old(F);
-   */
+  /*@ 
+    requires Perm(F,1) ** Perm(G,1);
+    ensures Perm(F,1) ** Perm(G,1);
+    ensures F == \old(G) && G == \old(F);
+  @*/
   void n()
   {
     long tmp;
@@ -20,20 +25,22 @@ public class SwapLong {
   }
 
 
-  /*@ requires Perm(F,100) ** Perm(G,100);
-      ensures Perm(F,100) ** Perm(G,100);
-      ensures F == \old(F) && G == \old(G);
-   */
+  /*@ 
+    requires Perm(F,1) ** Perm(G,1);
+    ensures Perm(F,1) ** Perm(G,1);
+    ensures F == \old(F) && G == \old(G);
+  @*/
   void twice()
   {
     n();
     n();
   }
   
-  /*@ requires Perm(F,100) ** Perm(G,100);
-      ensures Perm(F,100) ** Perm(G,100);
-      ensures F == \old(F) && G == \old(G);
-   */
+  /*@ 
+    requires Perm(F,1) ** Perm(G,1);
+    ensures Perm(F,1) ** Perm(G,1);
+    ensures F == \old(F) && G == \old(G);
+  @*/
   void wrong()
   {
     n();

--- a/examples/permissions/TreeStack.java
+++ b/examples/permissions/TreeStack.java
@@ -1,7 +1,8 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 //:: cases TreeStack
-//:: tools chalice
+//:: tools silicon
 //:: suite medium
+//:: verdict Pass
 
 /*
     Note that this specification only validates access permissions.
@@ -10,15 +11,15 @@
      
 */
 
-public class Tree {
+final public class Tree {
 
   public int data;
   public Tree left;
   public Tree right;
 
   /*@
-    public resource state()=Perm(data,100)**
-	Perm(left,100)**Perm(right,100)**
+    public resource state()=Perm(data,1)**
+	Perm(left,1)**Perm(right,1)**
 	left->state()**right->state();
   @*/
 
@@ -42,10 +43,10 @@ public class Tree {
            stk = null;
            //@ loop_invariant pp!=null;
            //@ loop_invariant p!=null;
-           //@ loop_invariant Perm(p.left,100)**Perm(p.right,100);
-           //@ loop_invariant Perm(p.data,100)**p.right->state();
-           //@ loop_invariant Perm(pp.left,100)**Perm(pp.right,100);
-           //@ loop_invariant Perm(pp.data,100)**pp.right->state();
+           //@ loop_invariant Perm(p.left,1)**Perm(p.right,1);
+           //@ loop_invariant Perm(p.data,1)**p.right->state();
+           //@ loop_invariant Perm(pp.left,1)**Perm(pp.right,1);
+           //@ loop_invariant Perm(pp.data,1)**pp.right->state();
            //@ loop_invariant p==pp.left;
            //@ loop_invariant tt==p.left;
            //@ loop_invariant tt->state();
@@ -62,8 +63,10 @@ public class Tree {
 	       }
 	       tt = p.right;
            pp.left= tt;
-           /*@
+           /*@ 
                fold pp.state();
+			   
+			   ghost
                loop_invariant pp!= null ** pp.state();
                loop_invariant stk->state();
                loop_invariant stk!=null ==> stk.get_ref_left() == pp ;
@@ -81,22 +84,22 @@ public class Tree {
 	 }
 }
 
-class Stack {
+final class Stack {
   public Tree root;
   public Tree ref;
   public Stack tail;
   
   /*@
     public resource state()=
-        Perm(ref,100)**Perm(tail,100)**Perm(root,100)**tail->state()**ref!=null **
-        Perm(ref.data,100)**Perm(ref.left,100)**Perm(ref.right,100)**ref.right->state()
+        Perm(ref,1)**Perm(tail,1)**Perm(root,1)**tail->state()**ref!=null **
+        Perm(ref.data,1)**Perm(ref.left,1)**Perm(ref.right,1)**ref.right->state()
         ** ((tail!=null)==>(ref==tail.get_ref_left() ** root==tail.get_root()))
         ** (tail==null ==> ref==root);
         
   @*/
   /*@
     requires ref!=null ** tail->state();
-    requires Perm(ref.data,100)**Perm(ref.left,100)**Perm(ref.right,100)**ref.right->state();
+    requires Perm(ref.data,1)**Perm(ref.left,1)**Perm(ref.right,1)**ref.right->state();
     requires tail!=null ==> ref==tail.get_ref_left();
     requires tail!=null ==> root==tail.get_root();
     requires tail==null ==> ref==root;
@@ -111,17 +114,17 @@ class Stack {
 
   /*@
     requires state();
-    public pure Tree get_ref()=ref; 
+    public pure Tree get_ref()=\unfolding state() \in ref; 
    @*/
 
   /*@
     requires state();
-    public pure Tree get_ref_left()=ref.left; 
+    public pure Tree get_ref_left()=\unfolding state() \in ref.left; 
    @*/
 
   /*@
     requires state();
-    public pure Tree get_root()=root;
+    public pure Tree get_root()=\unfolding state() \in root;
    @*/
 }
 

--- a/examples/predicates/IntegerList.java
+++ b/examples/predicates/IntegerList.java
@@ -1,89 +1,87 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 //:: cases IntegerList
-//:: tools chalice
+//:: tools silicon
 //:: verdict Fail
 
 public class IntegerList {
 
     private int val;
     private IntegerList next;
-    //@ int min;
+    //@ ghost int min;
 
     /*@
-        resource state()=
-            Perm(val,100)**
-            Perm(min,100)**
-            Perm(next,100)**
-            next->state()**
-            next->check_min(min);
+        final resource state() = Perm(val,1) ** Perm(min,1) ** Perm(next,1)**
+            next->state() ** next->check_min(min);
         
         requires state();
-        pure int get_min()=min;
+        pure int get_min() = \unfolding state() \in min;
         
         requires state();
-        ensures  \result ==> get_min()==i;
-        pure boolean check_min(int i)=min==i;
+        ensures \result ==> get_min() == i;
+        pure boolean check_min(int i) = \unfolding state() \in min == i;
         
         requires state();
-        pure int get_val()=val;
+        pure int get_val() = \unfolding state() \in val;
         
         requires state();
-        pure IntegerList get_next()=next;
+        pure IntegerList get_next() = \unfolding state() \in next;
     @*/
     
     /*@
         given int mmin;
         requires mmin <= val ** next->state() ** next->check_min(mmin);
-        ensures  state() ** check_min(mmin);
+        ensures state() ** check_min(mmin);
     @*/
-    public IntegerList(int val,IntegerList next){
+    public IntegerList(int val, IntegerList next){
         this.val=val;
         this.next=next;
-        //@ this.min=mmin;
+        //@ ghost this.min = mmin;
         //@ fold state();
     }
 
     /*@
         requires next !=null ** next.state() ** next.get_min() <= val;
-        ensures  \result!=null ** \result.state() ** \result.check_min(\old(next.get_min()));
+        ensures \result!=null ** \result.state() ** \result.check_min(\old(next.get_min()));
     @*/
-    public static IntegerList cons (int val,IntegerList next){
+    public static IntegerList cons(int val, IntegerList next){
         /*@
             unfold next.state();
-            int tmp=next.min;
+            ghost int tmp=next.min;
             fold next.state();
         @*/
-        return  (new IntegerList(val,next) /*@ with { mmin = tmp ; } */);
+		IntegerList res = new IntegerList(val, next) /*@ with { mmin = tmp; } @*/;
+        return res;
     }
 
     /*@
         given int mmin;
         requires mmin <= val;
-        ensures  \result!=null ** \result.state() ** \result.check_min(mmin);
+        ensures \result != null ** \result.state() ** \result.check_min(mmin);
     @*/
     public static IntegerList single(int val){
-        return  new IntegerList(val,null) /*@ with { mmin=mmin ; } */;
+		IntegerList res = new IntegerList(val, null) /*@ with { mmin=mmin ; } */;
+        return res;
     }
 
-    /* @ spec_ignore @* / public static void main(String args[]){
+    /*  spec_ignore @* / public static void main(String args[]){
         main();
     }*/
 
     static void main(){
         IntegerList list = single(3) /*@ with { mmin = 1 ; } */;
-        /* @ spec_ignore @* / System.out.printf("List is %s%n",list);*/
+        /*  spec_ignore @* / System.out.printf("List is %s%n",list);*/
         list = cons(2,list);
-        /* @ spec_ignore @* / System.out.printf("List is %s%n",list);*/
+        /*  spec_ignore @* / System.out.printf("List is %s%n",list);*/
         list = cons(1,list);
-        /* @ spec_ignore @* / System.out.printf("List is %s%n",list);*/
+        /*  spec_ignore @* / System.out.printf("List is %s%n",list);*/
         list = cons(0,list);
-        /* @ spec_ignore @* / System.out.printf("List is %s%n",list);*/
+        /*  spec_ignore @* / System.out.printf("List is %s%n",list);*/
     }
 
-    /* @ spec_ignore @* / public String toString(){
+    /*  spec_ignore @* / public String toString(){
         return toString("[");
     }*/
-    /* @ spec_ignore @* / public String toString(String prefix){
+    /*  spec_ignore @* / public String toString(String prefix){
         prefix=prefix+val;
         if (next==null) {
             return prefix+"]";

--- a/examples/predicates/TreeRecursive.java
+++ b/examples/predicates/TreeRecursive.java
@@ -1,11 +1,12 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 //:: cases TreeRecursive
-//:: tools chalice
+//:: tools silicon
+//:: verdict Pass
 /**
   
   The command line to verify with the VerCors Tool is:
   
-  vct --chalice TreeRecursive.java
+  vct --silicon TreeRecursive.java
   
   The expected result is Pass.
 */
@@ -17,15 +18,15 @@ public class Tree {
   public Tree right;
 
   /*@
-    public resource state()=Perm(data,100)**
-	Perm(left,100)**Perm(right,100)**
-	left->state()**right->state();
+    final public resource state()=Perm(data,1) **
+    Perm(left,1) ** Perm(right,1) **
+    left->state() ** right->state();
   @*/
 
   /*@
     requires t->state();
     ensures  t!=null ==> \result.length > 0;
-    public pure seq<int> contents(Tree t){
+    ghost public pure seq<int> contents(Tree t) {
       if(t==null){
           return seq<int>{};
       } else {

--- a/examples/quickselect/QuickSelect.java
+++ b/examples/quickselect/QuickSelect.java
@@ -1,5 +1,7 @@
 //:: case QuickSelect
 //:: tools silicon
+//:: verdict Pass
+//:: suite slow
 package quickselect;
 
 import static quickselect.RandomBetween.random_between;

--- a/examples/refute/Sat.java
+++ b/examples/refute/Sat.java
@@ -1,25 +1,24 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 //:: cases RefuteSat
-//:: tools chalice silicon
+//:: tools silicon
 //:: verdict Pass
-
 
 /*
   Everything is corrrect.
 */
 public class Sat {
 
-// satisfiable is good.
-/*@
-  requires true;
-@*/
+  // satisfiable is good.
+  /*@
+    requires true;
+  @*/
   public void good(){
   }
 
-// intentionally requiring false is acceptable too.
-/*@
-  requires false;
-@*/
+  // intentionally requiring false is acceptable too.
+  /*@
+    requires false;
+  @*/
   public void good2(){
   }
 

--- a/examples/refute/Unsat.java
+++ b/examples/refute/Unsat.java
@@ -1,16 +1,16 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 //:: cases RefuteUnsat
-// tools chalice silicon
-// verdict Fail
+//:: tools silicon
+//:: verdict Fail
 
 /*
-  The pre-condition is unsatisfyable.
+  The pre-condition is unsatisfiable.
 */
 public class Unsat {
 
-/*@
-  requires 1==0;
-@*/
+  /*@
+    requires 1==0;
+  @*/
   public void bad(){
   }
 

--- a/examples/refute/refute1.java
+++ b/examples/refute/refute1.java
@@ -1,6 +1,6 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 //:: cases Refute1
-//:: tools chalice silicon
+//:: tools silicon
 //:: verdict Pass
 
 /*
@@ -8,9 +8,9 @@
 */
 public class Refute {
 
-/*@
-  requires true;
-@*/
+  /*@
+    requires true;
+  @*/
   public void good(){
     //@ refute false;
   }

--- a/examples/refute/refute2.java
+++ b/examples/refute/refute2.java
@@ -1,6 +1,6 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 //:: cases Refute2
-// tools chalice silicon
+// tools silicon
 // verdict Fail
 
 /*
@@ -8,9 +8,9 @@
 */
 public class Refute {
 
-/*@
-  requires true;
-@*/
+  /*@
+    requires true;
+  @*/
   public void bad(){
     if (false) {
       //@ refute false;

--- a/examples/refute/refute3.java
+++ b/examples/refute/refute3.java
@@ -1,6 +1,6 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 //:: cases Refute3
-//:: tools chalice silicon
+//:: tools silicon
 //:: verdict Fail
 
 /*
@@ -10,10 +10,10 @@
 public class Refute {
 
   int x;
-/*@
-  requires Perm(x,write) ** x==2;
-  ensures  Perm(x,write) ** x==3;
-@*/
+  /*@
+    requires Perm(x,write) ** x==2;
+    ensures  Perm(x,write) ** x==3;
+  @*/
   public void bad2(){
     //@ refute x==3;
   }

--- a/examples/refute/refute4.java
+++ b/examples/refute/refute4.java
@@ -1,6 +1,6 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 //:: cases Refute4
-//:: tools chalice silicon
+//:: tools silicon
 //:: verdict Pass
 
 /*
@@ -10,10 +10,10 @@ public class Refute {
 
   int x;
 
-/*@
-  requires Perm(x,write) ** x==2;
-  ensures  Perm(x,write) ** x==3;
-@*/
+  /*@
+    requires Perm(x,write) ** x==2;
+    ensures  Perm(x,write) ** x==3;
+  @*/
   public void good2(){
     //@ refute x==3;
     x = 3;

--- a/examples/refute/refute5.java
+++ b/examples/refute/refute5.java
@@ -1,6 +1,6 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 //:: cases Refute5
-//:: tools chalice silicon
+//:: tools silicon
 //:: verdict Fail
 
 /*
@@ -11,10 +11,10 @@ public class Refute {
 
   int x;
 
-/*@
-  requires Perm(x,write) ** x==2;
-  ensures  Perm(x,write) ** x==3;
-@*/
+  /*@
+    requires Perm(x,write) ** x==2;
+    ensures  Perm(x,write) ** x==3;
+  @*/
   public void good2(){
     //@ assert x==3;
     //@ refute x==3;

--- a/examples/sequential/BoogieExample.java
+++ b/examples/sequential/BoogieExample.java
@@ -1,9 +1,10 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 //:: cases BoogieExample
-//:: tools boogie
-//:: verdict Fail
+//:: tools silicon
+//:: verdict Pass BoogieExample.F
+//:: verdict Fail BoogieExample.G
 
-/* vct --boogie BoogieExample.java
+/* vct --silicon BoogieExample.java
 
 produces
 
@@ -15,37 +16,35 @@ produces
 
 public class BoogieExample {
 
-/*@
-  ensures 100 < n ==> \result == n - 10;  // This postcondition is easy to check by hand
-  ensures n <= 100 ==> \result == 91;     // Do you believe this one is true?
- @*/
- public static int F(int n)
-{
-  int r;
-  if (100 < n) {
-    r = n - 10;
-  } else {
-    r = F(n + 11);
-    r = F(r);
+  /*@
+    ensures 100 < n ==> \result == n - 10;  // This postcondition is easy to check by hand
+    ensures n <= 100 ==> \result == 91;     // Do you believe this one is true?
+  @*/
+  public static int F(int n) {
+    int r;
+    if (100 < n) {
+      r = n - 10;
+    } else {
+      r = F(n + 11);
+      r = F(r);
+    }
+    return r;
   }
-  return r;
-}
 
-/*@
-  ensures \result <= 91;     // Do you believe this one is true?
- @*/
- public static int G(int n)
-{
-  int r;
-  if (100 < n) {
-    r = n - 10;
-    return r;
-  } else {
-    r = F(n + 11);
-    r = F(r);
-    return r;
+  /*@
+    ensures \result <= 91;     // Do you believe this one is true?
+  @*/
+  public static int G(int n) {
+    int r;
+    if (100 < n) {
+      r = n - 10;
+      return r;
+    } else {
+      r = F(n + 11);
+      r = F(r);
+      return r;
+    }
   }
-}
 
 }
 

--- a/examples/sequential/BoogieTest.java
+++ b/examples/sequential/BoogieTest.java
@@ -1,58 +1,64 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 //:: cases BoogieTest
-//:: tools boogie
-//:: verdict Fail
+//:: tools silicon
+//:: verdict Pass BoogieTest.abs BoogieTest.good_incr_1 BoogieTest.good_incr_2
+//:: verdict Fail BoogieTest.bad_incr_1 BoogieTest.bad_incr_2
 
-/* vct --boogie BoogieTest.java
+/* vct --silicon BoogieTest.java
 
 produces
 
   method abs: Pass
   method bad_incr_1: Fail (assertion violation)
+  method bad_incr_2: Fail (assertion violation)
   method good_incr_1: Pass
   method good_incr_2: Pass
-  method good_incr_3: Pass
   The final verdict is Fail
 
 */
 
 public class BoogieTest {
 
-  /*@ requires true;
-      ensures \result >= 0 && (\result==x || \result==-x);
-    @*/
+  /*@ 
+    requires true;
+    ensures \result >= 0 && (\result == x || \result == -x);
+  @*/
   public static int abs(int x){
     if(x>0) return x;
     return -x;
   }
   
-  /*@ requires true;
-      ensures \result==x+1;
-  */
+  /*@ 
+    requires true;
+    ensures \result == x+1;
+  @*/
   public static int bad_incr_1(int x){
     return x++;
   }
 
-  /*@ requires  true;
-      ensures \result==x+1;
-  */
-  public static int good_incr_1(int x){
+  /*@ 
+    requires true;
+    ensures \result == x+1;
+  @*/
+  public static int bad_incr_2(int x){
     return ++x;
   }
 
-  /*@ requires true;
-      ensures \result==x+1;
-  */
-  public static int good_incr_2(int x){
+  /*@ 
+    requires true;
+    ensures \result == x+1;
+  @*/
+  public static int good_incr_1(int x){
     int res=x+1;
     return res;
   }
 
-  /*@ requires true;
-      ensures \result==x+1;
-  */
-  public static int good_incr_3(int x){
-    int res=good_incr_2(x);
+  /*@ 
+    requires true;
+    ensures \result == x+1;
+  @*/
+  public static int good_incr_2(int x){
+    int res=good_incr_1(x);
     return res;
   }
 

--- a/examples/sequential/LoopInv.java
+++ b/examples/sequential/LoopInv.java
@@ -1,8 +1,9 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 //:: cases LoopInvBoogie
-//:: tools boogie
-//:: verdict Fail
-/* vct --boogie LoopInv.java
+//:: tools silicon
+//:: verdict Pass LoopInv f_ok
+//:: verdict Fail LoopInv f_bad
+/* vct --silicon LoopInv.java
 
 produces
 
@@ -12,34 +13,38 @@ produces
 
 */
 public class LoopInv {
-  /*@ requires n>0 ; */
-  /*@ ensures \result==n*n; */
-	public static int f_ok(int n){
-	  int res,i;
-		res=0;
-		i=0;
-		//@ loop_invariant res==i*n;
-		//@ loop_invariant i <= n;
-		while(i<n) {
-			res=res+n;
-			//i++;
-			i=i+1;
-		}
-		return res;
-	}
+  /*@ 
+    requires n > 0;
+    ensures \result == n * n; 
+  @*/
+  public static int f_ok(int n) {
+    int res, i;
+    res = 0;
+    i = 0;
+    //@ loop_invariant res == i * n;
+    //@ loop_invariant i <= n;
+    while (i < n) {
+      res = res + n;
+      //i++;
+      i = i + 1;
+    }
+    return res;
+  }
 
-  /*@ requires n>0 ; */
-  /*@ ensures \result==n*n; */
-	public static int f_bad(int n){
-	  int res,i;
-		res=0;
-		i=0;
-		//@ loop_invariant res==i*n;
-		//@ loop_invariant i < n;
-		while(i<n) {
-			res=res+n;
-			i=i+1;
-		}
-		return res;
-	}
+  /*@ 
+    requires n > 0;
+    ensures \result == n * n;
+  @*/
+  public static int f_bad(int n) {
+    int res, i;
+    res = 0;
+    i = 0;
+    //@ loop_invariant res == i * n;
+    //@ loop_invariant i < n;
+    while (i < n) {
+      res = res + n;
+      i = i + 1;
+    }
+    return res;
+  }
 }

--- a/examples/sequential/SimpleExamples.java
+++ b/examples/sequential/SimpleExamples.java
@@ -1,15 +1,16 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 //:: cases simpleExamples
-//:: tools boogie
+//:: tools silicon
+//:: verdict Pass
 
-// vct --boogie SimpleExamples.java 
+// vct --silicon SimpleExamples.java 
 // escjava2 SimpleExamples.java
 
 public class SimpleExamples {
 
-  /*@ ensures \result == x+1 ; @*/
-  public static int incr(int x){
-    int y=x+1;
+  /*@ ensures \result == x + 1 ; @*/
+  public static int incr(int x) {
+    int y = x + 1;
     return y;
   }
 

--- a/examples/technical/test-value1.java
+++ b/examples/technical/test-value1.java
@@ -1,11 +1,10 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 //:: cases TestValue1
-//:: tools silicon chalice carbon
+//:: tools silicon
 //:: verdict Fail
 
 class Test {
 
-  
   Test next;
   
   /*@

--- a/examples/technical/test-value2.java
+++ b/examples/technical/test-value2.java
@@ -1,6 +1,6 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 //:: cases TestValue2
-//:: tools silicon chalice carbon
+//:: tools silicon
 //:: verdict Fail
 
 class Test {


### PR DESCRIPTION
I skipped examples that use witnesses since we still have to figure out support for those. 

Note that there are some examples in here that do not yet verify due to missing support for resource@Class (APFs/inheritance), as well as an issue with longs (see #492). I have fixed the syntax of these examples so they can be used for testing when the issues/missing support are resolved. 

Some of these examples used boogie/chalice/dafny as a backend. I have converted those that I could such that they can be verified with the silicon backend. As a result, this PR fixes some of the examples mentioned in #428.