### PR TITLE
order of annotations is now preserved almost

### DIFF
--- a/col/src/main/java/vct/col/ast/print/AbstractPrinter.java
+++ b/col/src/main/java/vct/col/ast/print/AbstractPrinter.java
@@ -279,15 +279,13 @@ public class AbstractPrinter extends AbstractVisitor<Object> {
         for (ASTNode post : ASTUtils.conjuncts(contract.post_condition, StandardOperator.Star)) {
           if (pre.equals(post)) {
             contextElems.add(pre);
+            printContractElement(pre, "context");
             added = true;
           }
         }
         if (!added) {
           printContractElement(pre, "requires");
         }
-      }
-      for (ASTNode con : contextElems) {
-        printContractElement(con, "context");
       }
       for (ASTNode post : ASTUtils.conjuncts(contract.post_condition, StandardOperator.Star)) {
         if (!contextElems.contains(post)) {


### PR DESCRIPTION
Since merge 07d831b1de4c5d6b91cd4f204f435518cfd43432  a contract is printed as follows:
- Select all context annotations: i.e. the annotations occurring in the pre- and post-condition of a contract.
- Print all non-context pre-condition annotations
- Print all context annotations.
- Print all post-condition annotations

Problem:
Annotations are printed in an order such that VerCors cannot verify the contract anymore, e.g. it prints a contract:
requires a == 1;
context Perm(a,1\2);

Solution:
This pull-request works in almost all cases, except for contrived contracts as shown in issue #619