### PR TITLE
Fixes issue #537

### DIFF
--- a/examples/abrupt/ExceptionAbortsAssignment.java
+++ b/examples/abrupt/ExceptionAbortsAssignment.java
@@ -1,0 +1,35 @@
+//:: cases ExceptionAbortsAssignment
+//:: tools silicon
+//:: verdict Pass
+
+class C {
+    //@ ensures false;
+    //@ signals (RuntimeException e) true;
+    int e();
+
+    void m1() {
+        int x = 0;
+        try {
+            x = e();
+            //@ assert false; // Cannot be triggered, as exception is guaranteed
+        } catch (RuntimeException e) {
+
+        }
+        //@ assert x == 0;
+    }
+
+//    void e2(int x);
+
+//    void m2() {
+//        int x = 3;
+//        int y = (x = 4);
+        //@ assert x == 4;
+//        int x = 3;
+//        try {
+//            e2(x = e());
+//        } catch (RuntimeException e) {
+//
+//        }
+        //@ assert x == 3;
+//    }
+}

--- a/examples/abrupt/NoResultInSignals.java
+++ b/examples/abrupt/NoResultInSignals.java
@@ -1,0 +1,8 @@
+//:: cases NoResultInSignals
+//:: tools silicon
+//:: verdict Error
+
+class C {
+    //@ signals (RuntimeException e) \result;
+    boolean e();
+}

--- a/src/main/java/vct/col/rewrite/EncodeTryThrowSignals.java
+++ b/src/main/java/vct/col/rewrite/EncodeTryThrowSignals.java
@@ -20,6 +20,7 @@ import vct.col.ast.type.ASTReserved;
 import vct.col.ast.type.ClassType;
 import vct.col.ast.type.Type;
 import vct.col.ast.util.AbstractRewriter;
+import vct.col.util.AstToId;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -480,14 +481,26 @@ public class EncodeTryThrowSignals extends AbstractRewriter {
 
             ASTNode resultLocation = assignment.location().apply(this);
 
-            result = create.assignment(resultLocation, resultInvokation);
-
             // Then, if exceptions are involved, and "regular" methods are concerned, insert a check that possibly jumps to a handler
+            // If the check determines the call did not throw an exception, we put the return value in the variable (because if an
+            // exception was thrown, the value wouldn't have been written to the variable)
             Method.Kind methodKind = invokation.getDefinition().getKind();
             if ((methodKind == Method.Kind.Plain || methodKind == Method.Kind.Constructor) && invokation.getDefinition().canThrowSpec()) {
-                currentBlock.add(result);
                 result = null;
-                currentBlock.add(createExceptionCheck(currentNearestHandler()));
+                String tempName = generateLabel("temp", AstToId.toId(resultLocation));
+                // Temp var to store the return variable
+                currentBlock.add(create.field_decl(tempName, invokation.getDefinition().getReturnType()));
+                currentBlock.add(create.assignment(create.local_name(tempName), resultInvokation));
+
+                IfStatement exceptionCheck = createExceptionCheck(currentNearestHandler());
+                if (exceptionCheck.hasElse()) {
+                    Abort("Unexpected else branch");
+                }
+                exceptionCheck.addClause(IfStatement.elseGuard(), create.assignment(resultLocation, create.local_name(tempName)));
+                currentBlock.add(exceptionCheck);
+            } else {
+                // If exceptions are not concerned, just emit the regular assignment
+                result = create.assignment(resultLocation, resultInvokation);
             }
         } else {
             super.visit(assignment);


### PR DESCRIPTION
- Forbid \result in signals
- Save assignment of throwing method call in temp var to prevent overwriting a variable when an exception is thrown.