### PR TITLE
use Path objects instead of plain Strings to track file origins. Fixes #601

### DIFF
--- a/hre/src/main/java/hre/ast/FileContext.java
+++ b/hre/src/main/java/hre/ast/FileContext.java
@@ -5,6 +5,7 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.Path;
 import java.util.ArrayList;
 
 import javax.swing.JFrame;
@@ -22,7 +23,7 @@ public class FileContext {
   private ArrayList<Integer> offset=new ArrayList<Integer>();
   private final FileSwingContext gui;
   
-  public FileContext(String file,boolean use_gui){
+  public FileContext(Path filePath, boolean use_gui){
     if (use_gui) {
       gui=new FileSwingContext();  
     } else {
@@ -30,7 +31,7 @@ public class FileContext {
     }
     try {
       
-      BufferedReader in=new BufferedReader(new FileReader(file));
+      BufferedReader in=new BufferedReader(new FileReader(filePath.toFile()));
       String line;
       int pos=0;
       while((line=in.readLine())!=null){
@@ -61,7 +62,7 @@ public class FileContext {
         }
       });
     } catch (IOException e){
-      Abort("Could not create context for %s: %s",file,e);
+      Abort("Could not create context for %s: %s",filePath,e);
     }
     
   }

--- a/hre/src/main/java/hre/ast/FileOrigin.java
+++ b/hre/src/main/java/hre/ast/FileOrigin.java
@@ -5,7 +5,6 @@ import hre.lang.HREError;
 import static hre.lang.System.*;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Hashtable;
 
 /**
@@ -15,35 +14,38 @@ import java.util.Hashtable;
  */
 public class FileOrigin extends Origin {
 
-  private static Hashtable<Path, FileContext> data = new Hashtable<>();
+  private static Hashtable<Path, FileContext> fileContexts = new Hashtable<>();
 
   public int linesBefore=2;
   public int linesAfter=2;
-  
+
+  private Path filePath;
+  private int first_line, first_col, last_line, last_col;
 
   private void do_mark(String result) {
-    String file=getName();
-    FileContext fc=data.get(Paths.get(file));
-    if (fc==null) return;
-    fc.mark(this,result);
+    Path filePath = getPath();
+    FileContext fc = fileContexts.get(filePath);
+    if (fc == null) return;
+    fc.mark(this, result);
   }
 
   public void printContext(int before,int after){
-    String file=getName();
-    FileContext fc=data.get(Paths.get(file));
-    if (fc==null){
+    Path filePath = getPath();
+    FileContext fc = fileContexts.get(filePath);
+    if (fc == null){
       Output("=========================================");
-      Output("error at %s: ",this);
+      Output("error at %s: ", this);
     } else {
-      Output("=== %-30s ===",file);
-      fc.printContext(this,before,after);
+      Output("=== %-30s ===",filePath);
+      fc.printContext(this, before, after);
       Output("-----------------------------------------");
     }
   }
   
-  public static void add(String file,boolean gui){
-    data.put(Paths.get(file), new FileContext(file,gui));
+  public static void add(Path filePath, boolean gui) {
+    fileContexts.put(filePath, new FileContext(filePath, gui));
   }
+
   public synchronized void report(String level, Iterable<String> message) {
     printContext(linesBefore,linesAfter);
     for(String line:message){
@@ -75,36 +77,35 @@ public class FileOrigin extends Origin {
     Output("=========================================");
   }
 
-    private String file_name;
-    private int first_line, first_col, last_line, last_col;
-    public FileOrigin(String file_name,int first_line, int first_col, int last_line, int last_col){
-        if (first_line <0) throw new HREError("bad first line : %d",first_line);
-        this.file_name=file_name;
-        this.first_line=first_line;
-        this.first_col=first_col;
-        this.last_line=last_line;
-        this.last_col=last_col;
-        if (file_name==null) throw new Error("null file name");
-    }
+
+  public FileOrigin(Path filePath, int first_line, int first_col, int last_line, int last_col){
+    if (first_line <0) throw new HREError("bad first line : %d",first_line);
+    this.filePath = filePath;
+    this.first_line = first_line;
+    this.first_col = first_col;
+    this.last_line = last_line;
+    this.last_col = last_col;
+    if (filePath == null) throw new Error("null file name");
+  }
     
-    public String toString(){
-      if (last_line>=0) {
-        return String.format(
-            "file %s from line %d column %d until line %d column %d",
-            file_name,first_line, first_col, last_line, last_col
-        );
-      } else {
-        return String.format(
-            "file %s at line %d column %d",
-            file_name,first_line, first_col
-        );       
-      }
-     
+  public String toString(){
+    if (last_line>=0) {
+      return String.format(
+          "file %s from line %d column %d until line %d column %d",
+              filePath,first_line, first_col, last_line, last_col
+      );
+    } else {
+      return String.format(
+          "file %s at line %d column %d",
+              filePath,first_line, first_col
+      );
     }
 
-    public FileOrigin merge(FileOrigin origin){
-      return new FileOrigin(file_name,first_line,first_col,origin.last_line,origin.last_col);
-    }
+  }
+
+  public FileOrigin merge(FileOrigin origin){
+    return new FileOrigin(filePath,first_line,first_col,origin.last_line,origin.last_col);
+  }
 
   /**
    * Merges this and origin into the combined area they represent.
@@ -112,61 +113,64 @@ public class FileOrigin extends Origin {
    * @param origin
    * @return
    */
-    public FileOrigin maximumMerge(FileOrigin origin) {
-      assert file_name == origin.file_name;
+  public FileOrigin maximumMerge(FileOrigin origin) {
+    assert filePath == origin.filePath;
 
-      int new_first_line, new_first_col, new_last_line, new_last_col;
+    int new_first_line, new_first_col, new_last_line, new_last_col;
 
-      if (first_line < origin.first_line) {
-        new_first_line = first_line;
-        new_first_col = first_col;
-      } else if (first_line == origin.first_line) {
-        new_first_line = first_line;
-        new_first_col = Math.min(first_col, origin.first_col);
-      } else {
-        new_first_line = origin.first_line;
-        new_first_col = origin.first_col;
-      }
-
-      if (last_line < origin.last_line) {
-        new_last_line = origin.last_line;
-        new_last_col = origin.last_col;
-      } else if (last_line == origin.last_line) {
-        new_last_line = last_line;
-        new_last_col = Math.max(last_col, origin.last_col);
-      } else {
-        new_last_line = last_line;
-        new_last_col = last_col;
-      }
-
-      return new FileOrigin(file_name, new_first_line, new_first_col, new_last_line, new_last_col);
+    if (first_line < origin.first_line) {
+      new_first_line = first_line;
+      new_first_col = first_col;
+    } else if (first_line == origin.first_line) {
+      new_first_line = first_line;
+      new_first_col = Math.min(first_col, origin.first_col);
+    } else {
+      new_first_line = origin.first_line;
+      new_first_col = origin.first_col;
     }
 
-    public FileOrigin(String file_name,int first_line, int first_col){
-      if (first_line <0) throw new HREError("bad first line : %d",first_line);
-      this.file_name=file_name;
-      this.first_line=first_line;
-      this.first_col=first_col;
-      this.last_line=-1;
-      this.last_col=-1;
-      if (file_name==null) throw new Error("null file name");      
+    if (last_line < origin.last_line) {
+      new_last_line = origin.last_line;
+      new_last_col = origin.last_col;
+    } else if (last_line == origin.last_line) {
+      new_last_line = last_line;
+      new_last_col = Math.max(last_col, origin.last_col);
+    } else {
+      new_last_line = last_line;
+      new_last_col = last_col;
     }
+
+    return new FileOrigin(filePath, new_first_line, new_first_col, new_last_line, new_last_col);
+  }
+
+  public FileOrigin(Path filePath, int first_line, int first_col){
+    if (first_line <0) throw new HREError("bad first line : %d",first_line);
+    this.filePath = filePath;
+    this.first_line = first_line;
+    this.first_col = first_col;
+    this.last_line = -1;
+    this.last_col = -1;
+    if (filePath == null) throw new Error("null file name");
+  }
     
-    public String getName(){
-      return file_name;
-    }
-    
-    public int getFirstLine(){
-      return first_line;
-    }
-    public int getFirstColumn(){
-      return first_col;
-    }
-    public int getLastLine(){
-      return last_line;
-    }
-    public int getLastColumn(){
-      return last_col;
-    }
+  public Path getPath(){
+    return filePath;
+  }
+
+  public int getFirstLine(){
+    return first_line;
+  }
+
+  public int getFirstColumn(){
+    return first_col;
+  }
+
+  public int getLastLine(){
+    return last_line;
+  }
+
+  public int getLastColumn(){
+    return last_col;
+  }
 }
 

--- a/hre/src/main/java/hre/ast/FileOrigin.java
+++ b/hre/src/main/java/hre/ast/FileOrigin.java
@@ -4,7 +4,8 @@ package hre.ast;
 import hre.lang.HREError;
 import static hre.lang.System.*;
 
-import java.io.PrintStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Hashtable;
 
 /**
@@ -14,22 +15,22 @@ import java.util.Hashtable;
  */
 public class FileOrigin extends Origin {
 
+  private static Hashtable<Path, FileContext> data = new Hashtable<>();
+
   public int linesBefore=2;
   public int linesAfter=2;
   
 
   private void do_mark(String result) {
     String file=getName();
-    FileContext fc=data.get(file);
+    FileContext fc=data.get(Paths.get(file));
     if (fc==null) return;
     fc.mark(this,result);
   }
 
-  private static Hashtable<String,FileContext> data=new Hashtable<String,FileContext>();
-
   public void printContext(int before,int after){
     String file=getName();
-    FileContext fc=data.get(file);
+    FileContext fc=data.get(Paths.get(file));
     if (fc==null){
       Output("=========================================");
       Output("error at %s: ",this);
@@ -41,7 +42,7 @@ public class FileOrigin extends Origin {
   }
   
   public static void add(String file,boolean gui){
-    data.put(file,new FileContext(file,gui));
+    data.put(Paths.get(file), new FileContext(file,gui));
   }
   public synchronized void report(String level, Iterable<String> message) {
     printContext(linesBefore,linesAfter);

--- a/hre/src/main/java/hre/ast/HREOrigins.java
+++ b/hre/src/main/java/hre/ast/HREOrigins.java
@@ -1,5 +1,7 @@
 package hre.ast;
 
+import java.nio.file.Path;
+
 public class HREOrigins implements OriginFactory<Origin> {
 
   @Override
@@ -8,12 +10,12 @@ public class HREOrigins implements OriginFactory<Origin> {
   }
 
   @Override
-  public Origin file(String file, int line, int col) {
+  public Origin file(Path file, int line, int col) {
     return new FileOrigin(file,line,col);
   }
 
   @Override
-  public Origin file(String file, int ln1, int c1, int ln2, int c2) {
+  public Origin file(Path file, int ln1, int c1, int ln2, int c2) {
     return new FileOrigin(file,ln1,c1,ln2,c2);
   }
 

--- a/hre/src/main/java/hre/ast/OriginFactory.java
+++ b/hre/src/main/java/hre/ast/OriginFactory.java
@@ -1,11 +1,13 @@
 package hre.ast;
 
+import java.nio.file.Path;
+
 public interface OriginFactory<O> {
 
   public O message(String fmt,Object ... args);
   
-  public O file(String file,int line,int col);
+  public O file(Path file, int line, int col);
   
-  public O file(String file,int ln1,int c1, int ln2, int c2);
+  public O file(Path file,int ln1,int c1, int ln2, int c2);
   
 }

--- a/parsers/src/main/java/vct/parsers/ToCOL.scala
+++ b/parsers/src/main/java/vct/parsers/ToCOL.scala
@@ -7,6 +7,8 @@ import vct.col.ast.generic.ASTNode
 import vct.col.ast.stmt.decl.Contract
 import vct.col.ast.util.{ASTFactory, ContractBuilder}
 
+import java.nio.file.Paths
+
 abstract class ToCOL(fileName: String, tokens: CommonTokenStream, parser: org.antlr.v4.runtime.Parser) {
   val create = new ASTFactory[ParserRuleContext]()
 
@@ -16,7 +18,7 @@ abstract class ToCOL(fileName: String, tokens: CommonTokenStream, parser: org.an
     val endLine = tree.stop.getLine
     val endCol = tree.stop.getCharPositionInLine + tree.stop.getStopIndex - tree.stop.getStartIndex + 1
 
-    new FileOrigin(fileName, startLine, startCol, endLine, endCol)
+    new FileOrigin(Paths.get(fileName), startLine, startCol, endLine, endCol)
   }
 
   def origin[T <: ASTNode](tree: ParserRuleContext, node: T): T = {

--- a/src/main/java/vct/java/JavaASTClassLoader.scala
+++ b/src/main/java/vct/java/JavaASTClassLoader.scala
@@ -60,7 +60,7 @@ object JavaASTClassLoader extends ExternalClassLoader {
     ns match {
       // If we're going by file: require a namespace, as we can't guess how many directories to go up etc.
       case Some(ns) if ns.getOrigin != null && ns.getOrigin.isInstanceOf[FileOrigin] =>
-        var basePath = Paths.get(ns.getOrigin.asInstanceOf[FileOrigin].getName).toAbsolutePath.getParent
+        var basePath = ns.getOrigin.asInstanceOf[FileOrigin].getPath.toAbsolutePath.getParent
         for(_ <- ns.getDeclName.name.filter(_.nonEmpty /* pls */)) {
           basePath = basePath.getParent
         }

--- a/src/main/java/vct/main/Main.scala
+++ b/src/main/java/vct/main/Main.scala
@@ -19,6 +19,7 @@ import vct.col.features.{Feature, RainbowVisitor}
 import vct.main.Passes.BY_KEY
 import vct.test.CommandLineTesting
 
+import java.nio.file.Paths
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
@@ -189,10 +190,10 @@ class Main {
     report.add(new ErrorDisplayVisitor)
 
     tk.show
-    for (name <- inputPaths) {
-      val f = new File(name)
-      if (!no_context.get) FileOrigin.add(name, gui_context.get)
-      report.getOutput.add(Parsers.parseFile(f.getPath))
+    for (pathName <- inputPaths) {
+      val path = Paths.get(pathName);
+      if (!no_context.get) FileOrigin.add(path, gui_context.get)
+      report.getOutput.add(Parsers.parseFile(path))
     }
 
     Progress("Parsed %d file(s) in: %dms", Int.box(inputPaths.length), Long.box(tk.show))

--- a/src/main/java/vct/main/Parsers.java
+++ b/src/main/java/vct/main/Parsers.java
@@ -3,6 +3,7 @@ package vct.main;
 import hre.config.IntegerSetting;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import vct.col.ast.stmt.decl.ProgramUnit;
 import vct.parsers.Parser;
@@ -38,20 +39,21 @@ public class Parsers {
     return null;
   }
   
-  public static ProgramUnit parseFile(String name){
-    int dot=name.lastIndexOf('.');
-    if (dot<0) {
-      Fail("cannot deduce language of %s",name);
+  public static ProgramUnit parseFile(Path filePath) {
+    String name = filePath.toString();
+    int dot = name.lastIndexOf('.');
+    if (dot < 0) {
+      Fail("cannot deduce language of %s", filePath);
     }
-    String lang=name.substring(dot+1);
-    Progress("Parsing %s file %s",lang,name);
+    String lang = name.substring(dot + 1);
+    Progress("Parsing %s file %s", lang, filePath);
     Parser parser = Parsers.getParser(lang);
     if (parser == null) {
       Abort("Cannot detect language for extension \".%s\"", lang);
       return null;
     } else {
-      ProgramUnit unit=Parsers.getParser(lang).parse(new File(name));
-      Progress("Read %s succesfully",name);
+      ProgramUnit unit = Parsers.getParser(lang).parse(filePath.toFile());
+      Progress("Read %s successfully", name);
       return unit;
     }
   }

--- a/viper/src/main/scala/viper/api/SilverProgramFactory.scala
+++ b/viper/src/main/scala/viper/api/SilverProgramFactory.scala
@@ -100,12 +100,12 @@ class SilverProgramFactory[O] extends ProgramFactory[O,Type,Exp,Stmt,
       case _ => y match {
         case SourcePosition(file,start,tmp) =>
           tmp match {
-            case None => f.file(file.toString(),start.line,start.column)
+            case None => f.file(file,start.line,start.column)
             case Some(end) =>
               if (file==null){
                 f.message("null origin");
               } else {
-                f.file(file.toString(),start.line,start.column,end.line,end.column)
+                f.file(file,start.line,start.column,end.line,end.column)
               }
           }
         case _ => null.asInstanceOf[OO]


### PR DESCRIPTION
This commit changes the minimal amount of lines to fix the issue.
To explain why this fixes the issue I'm going to use this screenshot, because pictures can say more than a 1000 words😄:
![afbeelding](https://user-images.githubusercontent.com/27810652/110708508-14c28980-81fb-11eb-8cd8-f462f51a4d4d.png)

Some extra changes that are worth considering but not included in this commit:

- change from Hashtable to HashMap. Hashtable is a thread-safe 'synchronized' dictionary implementation, but since all VerCors passes run in one thread it seems that this is unnecessarily costly.
- more changes from String to Path. Currently I only used Path objects internal to the FileOrigin class, but for example the getName() method might be refactored to return a Path as well since it expresses the intent better. Potentially there are more places like this.