### PR TITLE
Predicate refactor

### DIFF
--- a/examples/predicates/ScaleInlinePredicate.pvl
+++ b/examples/predicates/ScaleInlinePredicate.pvl
@@ -1,0 +1,37 @@
+//:: cases ScaleInlinePredicate
+//:: tools silicon
+//:: verdict Pass
+
+class C {
+    int x;
+    int y;
+    inline resource r() = Perm(x, write);
+
+    inline resource s() = r() ** Perm(y, 1\2) ** x == y;
+
+    requires [1\2]r();
+    void m() {
+        unfold [1\2]r();
+        assert Perm(x, 1\2);
+    }
+
+    requires [1\4]r();
+    void m2() {
+        unfold [1\2][1\2]r();
+        assert Perm(x, 1\4);
+    }
+
+    requires s();
+    void m3() {
+        fold [1\2]s();
+        assert x == y;
+        assert Perm(y, 1\2) ** Perm(x, write);
+    }
+
+    requires [1\8]s();
+    void m4() {
+        fold [1\4][1\4]s();
+        assert x == y;
+        assert Perm(y, 1\16) ** Perm(x, 1\8);
+    }
+}

--- a/src/main/java/vct/col/rewrite/InlinePredicatesFunctions.java
+++ b/src/main/java/vct/col/rewrite/InlinePredicatesFunctions.java
@@ -15,12 +15,12 @@ import vct.col.ast.util.AbstractRewriter;
 import java.util.HashMap;
 import java.util.Stack;
 
-public class InlinePredicatesRewriter extends AbstractRewriter {
+public class InlinePredicatesFunctions extends AbstractRewriter {
 
   int count = 0;
   Stack<String> inlinedScalars = new Stack<>();
  
-  public InlinePredicatesRewriter(ProgramUnit source) {
+  public InlinePredicatesFunctions(ProgramUnit source) {
     super(source);
   }
 

--- a/src/main/java/vct/col/rewrite/InlinePredicatesRewriter.java
+++ b/src/main/java/vct/col/rewrite/InlinePredicatesRewriter.java
@@ -165,7 +165,9 @@ public class InlinePredicatesRewriter extends AbstractRewriter {
   public void visit(ASTSpecial e) {
     if (e.kind == ASTSpecial.Kind.Fold || e.kind == ASTSpecial.Kind.Unfold) {
       Warning("Folding/unfolding an inline predicate is allowed but not encouraged. See https://github.com/utwente-fmt/vercors/wiki/Resources-and-Predicates#inline-predicates for more info.");
+      create.special(ASTSpecial.Kind.Assert, rewrite(e.getArg(0)));
+    } else {
+      super.visit(e);
     }
-    super.visit(e);
   }
 }

--- a/src/main/java/vct/col/rewrite/InlinePredicatesRewriter.java
+++ b/src/main/java/vct/col/rewrite/InlinePredicatesRewriter.java
@@ -41,7 +41,7 @@ public class InlinePredicatesRewriter extends AbstractRewriter {
   @Override
   public void visit(MethodInvokation e){
     if (inline(e)){
-      result= inlineCall(e, e.getDefinition());
+      result = inlineCall(e, e.getDefinition());
     } else if (!inlinedScalars.empty() && e.getDefinition().getKind().equals(Method.Kind.Predicate)) {
       // Because the previous if branch was false, we know this is a predicate that is not inline
       // Hence, we have to add a scale that scales the predicate according to any earlier encountered scales
@@ -163,18 +163,9 @@ public class InlinePredicatesRewriter extends AbstractRewriter {
 
   @Override
   public void visit(ASTSpecial e) {
-      switch (e.kind) {
-        case Fold:
-        case Unfold:
-          if (inline(e.getArg(0))) {
-            result = create.special(ASTSpecial.Kind.Assert, rewrite(e.getArg(0)));
-          } else {
-            super.visit(e);
-          }
-          break;
-        default:
-          super.visit(e);
-          break;
-      }
+    if (e.kind == ASTSpecial.Kind.Fold || e.kind == ASTSpecial.Kind.Unfold) {
+      Warning("Folding/unfolding an inline predicate is allowed but not encouraged. See https://github.com/utwente-fmt/vercors/wiki/Resources-and-Predicates#inline-predicates for more info.");
+    }
+    super.visit(e);
   }
 }

--- a/src/main/java/vct/col/rewrite/JavaEncoder.java
+++ b/src/main/java/vct/col/rewrite/JavaEncoder.java
@@ -99,8 +99,10 @@ public class JavaEncoder extends AbstractRewriter {
       prefix="procedure_";
     } else {
       String name[]=cls.getFullName();
-      if (m.name().equals(cls.name()) || m.getKind() == Kind.Constructor){
-        prefix="constructor_";
+      if (m.name().equals(cls.name()) || m.getKind() == Kind.Constructor) {
+        prefix = "constructor_";
+      } else if (m.getKind() == Kind.Predicate) {
+        prefix = "predicate_";
       } else {
         prefix="method_";
       }

--- a/src/main/java/vct/main/Main.java
+++ b/src/main/java/vct/main/Main.java
@@ -939,7 +939,7 @@ public class Main
     });
     defined_passes.put("inline",new CompilerPass("Inline all methods marked as inline"){
       public ProgramUnit apply(ProgramUnit arg,String ... args){
-        return new InlinePredicatesRewriter(arg).rewriteAll();
+        return new InlinePredicatesFunctions(arg).rewriteAll();
       }
     });
     defined_passes.put("kernel-split",new CompilerPass("Split kernels into main, thread and barrier."){


### PR DESCRIPTION
Improve support for predicates.

- Inline predicates can be scaled.
- Add tests for inline predicates.
- Unfolding and folding of inline predicates is now encoded as asserting the predicate body.