### PR TITLE
Move semantic predicates to the end of lexer rules

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,6 @@ lazy val vercors = (project in file("."))
         |(concurrent) programs written in Java, C, OpenCL, OpenMP, and its own Prototypal Verification Language
         |PVL. """.stripMargin.replaceAll("\n", ""),
 
-    libraryDependencies += "commons-io" % "commons-io" % "2.4",
     libraryDependencies += "com.google.code.gson" % "gson" % "2.8.0",
     libraryDependencies += "org.scalactic" %% "scalactic" % "3.0.1",
     libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test",

--- a/parsers/lib/antlr4/LangCLexer.g4
+++ b/parsers/lib/antlr4/LangCLexer.g4
@@ -363,8 +363,8 @@ BlockCommentStart: '/*' -> mode(COMMENT), skip;
 LineCommentStart: '//' -> mode(LINE_COMMENT), skip;
 
 EndSpec
-    : {inBlockSpec}? '@'? '*/' {inBlockSpec = false;}
-    | {inLineSpec}? ('\n'|'\r\n') {inLineSpec = false;}
+    : '@'? '*/' {inBlockSpec}? {inBlockSpec = false;}
+    | ('\n'|'\r\n') {inLineSpec}? {inLineSpec = false;}
     ;
 
 Whitespace
@@ -404,7 +404,7 @@ Identifier
     ;
 
 ExtraAt
-    : {inBlockSpec}? ('\n'|'\r\n') [ \t\u000C]* '@' -> skip
+    :  ('\n'|'\r\n') [ \t\u000C]* '@' {inBlockSpec}? -> skip
     ;
 
 mode COMMENT;

--- a/parsers/lib/antlr4/LangJavaLexer.g4
+++ b/parsers/lib/antlr4/LangJavaLexer.g4
@@ -413,11 +413,11 @@ ELLIPSIS : '...';
 FileName : '"' ~[\r\n"]* '"' ;
 
 EndSpec
-    : {inBlockSpec}? '@'? '*/' {inBlockSpec = false;}
-    | {inLineSpec}? ('\n'|'\r\n') {inLineSpec = false;}
+    : '@'? '*/' {inBlockSpec}? {inBlockSpec = false;}
+    | ('\n'|'\r\n') {inLineSpec}? {inLineSpec = false;}
     ;
 
-LineCommentStartInSpec: {inLineSpec}? '//' {inLineSpec=false;} -> mode(LINE_COMMENT);
+LineCommentStartInSpec: '//' {inLineSpec}? {inLineSpec=false;} -> mode(LINE_COMMENT);
 
 BlockStartSpecImmediate: '/*' [ \t\u000C]* '@' {inBlockSpec = true;};
 BlockCommentStart: '/*' -> mode(COMMENT), skip;
@@ -438,7 +438,7 @@ Identifier
     ;
 
 ExtraAt
-    : {inBlockSpec}? ('\n'|'\r\n') [ \t\u000C]* '@' -> skip
+    :  ('\n'|'\r\n') [ \t\u000C]* '@' {inBlockSpec}? -> skip
     ;
 
 WS  :  [ \t\r\n\u000C] -> skip


### PR DESCRIPTION
This PR moves semantic predicates to the end of the rules for
improved perfomance. It is only applied to the lexers because it does
not influence the parsers.

Relevant links:
- https://github.com/antlr/antlr4/issues/883#issuecomment-106830474