### PR TITLE
logging may overwrite progress messages; make test progress list currently running tasks

### DIFF
--- a/hre/src/main/java/hre/lang/System.java
+++ b/hre/src/main/java/hre/lang/System.java
@@ -147,6 +147,8 @@ public class System {
         debugfilterByLine.add(classLineCombo);
     }
 
+    private static boolean needLineClear = false;
+
     private static void log(LogLevel level, Map<Appendable, LogLevel> outputs, String format, Object... args) {
         // Only format the string (expensive) when the message is actually outputted
         String message = null;
@@ -158,11 +160,22 @@ public class System {
                         for (LogWriter writer : activeLogWriters) {
                             writer.doFlush();
                         }
+                        message = level.getShorthand() + String.format(format, args);
+                    }
 
-                        message = level.getShorthand() + String.format(format + "%n", args);
+                    if(needLineClear) {
+                        entry.getKey().append("\033[0K");
+                        needLineClear = false;
                     }
 
                     entry.getKey().append(message);
+
+                    if(level == LogLevel.Progress) {
+                        entry.getKey().append("\r");
+                        needLineClear = true;
+                    } else {
+                        entry.getKey().append("\r\n");
+                    }
                 } catch (IOException e) {
                     if (level != LogLevel.Abort) {
                         Abort("IO Error: %s", e);

--- a/src/main/java/vct/test/ThreadPool.scala
+++ b/src/main/java/vct/test/ThreadPool.scala
@@ -1,0 +1,49 @@
+package vct.test
+
+import java.util.concurrent.{Callable, LinkedBlockingDeque}
+
+import hre.lang.System.Output
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+case class ThreadPool[T <: Callable[S], S](threadCount: Int, tasks: Seq[T]) {
+  val taskQueue: mutable.ArrayBuffer[T] = mutable.ArrayBuffer()
+  val taskResult: LinkedBlockingDeque[(T, S, Seq[T], Int)] = new LinkedBlockingDeque()
+  // ordered buffer, so the oldest work appears in front
+  val runningWork: mutable.ArrayBuffer[T] = mutable.ArrayBuffer()
+
+  def fetchWork(): Option[T] = this.synchronized {
+    if(taskQueue.isEmpty) {
+      None
+    } else {
+      val result = taskQueue.remove(0)
+      runningWork += result
+      Some(result)
+    }
+  }
+
+  def replaceWork(work: T, result: S): Option[T] = this.synchronized {
+    runningWork -= work
+    val newWork = fetchWork()
+    taskResult.push((work, result, runningWork.clone(), taskQueue.size))
+    newWork
+  }
+
+  def start(): Unit = {
+    taskQueue ++= tasks
+    val threads = (0 until threadCount).map(_ => new Thread(() => {
+      var work: Option[T] = fetchWork()
+      while(work.nonEmpty) {
+        work = replaceWork(work.get, work.get.call())
+      }
+    }))
+    threads.foreach(_.start())
+  }
+
+  def results(): Stream[(T, S, Seq[T], Int)] =
+    tasks.toStream.map(_ => {
+      val resultToPut = taskResult.take()
+      resultToPut
+    })
+}


### PR DESCRIPTION
Progress lines were printed as:

```
"[progress] %s%n"
```

But now are printed as:

```
"[progress] %s\r"
```

Any lines following a progress line will start with "\033[0K", a widely supported [ansi escape code](http://ascii-table.com/ansi-escape-sequences.php) to clear the current line. The effect is that progress lines are visible only until the next line is printed, usually the next progress line.