### PR TITLE
Make git detection work on windows

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,18 +48,6 @@ lazy val col = (project in file("col")).dependsOn(hre)
 lazy val parsers = (project in file("parsers")).dependsOn(hre, col)
 lazy val viper_api = (project in file("viper")).dependsOn(hre, col, silver_ref, carbon_ref, silicon_ref)
 
-def hasGit = "which git" ! ProcessLogger(a => (), b => ()) == 0 // Right hand side of ! silences it
-def gitHasChanges =
-  if (hasGit) {
-    if (("git diff-index --quiet HEAD --" ! ProcessLogger(a => (), b => ())) == 1) {
-      "with changes"
-    } else {
-      ""
-    }
-  } else {
-    "unknown"
-  }
-
 lazy val vercors = (project in file("."))
   .dependsOn(hre)
   .dependsOn(col)
@@ -103,22 +91,13 @@ lazy val vercors = (project in file("."))
 
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion,
       BuildInfoKey.action("currentBranch") {
-        // If git doesn't exist in path abort
-        if (hasGit) {
-          ("git rev-parse --abbrev-ref HEAD" !!).stripLineEnd
-        } else {
-          "unknown"
-        }
+        Git.currentBranch
       },
       BuildInfoKey.action("currentShortCommit") {
-        if (hasGit) {
-          ("git rev-parse --short HEAD" !!).stripLineEnd
-        } else {
-          "unknown"
-        }
+        Git.currentShortCommit
       },
       BuildInfoKey.action("gitHasChanges") {
-        gitHasChanges
+        Git.gitHasChanges
       }
     ),
     buildInfoOptions += BuildInfoOption.BuildTime,

--- a/project/Git.scala
+++ b/project/Git.scala
@@ -1,0 +1,41 @@
+import java.io.File
+import java.nio.file.{Files, Paths}
+
+import scala.sys.process._
+
+object Git {
+  // This method is probably duplicated because it's unclear how to share code between build.sbt and regular project code
+  def commandExists(cmd: String): Boolean = System.getenv("PATH")
+    .split(File.pathSeparator)
+    .exists(path => {
+      val p = Paths.get(path).resolve(cmd)
+      Files.exists(p) && !Files.isDirectory(p) && Files.isExecutable(p)
+    })
+
+  def hasGit = commandExists("git") || commandExists("git.exe")
+
+  def gitHasChanges =
+    if (hasGit) {
+      if (("git diff-index --quiet HEAD --" ! ProcessLogger(a => (), b => ())) == 1) {
+        "with changes"
+      } else {
+        "no changes"
+      }
+    } else {
+      "unknown if there are changes"
+    }
+
+  def currentBranch: String =
+    if (hasGit) {
+      ("git rev-parse --abbrev-ref HEAD" !!).stripLineEnd
+    } else {
+      "unknown branch"
+    }
+
+  def currentShortCommit: String =
+    if (hasGit) {
+      ("git rev-parse --short HEAD" !!).stripLineEnd
+    } else {
+      "unknown commit"
+    }
+}

--- a/project/Git.scala
+++ b/project/Git.scala
@@ -16,7 +16,7 @@ object Git {
 
   def gitHasChanges =
     if (hasGit) {
-      if (("git diff-index --quiet HEAD --" ! ProcessLogger(a => (), b => ())) == 1) {
+      if ((Seq("git", "diff-index", "--quiet", "HEAD", "--") ! ProcessLogger(a => (), b => ())) == 1) {
         "with changes"
       } else {
         "no changes"
@@ -27,14 +27,14 @@ object Git {
 
   def currentBranch: String =
     if (hasGit) {
-      ("git rev-parse --abbrev-ref HEAD" !!).stripLineEnd
+      (Seq("git", "rev-parse", "--abbrev-ref", "HEAD") !!).stripLineEnd
     } else {
       "unknown branch"
     }
 
   def currentShortCommit: String =
     if (hasGit) {
-      ("git rev-parse --short HEAD" !!).stripLineEnd
+      (Seq("git", "rev-parse", "--short", "HEAD") !!).stripLineEnd
     } else {
       "unknown commit"
     }


### PR DESCRIPTION
This PR ensures git detection is done properly with windows support, such that vercors can actually build without requiring git/mingw to be in the PATH.