### PR TITLE
Refactor ContractBuilder to use isEmpty

### DIFF
--- a/col/src/main/java/vct/col/ast/stmt/decl/Method.java
+++ b/col/src/main/java/vct/col/ast/stmt/decl/Method.java
@@ -349,7 +349,7 @@ public class Method extends ASTDeclaration {
    * Example: "signals (Exception e) false;" guarantees an "Exception" will never be thrown.
    */
   public boolean canThrowSpec() {
-    return getContract().signals.length > 0 || canThrow();
+    return (getContract() != null && getContract().signals.length > 0) || canThrow();
   }
 }
 

--- a/col/src/main/java/vct/col/ast/util/AbstractRewriter.java
+++ b/col/src/main/java/vct/col/ast/util/AbstractRewriter.java
@@ -467,14 +467,17 @@ public class AbstractRewriter extends AbstractVisitor<ASTNode> {
     DeclarationStatement args[]=rewrite(m.getArgs());
 
     Contract mc=m.getContract();
-    if (mc!=null){
-      rewrite(mc,currentContractBuilder);
-    }
+    Contract c;
     // Ensure we maintain the type of emptiness of mc
-    // If mc != null, but it is an empty contract, allow an empty contract in c
-    // If mc == null, make sure c == null if currentContractBuilder has an empty contract
-    // This way, if there was an non-null empty contract before, there is one after
-    Contract c=currentContractBuilder.getContract(mc != null && mc.isEmpty());
+    // If the contract was null previously, the new contract can also be null
+    // If the contract was non-null previously, the new contract cannot be null
+    if (mc!=null) {
+      rewrite(mc,currentContractBuilder);
+      c = currentContractBuilder.getContract(false);
+    } else {
+      c = currentContractBuilder.getContract(true);
+    }
+
     if (mc != null && c != null && c.getOrigin() == null) {
       c.setOrigin(mc.getOrigin());
     }

--- a/col/src/main/java/vct/col/ast/util/ContractBuilder.java
+++ b/col/src/main/java/vct/col/ast/util/ContractBuilder.java
@@ -18,8 +18,6 @@ import static vct.col.ast.stmt.decl.Contract.default_true;
 
 public class ContractBuilder {
 
-  private boolean empty=true;
-
   private ASTNode pre_condition = default_true;
   private ASTNode post_condition = default_true;
   private ASTNode invariant = default_true;
@@ -59,7 +57,6 @@ public class ContractBuilder {
    * @param decls A block consisting of declaration statement only.
    */
   public void given(BlockStatement decls){
-    empty=false;
     scan_to(given,decls);
   }
   /**
@@ -67,7 +64,6 @@ public class ContractBuilder {
    * @param decls
    */
   public void yields(BlockStatement decls){
-    empty=false;
     scan_to(yields,decls);
   }
   /**
@@ -75,19 +71,16 @@ public class ContractBuilder {
    * @param decls Any number of declarations.
    */
   public void given(DeclarationStatement ... decls){
-    empty=false;
     for(DeclarationStatement d:decls) given.add(d);
   }
   
   public void given(VariableDeclaration decl){
-	empty=false;
     for(DeclarationStatement d:decl.flatten()){
       given.add(d);
     }
   }
 
   public void yields(VariableDeclaration decl){
-    empty=false;
     for(DeclarationStatement d:decl.flatten()){
       yields.add(d);
     }
@@ -97,14 +90,12 @@ public class ContractBuilder {
    * @param decls Any number of declarations.
    */
   public void yields(DeclarationStatement ... decls){
-    empty=false;
     for(DeclarationStatement d:decls) yields.add(d);
   }
   public void ensures(ASTNode condition){
     ensures(condition,true);
   }
   public void ensures(ASTNode condition,boolean at_end){
-    empty=false;
     if (post_condition==default_true) {
       post_condition=condition;
     } else {
@@ -121,7 +112,6 @@ public class ContractBuilder {
     requires(condition,true);
   }
   public void requires(ASTNode condition,boolean at_end){
-    empty=false;
     if (pre_condition==default_true) {
       pre_condition=condition;
     } else {
@@ -136,7 +126,6 @@ public class ContractBuilder {
   }
 
   public void appendInvariant(ASTNode condition){
-    empty=false;
     if (invariant==default_true) {
       invariant=condition;
     } else {
@@ -147,7 +136,6 @@ public class ContractBuilder {
   }
   
   public void prependInvariant(ASTNode condition){
-    empty=false;
     if (invariant==default_true) {
       invariant=condition;
     } else {
@@ -162,7 +150,7 @@ public class ContractBuilder {
   }
   
   public Contract getContract(boolean null_on_empty){
-    if (empty && null_on_empty) return null;
+    if (isEmpty() && null_on_empty) return null;
     DeclarationStatement[] decls=new DeclarationStatement[0];
     ASTNode[] mods=null;
     if (modifiable!=null){
@@ -184,14 +172,14 @@ public class ContractBuilder {
             );
   }
   public void modifies(ASTNode ... locs) {
-    empty=false;
+    if (locs.length == 0) return;
     if (modifiable==null) modifiable=new HashSet<ASTNode>();
     for (ASTNode loc : locs){
       modifiable.add(loc);
     }
   }
   public void accesses(ASTNode ... locs) {
-    empty=false;
+    if (locs.length == 0) return;
     if (accessible==null) accessible=new HashSet<ASTNode>();
     for (ASTNode loc : locs){
       accessible.add(loc);
@@ -207,7 +195,6 @@ public class ContractBuilder {
   }
 
   public void signals(SignalsClause signalsClause) {
-    empty = false;
     signals.add(signalsClause);
   }
 

--- a/parsers/src/main/java/vct/parsers/rewrite/StripUnusedExtern.java
+++ b/parsers/src/main/java/vct/parsers/rewrite/StripUnusedExtern.java
@@ -43,7 +43,7 @@ public class StripUnusedExtern extends AbstractRewriter {
       defined_names.add(m.name());
       Method ext = externs.get(m.name());
       if (ext != null) {
-        if (!m.getContract().isEmpty()){
+        if (m.getContract() != null && !m.getContract().isEmpty()){
           Fail("%s: contract must be written for the extern declaration",m.getOrigin());
         }
         defined_names.add(m.name());

--- a/src/main/java/vct/col/rewrite/CheckHistoryAlgebra.java
+++ b/src/main/java/vct/col/rewrite/CheckHistoryAlgebra.java
@@ -922,10 +922,12 @@ public class CheckHistoryAlgebra extends AbstractRewriter {
           , create.expression(Old,create.field_name(d.name() + "_hist_value"))
       ));
     }
-    ASTNode temp=rewrite(def.getContract().pre_condition);
-    Debug("REQ %s", temp);
-    cb.requires(temp);
-    cb.ensures(new_sigma.rewrite(rename_old.rewrite(def.getContract().post_condition)));
+    if (def.getContract() != null) {
+      ASTNode temp = rewrite(def.getContract().pre_condition);
+      Debug("REQ %s", temp);
+      cb.requires(temp);
+      cb.ensures(new_sigma.rewrite(rename_old.rewrite(def.getContract().post_condition)));
+    }
     
     ArrayList<ASTNode> def_names=new ArrayList<ASTNode>();
     for(DeclarationStatement d:def.getArgs()){

--- a/src/main/java/vct/col/rewrite/PropagateInvariants.java
+++ b/src/main/java/vct/col/rewrite/PropagateInvariants.java
@@ -83,8 +83,8 @@ public class PropagateInvariants extends AbstractRewriter {
     ParallelBlock res=create.parallel_block(
         pb.label(),
         // Make sure the contract remains null if the original contract is null,
-        // and non-null empty if the original contract is
-        cb.getContract(pb.contract() == null && pb.contract().isEmpty()),
+        // and non-null if the original contract is
+        cb.getContract(pb.contract() == null),
         rewrite(pb.itersJava()),
         rewrite(pb.block()),
         rewrite(pb.deps())

--- a/src/main/java/vct/col/rewrite/PropagateInvariants.java
+++ b/src/main/java/vct/col/rewrite/PropagateInvariants.java
@@ -82,7 +82,9 @@ public class PropagateInvariants extends AbstractRewriter {
     rewrite(pb.contract(), cb);
     ParallelBlock res=create.parallel_block(
         pb.label(),
-        cb.getContract(),
+        // Make sure the contract remains null if the original contract is null,
+        // and non-null empty if the original contract is
+        cb.getContract(pb.contract() == null && pb.contract().isEmpty()),
         rewrite(pb.itersJava()),
         rewrite(pb.block()),
         rewrite(pb.deps())

--- a/src/main/java/vct/col/util/JavaTypeCheck.java
+++ b/src/main/java/vct/col/util/JavaTypeCheck.java
@@ -43,7 +43,7 @@ public class JavaTypeCheck extends AbstractTypeCheck {
 
     super.visit(m);
 
-    if (m.getKind() == Method.Kind.Pure && m.getContract() != null && m.canThrowSpec()) {
+    if (m.getKind() == Method.Kind.Pure && m.canThrowSpec()) {
       Fail("Pure methods cannot throw exceptions");
     }
 

--- a/src/main/java/vct/col/util/JavaTypeCheck.java
+++ b/src/main/java/vct/col/util/JavaTypeCheck.java
@@ -43,7 +43,7 @@ public class JavaTypeCheck extends AbstractTypeCheck {
 
     super.visit(m);
 
-    if (m.getKind() == Method.Kind.Pure && m.canThrowSpec()) {
+    if (m.getKind() == Method.Kind.Pure && m.getContract() != null && m.canThrowSpec()) {
       Fail("Pure methods cannot throw exceptions");
     }
 

--- a/src/main/java/vct/main/Main.java
+++ b/src/main/java/vct/main/Main.java
@@ -342,9 +342,8 @@ public class Main
 
         if (features.usesSwitch()) {
           passes.add("unfold-switch");
+          passes.add("java-check");
         }
-
-        passes.add("java-check");
 
         if ((features.usesFinally() || abruptTerminationViaExceptions.get()) && (usesBreakContinue || features.usesReturn())) {
           passes.add("break-return-to-exceptions");


### PR DESCRIPTION
Previously ContractBuilder kept track of the emptiness of the contract by setting an extra empty boolean. But the isEmpty method does effectively the same, so it should be used instead for more robust code. Fixes #515.