### PR TITLE
Ignore MacOS specific OS file in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ tmp.*
 vct-tool.jar
 *~
 
+# Mac specific OS files
+.DS_Store
+
 # Vim swap file
 *.swp
 


### PR DESCRIPTION
Added .DS_Store to the gitignore, to ignore these MacOS specific files which contain metadata about display options of folders.