### PR TITLE
Gpgpu support

### DIFF
--- a/col/src/main/java/vct/col/ast/type/ASTReserved.java
+++ b/col/src/main/java/vct/col/ast/type/ASTReserved.java
@@ -103,6 +103,14 @@ public enum ASTReserved {
   /**
    * The default case in a switch.
    */
-  Default
+  Default,
+  /**
+   * Global thread ID, equivalent to get_global_id(0) in OpenCL.
+   */
+  GlobalThreadId,
+  /**
+   * Local thread ID, equivalent to get_local_id(0) in OpenCL.
+   */
+  LocalThreadId,
 }
 

--- a/col/src/main/java/vct/col/ast/util/NameScanner.scala
+++ b/col/src/main/java/vct/col/ast/util/NameScanner.scala
@@ -77,8 +77,6 @@ class NameScanner extends RecursiveVisitor[AnyRef](null, null) {
       Abort("Cannot put a free var when it has a decl")
     }
 
-    Objects.requireNonNull(typ)
-
     freeNames.get(name) match {
       case Some(_) =>
         // Disallow putting the same free var again, to prevent the writtenTo flag to be accidentally reset

--- a/examples/gpgpu/opencl.c
+++ b/examples/gpgpu/opencl.c
@@ -5,16 +5,16 @@
 
 /*@
     context_everywhere opencl_gcount == 1;
-    context \pointer_index(a, get_local_id(0)*2, write);
-    context \pointer_index(a, get_local_id(0)*2+1, write);
-    context \pointer_index(b, get_local_id(0), write);
+    context \pointer_index(a, \ltid*2, write);
+    context \pointer_index(a, \ltid*2+1, write);
+    context \pointer_index(b, \ltid, write);
 @*/
 __kernel void example(int a[], int b[], int len) {
     int tid = get_local_id(0);
     a[tid*2] = tid;
     /*@
-        context \pointer_index(a, get_local_id(0)*2, write);
-        context \pointer_index(a, get_local_id(0)*2+1, write);
+        context \pointer_index(a, \ltid*2, write);
+        context \pointer_index(a, \ltid*2+1, write);
     @*/
     barrier(CLK_LOCAL_MEM_FENCE);
     a[tid*2+1] = a[tid*2] * 2;

--- a/parsers/lib/antlr4/LangCParser.g4
+++ b/parsers/lib/antlr4/LangCParser.g4
@@ -545,6 +545,7 @@ translationUnit
 externalDeclaration
     :   functionDefinition
     |   declaration
+    |   valEmbedDeclarationBlock
     |   ';' // stray ;
     ;
 

--- a/parsers/lib/antlr4/SpecLexer.g4
+++ b/parsers/lib/antlr4/SpecLexer.g4
@@ -106,6 +106,8 @@ MSUM: '\\msum';
 MCMP: '\\mcmp';
 MREP: '\\mrep';
 RESULT: '\\result';
+LTID: '\\ltid';
+GTID: '\\gtid';
 
 NONE: 'none';
 OPTION_NONE: 'None';

--- a/parsers/lib/antlr4/SpecParser.g4
+++ b/parsers/lib/antlr4/SpecParser.g4
@@ -145,6 +145,8 @@ valReserved
  | 'read' // Any read permission
  | 'None' // The empty value of the option langType
  | 'empty' // The empty process in the context of Models
+ | '\\ltid'
+ | '\\gtid'
  ;
 
 valType

--- a/parsers/src/main/java/vct/parsers/CMLtoCOL.scala
+++ b/parsers/src/main/java/vct/parsers/CMLtoCOL.scala
@@ -55,7 +55,8 @@ class CMLtoCOL(fileName: String, tokens: CommonTokenStream, parser: CParser)
   def convertDecl(tree: ExternalDeclarationContext): Seq[ASTDeclaration] = tree match {
     case ExternalDeclaration0(funcDecl) => convertDecl(funcDecl)
     case ExternalDeclaration1(decl) => convertDecl(decl)
-    case ExternalDeclaration2(";") => Seq()
+    case ExternalDeclaration2(valDecls) => convertValDecl(valDecls)
+    case ExternalDeclaration3(";") => Seq()
   }
 
   def convertDecl(tree: FunctionDefinitionContext): Seq[ASTDeclaration] = origin(tree, tree match {

--- a/parsers/src/main/java/vct/parsers/CMLtoCOL.scala
+++ b/parsers/src/main/java/vct/parsers/CMLtoCOL.scala
@@ -1136,6 +1136,10 @@ class CMLtoCOL(fileName: String, tokens: CommonTokenStream, parser: CParser)
       create reserved_name ASTReserved.OptionNone
     case ValReserved7("empty") =>
       create reserved_name ASTReserved.EmptyProcess
+    case ValReserved8("\\ltid") =>
+      create reserved_name ASTReserved.LocalThreadId
+    case ValReserved9("\\gtid") =>
+      create reserved_name ASTReserved.GlobalThreadId
   })
 
   /**
@@ -1153,6 +1157,8 @@ class CMLtoCOL(fileName: String, tokens: CommonTokenStream, parser: CParser)
     case ValReserved5(s) => s
     case ValReserved6(s) => s
     case ValReserved7(s) => s
+    case ValReserved8("\\ltid") => fail(reserved, "This identifier is invalid in the current language")
+    case ValReserved9("\\gtid") => fail(reserved, "This identifier is invalid in the current language")
   }
 
   def convertOverlappingValReservedName(reserved: ValReservedContext): NameExpression =

--- a/parsers/src/main/java/vct/parsers/JavaJMLtoCOL.scala
+++ b/parsers/src/main/java/vct/parsers/JavaJMLtoCOL.scala
@@ -1027,6 +1027,10 @@ case class JavaJMLtoCOL(fileName: String, tokens: CommonTokenStream, parser: Jav
       create reserved_name ASTReserved.OptionNone
     case ValReserved7("empty") =>
       create reserved_name ASTReserved.EmptyProcess
+    case ValReserved8("\\ltid") =>
+      create reserved_name ASTReserved.LocalThreadId
+    case ValReserved9("\\gtid") =>
+      create reserved_name ASTReserved.GlobalThreadId
   })
 
   /**
@@ -1044,6 +1048,8 @@ case class JavaJMLtoCOL(fileName: String, tokens: CommonTokenStream, parser: Jav
     case ValReserved5(s) => s
     case ValReserved6(s) => s
     case ValReserved7(s) => s
+    case ValReserved8("\\ltid") => fail(reserved, "This identifier is invalid in the current language")
+    case ValReserved9("\\gtid") => fail(reserved, "This identifier is invalid in the current language")
   }
 
   def convertOverlappingValReservedName(reserved: ValReservedContext): NameExpression =

--- a/parsers/src/main/java/vct/parsers/PVLtoCOL.scala
+++ b/parsers/src/main/java/vct/parsers/PVLtoCOL.scala
@@ -921,6 +921,10 @@ case class PVLtoCOL(fileName: String, tokens: CommonTokenStream, parser: PVLPars
       create reserved_name ASTReserved.OptionNone
     case ValReserved7("empty") =>
       create reserved_name ASTReserved.EmptyProcess
+    case ValReserved8("\\ltid") =>
+      create reserved_name ASTReserved.LocalThreadId
+    case ValReserved9("\\gtid") =>
+      create reserved_name ASTReserved.GlobalThreadId
   })
 
   /**
@@ -938,6 +942,8 @@ case class PVLtoCOL(fileName: String, tokens: CommonTokenStream, parser: PVLPars
     case ValReserved5(s) => s
     case ValReserved6(s) => s
     case ValReserved7(s) => s
+    case ValReserved8("\\ltid") => fail(reserved, "This identifier is invalid in the current language")
+    case ValReserved9("\\gtid") => fail(reserved, "This identifier is invalid in the current language")
   }
 
   def convertOverlappingValReservedName(reserved: ValReservedContext): NameExpression =

--- a/parsers/src/main/java/vct/parsers/rewrite/KernelBodyRewriter.java
+++ b/parsers/src/main/java/vct/parsers/rewrite/KernelBodyRewriter.java
@@ -2,18 +2,17 @@ package vct.parsers.rewrite;
 
 import java.util.ArrayList;
 
-import vct.col.ast.expr.OperatorExpression;
+import vct.col.ast.expr.*;
 import vct.col.ast.generic.ASTNode;
 import vct.col.ast.stmt.composite.BlockStatement;
 import vct.col.ast.stmt.decl.Contract;
+import vct.col.ast.type.ASTReserved;
 import vct.col.ast.type.PrimitiveSort;
 import vct.col.ast.util.AbstractRewriter;
 import vct.col.ast.util.ContractBuilder;
 import vct.col.ast.stmt.decl.DeclarationStatement;
 import vct.col.ast.stmt.decl.Method;
-import vct.col.ast.expr.MethodInvokation;
 import vct.col.ast.stmt.decl.ProgramUnit;
-import vct.col.ast.expr.StandardOperator;
 import vct.col.ast.type.Type;
 import vct.col.ast.util.ASTUtils;
 
@@ -48,6 +47,26 @@ class KernelBodyRewriter extends AbstractRewriter {
             default:
                 super.visit(e);
         }
+    }
+
+    @Override
+    public void visit(NameExpression n) {
+      if(n.kind() != NameExpressionKind.Reserved) {
+          super.visit(n);
+          return;
+      }
+
+      switch(n.reserved()) {
+          case GlobalThreadId:
+              result = plus(mult(create.local_name("opencl_gid"), create.local_name("opencl_gsize")),
+                                    create.local_name("opencl_lid"));
+              break;
+          case LocalThreadId:
+              result = create.local_name("opencl_lid");
+              break;
+          default:
+              super.visit(n);
+      }
     }
 
     @Override

--- a/src/main/java/vct/col/rewrite/SimplifyQuantifiedRelations.scala
+++ b/src/main/java/vct/col/rewrite/SimplifyQuantifiedRelations.scala
@@ -169,7 +169,7 @@ class SimplifyQuantifiedRelations(source: ProgramUnit) extends AbstractRewriter(
   }
 
   def rewriteMain(bounds: Map[String, (ASTNode, ASTNode)], main: ASTNode): Option[ASTNode] = {
-    val (left, op, right) = main match {
+    val (left, op, right) = rewrite(main) match {
       case exp: OperatorExpression if Set(LT, LTE, GT, GTE).contains(exp.operator) =>
         (exp.first, exp.operator, exp.second)
       case _ => return None

--- a/src/main/java/vct/col/util/AbstractTypeCheck.java
+++ b/src/main/java/vct/col/util/AbstractTypeCheck.java
@@ -661,8 +661,13 @@ public class AbstractTypeCheck extends RecursiveVisitor<Type> {
           e.setType(new PrimitiveType(PrimitiveSort.Integer));
           break;
         }
+      case LocalThreadId:
+      case GlobalThreadId:
+          e.setType(new PrimitiveType(PrimitiveSort.Integer));
+          break;
         default:
             Abort("missing case for reserved name %s",name);
+
         }
         break;
       case Unresolved:{


### PR DESCRIPTION
* Adds ghost declarations to C
* Adds new syntactic sugar for `get_global_id(0)` and `get_local_id(0)`: respectively `\gtid` and `\ltid`
* Fix a bug in the simplification of quantified relational statements, where nested quantifiers were not simplified as expected.

closes #513 