### PR TITLE
Disable casting in parblockencoder

### DIFF
--- a/examples/known-problems/summation.c
+++ b/examples/known-problems/summation.c
@@ -1,13 +1,11 @@
-// -*- tab-width:2 ; indent-tabs-mode:nil -*-
 //:: cases SummationReduction
-//:: suite problem-fail
 //:: tools silicon
 //:: verdict Pass
 
-float res;
+int res;
 
 /*@
-  given seq<float> ar_values;
+  given seq<int> ar_values;
   context \pointer(ar, N, 1\2);
   context Perm(res,write);
   context ar_values == \values(ar, 0, N);
@@ -16,8 +14,8 @@ float res;
 
   ensures  res==(\sum int k ; 0 <= k && k < N ; ar_values[k] );
 @*/
-void do_sum(int N,float ar[N]){
-  res=(float)0;
+void do_sum(int N,int ar[N]){
+  res=0;
   for(int i=0;i<N;i++)
     /*@
       context ar != NULL;

--- a/src/main/java/vct/col/rewrite/ParallelBlockEncoder.java
+++ b/src/main/java/vct/col/rewrite/ParallelBlockEncoder.java
@@ -745,7 +745,7 @@ public class ParallelBlockEncoder extends AbstractRewriter {
         body_cb.requires(create.expression(StandardOperator.PointsTo,
             copy_rw.rewrite(expr.arg(0)),
             create.reserved_name(ASTReserved.FullPerm),
-            create.expression(StandardOperator.Cast,expr.arg(0).getType(),create.constant(0))
+            create.constant(0)
         ));
       } else if(is_a_quantified(clause,Binder.Star,StandardOperator.ReducibleSum)){
         BindingExpression bclause=(BindingExpression)clause;


### PR DESCRIPTION
Parblockencoder inserts a cast like `((int) 0)` for some examples (in particular, `summation.c`). Since floats are not supported, this cast is unnecessary, so it can be removed. This cast triggers also some inheritance code logic, which results in a broken program. To avoid that problem for now, the cast is also best removed. Hopefully in the future when the inheritance logic is better maybe the cast can be enabled again, such that if we want to also support floats for this we can implement it.