### PR TITLE
A get function for options 

### DIFF
--- a/col/src/main/java/vct/col/ast/expr/StandardOperator.java
+++ b/col/src/main/java/vct/col/ast/expr/StandardOperator.java
@@ -281,6 +281,10 @@ public enum StandardOperator {
    */
   OptionGet(1),
   /**
+   * The getOrElse operator for the options type
+   */
+  OptionGetOrElse(2),
+  /**
    * Declares the first argument to be a valid array of the given size.
    */
   ValidArray(2),

--- a/col/src/main/java/vct/col/ast/syntax/PVLSyntax.java
+++ b/col/src/main/java/vct/col/ast/syntax/PVLSyntax.java
@@ -50,8 +50,8 @@ public class PVLSyntax {
       syntax.addFunction(Old,"\\old");
 
       syntax.addFunction(OptionSome, "Some");
-      syntax.addFunction(OptionGet, "optionGet");
-      syntax.addFunction(OptionGetOrElse, "optionGetOrElse");
+      syntax.addFunction(OptionGet, "getOption");
+      syntax.addFunction(OptionGetOrElse, "getOrElseOption");
 
       syntax.addFunction(MapBuild, "buildMap");
       syntax.addFunction(MapEquality, "equalsMap");

--- a/col/src/main/java/vct/col/ast/syntax/PVLSyntax.java
+++ b/col/src/main/java/vct/col/ast/syntax/PVLSyntax.java
@@ -50,8 +50,8 @@ public class PVLSyntax {
       syntax.addFunction(Old,"\\old");
 
       syntax.addFunction(OptionSome, "Some");
-      syntax.addFunction(OptionGet, "oget");
-      syntax.addFunction(OptionGetOrElse, "ogetOrElse");
+      syntax.addFunction(OptionGet, "optionGet");
+      syntax.addFunction(OptionGetOrElse, "optionGetOrElse");
 
       syntax.addFunction(MapBuild, "buildMap");
       syntax.addFunction(MapEquality, "equalsMap");

--- a/col/src/main/java/vct/col/ast/syntax/PVLSyntax.java
+++ b/col/src/main/java/vct/col/ast/syntax/PVLSyntax.java
@@ -66,8 +66,6 @@ public class PVLSyntax {
       syntax.addFunction(TupleFst, "getFst");
       syntax.addFunction(TupleSnd, "getSnd");
 
-
-
       syntax.addOperator(Size,-1,"|","|");
       syntax.addOperator(Member,45,"","in","");
       syntax.addOperator(Slice, 10, "[","","..","","]");

--- a/col/src/main/java/vct/col/ast/syntax/PVLSyntax.java
+++ b/col/src/main/java/vct/col/ast/syntax/PVLSyntax.java
@@ -50,20 +50,22 @@ public class PVLSyntax {
       syntax.addFunction(Old,"\\old");
 
       syntax.addFunction(OptionSome, "Some");
-                                                                 
-      syntax.addFunction(MapBuild, "buildMap");           
-      syntax.addFunction(MapEquality, "equalsMap");       
-      syntax.addFunction(MapDisjoint, "disjointMap");     
-      syntax.addFunction(MapKeySet, "keysMap");           
-      syntax.addFunction(MapCardinality, "cardMap");      
-      syntax.addFunction(MapValueSet, "valuesMap");       
-      syntax.addFunction(MapGetByKey, "getFromMap");      
-      syntax.addFunction(MapRemoveKey, "removeFromMap"); 
-      syntax.addFunction(MapItemSet, "itemsMap");
+      syntax.addFunction(OptionGet, "oget");
+      syntax.addFunction(OptionGetOrElse, "ogetOrElse");
 
+      syntax.addFunction(MapBuild, "buildMap");
+      syntax.addFunction(MapEquality, "equalsMap");
+      syntax.addFunction(MapDisjoint, "disjointMap");
+      syntax.addFunction(MapKeySet, "keysMap");
+      syntax.addFunction(MapCardinality, "cardMap");
+      syntax.addFunction(MapValueSet, "valuesMap");
+      syntax.addFunction(MapGetByKey, "getFromMap");
+      syntax.addFunction(MapRemoveKey, "removeFromMap");
+      syntax.addFunction(MapItemSet, "itemsMap");
 
       syntax.addFunction(TupleFst, "getFst");
       syntax.addFunction(TupleSnd, "getSnd");
+
 
 
       syntax.addOperator(Size,-1,"|","|");

--- a/examples/manual/option.pvl
+++ b/examples/manual/option.pvl
@@ -22,8 +22,8 @@ class optiontest {
     assert y != None;
     assert z == None;
 
-    assert oget(y) == 37;
-    assert ogetOrElse(x, 21387) == 21387;
+    assert optionGet(y) == 37;
+    assert optionGetOrElse(x, 21387) == 21387;
 
   }
 }

--- a/examples/manual/option.pvl
+++ b/examples/manual/option.pvl
@@ -11,18 +11,20 @@
 
 class optiontest {
   void test(){
+
     option<int> x=None;
     option<int> y=Some(37);
     
     option<optiontest> z=None;
     
     assert x != y;
-    
     assert x == None;
-    
     assert y != None;
-    
     assert z == None;
+
+    assert oget(y) == 37;
+    assert ogetOrElse(x, 21387) == 21387;
+
   }
 }
 

--- a/examples/manual/option.pvl
+++ b/examples/manual/option.pvl
@@ -22,8 +22,8 @@ class optiontest {
     assert y != None;
     assert z == None;
 
-    assert optionGet(y) == 37;
-    assert optionGetOrElse(x, 21387) == 21387;
+    assert getOption(y) == 37;
+    assert getOrElseOption(x, 21387) == 21387;
 
   }
 }

--- a/src/main/java/vct/col/rewrite/SilverClassReduction.java
+++ b/src/main/java/vct/col/rewrite/SilverClassReduction.java
@@ -436,6 +436,11 @@ public class SilverClassReduction extends AbstractRewriter {
       result=create.invokation(null, null,method,rewrite(e.argsJava()));
       break;
     }
+    case OptionGetOrElse: {
+      options=true;
+      result=create.invokation(rewrite(e.first().getType()), null,"getVCTOptionOrElse",rewrite(e.argsJava()));
+      break;
+    }
     case New:{
       ClassType t=(ClassType)e.arg(0);
       ASTClass cl=source().find(t);

--- a/src/main/java/vct/col/util/AbstractTypeCheck.java
+++ b/src/main/java/vct/col/util/AbstractTypeCheck.java
@@ -1158,6 +1158,15 @@ public class AbstractTypeCheck extends RecursiveVisitor<Type> {
         e.setType((Type) ((PrimitiveType) t).firstarg());
         break;
       }
+      case OptionGetOrElse: {
+        if (!tt[0].isPrimitive(PrimitiveSort.Option)) {
+          Fail("first argument is %s rather then an option ", tt[0]);
+        } else if (!tt[1].comparableWith(source(), (Type) tt[0].firstarg())) {
+          Fail("type of the second argument %s does not match the value type of the option %s", tt[1], tt[0].firstarg());
+        }
+        e.setType(tt[1]);
+        break;
+      }
       case PreIncr:
       case PreDecr:
       case PostIncr:

--- a/src/main/java/vct/col/util/AbstractTypeCheck.java
+++ b/src/main/java/vct/col/util/AbstractTypeCheck.java
@@ -1164,7 +1164,7 @@ public class AbstractTypeCheck extends RecursiveVisitor<Type> {
         } else if (!tt[1].comparableWith(source(), (Type) tt[0].firstarg())) {
           Fail("type of the second argument %s does not match the value type of the option %s", tt[1], tt[0].firstarg());
         }
-        e.setType(tt[1]);
+        e.setType((Type) tt[0].firstarg());
         break;
       }
       case PreIncr:

--- a/src/main/universal/res/config/prelude.sil
+++ b/src/main/universal/res/config/prelude.sil
@@ -56,6 +56,7 @@ domain VCTOption[T] {
   function VCTNone(): VCTOption[T]
   function VCTSome(t: T): VCTOption[T]
   function getVCTOption(o:VCTOption[T]) : T
+  function getVCTOptionOrElse(o:VCTOption[T], default:T): T
 
   axiom not_equal_vct {
     forall x: T :: VCTNone() != VCTSome(x)
@@ -68,6 +69,15 @@ domain VCTOption[T] {
   axiom get_axiom_vct_2 {
     (forall x: VCTOption[T] :: {VCTSome(getVCTOption(x))} VCTSome(getVCTOption(x)) == x)
   }
+
+  axiom get_or_else_axiom_1 {
+      forall val: T, default: T :: {getVCTOptionOrElse(VCTSome(val), default)} getVCTOptionOrElse(VCTSome(val), default) == val
+  }
+
+  axiom get_or_else_axiom_2 {
+      forall default: T :: {getVCTOptionOrElse(VCTNone(), default)} getVCTOptionOrElse(VCTNone(), default) == default
+  }
+
 }
 
 


### PR DESCRIPTION
This PR solves issue #223 (partially).

In the issue there were suggestions, but it was never decided which suggestion to implement. To get the ball rolling, I have extended the VCTOption domain to also have a  "getOrElse" function (see the associated axioms below).

Currently, I just extended the syntax (through the PVLSyntax class) to include two functions "optionGet(o1)" and "optionGetOrElse(o1, default)" corresponding to the get operation and getOrElse operation.

```
axiom get_or_else_axiom_1 {
    forall val: T, default: T :: {getVCTOptionOrElse(VCTSome(val), default)} 
        getVCTOptionOrElse(VCTSome(val), default) == val
}

axiom get_or_else_axiom_2 {
    forall default: T :: {getVCTOptionOrElse(VCTNone(), default)} 
        getVCTOptionOrElse(VCTNone(), default) == default
}
```