### PR TITLE
Include & to ensure that the exceptions chapter is also included

### DIFF
--- a/util/wiki/generate_wiki_pdf.py
+++ b/util/wiki/generate_wiki_pdf.py
@@ -110,7 +110,7 @@ def collect_chapters(wiki_location):
     contents = unquote(contents)
 
     # Matches sidebar entries
-    chapter_re = re.compile("\[([A-Za-z /\?]+)\]\(https.*/([A-Za-z\-\?]+)\)")
+    chapter_re = re.compile("\[([A-Za-z /\?\&]+)\]\(https.*/([A-Za-z\-\?\&]+)\)")
     # Extract titles and last parts of links to chapters
     # Ignore "wiki" chapter, which is just a link to the wiki
     chapters = [chapter for chapter in chapter_re.findall(contents) if chapter[0] != "Home"]


### PR DESCRIPTION
Currently the exceptions chapter in the wiki is not included because the & character is not allowed by the chapter regex. This PR adds the & character.

@niomaster When the PR is merged, can you refresh the wiki on the VerCors website?