### PR TITLE
Issue 663 2

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       # This should automatically cancel any previous workflows that are still
       # running when for example new commits are pushed.
-      # - uses: technote-space/auto-cancel-redundant-workflow@v1
+      - uses: technote-space/auto-cancel-redundant-workflow@v1
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       # This should automatically cancel any previous workflows that are still
       # running when for example new commits are pushed.
-      - uses: technote-space/auto-cancel-redundant-workflow@v1
+      # - uses: technote-space/auto-cancel-redundant-workflow@v1
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/col/src/main/java/vct/col/ast/stmt/composite/ForEachLoop.java
+++ b/col/src/main/java/vct/col/ast/stmt/composite/ForEachLoop.java
@@ -3,7 +3,6 @@ package vct.col.ast.stmt.composite;
 import hre.ast.MessageOrigin;
 import hre.util.ScalaHelper;
 import scala.collection.Iterable;
-import scala.collection.JavaConverters;
 import vct.col.ast.util.ASTMapping;
 import vct.col.ast.util.ASTMapping1;
 import vct.col.ast.generic.ASTNode;
@@ -12,9 +11,6 @@ import vct.col.ast.stmt.composite.BlockStatement;
 import vct.col.ast.stmt.decl.Contract;
 import vct.col.ast.stmt.decl.DeclarationStatement;
 import vct.col.ast.util.ASTVisitor;
-
-import java.util.Arrays;
-import java.util.Collections;
 
 import static hre.lang.System.Debug;
 

--- a/col/src/main/java/vct/col/ast/stmt/composite/LoopStatement.java
+++ b/col/src/main/java/vct/col/ast/stmt/composite/LoopStatement.java
@@ -4,7 +4,6 @@ package vct.col.ast.stmt.composite;
 import hre.ast.MessageOrigin;
 import hre.lang.HREError;
 import hre.util.ScalaHelper;
-import scala.collection.JavaConverters;
 import vct.col.ast.expr.StandardOperator;
 import vct.col.ast.util.ASTMapping;
 import vct.col.ast.util.ASTMapping1;
@@ -14,9 +13,6 @@ import vct.col.ast.stmt.decl.Contract;
 import vct.col.ast.util.ASTVisitor;
 import vct.col.ast.util.ContractBuilder;
 import vct.col.ast.util.ASTUtils;
-
-import java.util.Arrays;
-import java.util.Collections;
 
 import static hre.lang.System.Debug;
 

--- a/col/src/main/java/vct/col/ast/stmt/composite/Switch.java
+++ b/col/src/main/java/vct/col/ast/stmt/composite/Switch.java
@@ -2,7 +2,6 @@ package vct.col.ast.stmt.composite;
 
 import hre.util.ScalaHelper;
 import scala.collection.Iterable;
-import scala.collection.JavaConverters;
 import vct.col.ast.generic.DebugNode;
 import vct.col.ast.util.ASTMapping;
 import vct.col.ast.util.ASTMapping1;
@@ -11,7 +10,6 @@ import vct.col.ast.util.ASTVisitor;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 
 import static hre.lang.System.Debug;
 

--- a/col/src/main/java/vct/col/ast/stmt/composite/TryCatchBlock.scala
+++ b/col/src/main/java/vct/col/ast/stmt/composite/TryCatchBlock.scala
@@ -2,7 +2,6 @@ package vct.col.ast.stmt.composite
 
 import vct.col.ast.`type`.Type
 import vct.col.ast.generic.ASTNode
-import vct.col.ast.stmt.decl.DeclarationStatement
 import vct.col.ast.util.{ASTMapping, ASTMapping1, ASTVisitor, VisitorHelper}
 
 import scala.jdk.CollectionConverters._

--- a/col/src/main/java/vct/col/ast/stmt/decl/ASTClass.java
+++ b/col/src/main/java/vct/col/ast/stmt/decl/ASTClass.java
@@ -9,7 +9,6 @@ import java.util.*;
 
 import hre.util.ScalaHelper;
 import scala.Option;
-import scala.collection.JavaConverters;
 import vct.col.ast.stmt.decl.Method.Kind;
 import vct.col.ast.util.*;
 import vct.col.ast.generic.ASTNode;

--- a/col/src/main/java/vct/col/ast/stmt/decl/Axiom.scala
+++ b/col/src/main/java/vct/col/ast/stmt/decl/Axiom.scala
@@ -1,6 +1,5 @@
 package vct.col.ast.stmt.decl
 
-import vct.col.ast._
 import vct.col.ast.generic.ASTNode
 import vct.col.ast.util.{ASTMapping, ASTMapping1, ASTVisitor, ClassName, VisitorHelper}
 

--- a/col/src/main/java/vct/col/ast/stmt/decl/Contract.java
+++ b/col/src/main/java/vct/col/ast/stmt/decl/Contract.java
@@ -4,13 +4,10 @@ package vct.col.ast.stmt.decl;
 import hre.ast.MessageOrigin;
 import hre.ast.Origin;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 
 import hre.util.ScalaHelper;
 import scala.collection.Iterable;
-import scala.collection.JavaConverters;
 import vct.col.ast.expr.NameExpression;
 import vct.col.ast.expr.StandardOperator;
 import vct.col.ast.expr.constant.ConstantExpression;

--- a/col/src/main/java/vct/col/ast/stmt/decl/Method.java
+++ b/col/src/main/java/vct/col/ast/stmt/decl/Method.java
@@ -7,7 +7,6 @@ import hre.ast.Origin;
 import hre.util.ScalaHelper;
 import scala.Option;
 import scala.collection.Iterable;
-import scala.collection.JavaConverters;
 import vct.col.ast.expr.*;
 import vct.col.ast.expr.constant.ConstantExpression;
 import vct.col.ast.generic.ASTList;

--- a/col/src/main/java/vct/col/ast/stmt/decl/NameSpace.java
+++ b/col/src/main/java/vct/col/ast/stmt/decl/NameSpace.java
@@ -2,13 +2,11 @@ package vct.col.ast.stmt.decl;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Iterator;
 
 import hre.lang.HREError;
 import hre.util.ScalaHelper;
 import scala.collection.Iterable;
-import scala.collection.JavaConverters;
 import vct.col.ast.util.ASTMapping;
 import vct.col.ast.util.ASTMapping1;
 import vct.col.ast.generic.ASTNode;

--- a/col/src/main/java/vct/col/ast/stmt/decl/ProgramUnit.java
+++ b/col/src/main/java/vct/col/ast/stmt/decl/ProgramUnit.java
@@ -3,7 +3,6 @@ package vct.col.ast.stmt.decl;
 import java.util.*;
 
 import hre.util.ScalaHelper;
-import scala.collection.JavaConverters;
 import vct.col.ast.generic.ASTNode;
 import vct.col.ast.generic.ASTSequence;
 import vct.col.ast.generic.DebugNode;

--- a/col/src/main/java/vct/col/ast/stmt/decl/VariableDeclaration.java
+++ b/col/src/main/java/vct/col/ast/stmt/decl/VariableDeclaration.java
@@ -5,7 +5,6 @@ import hre.ast.MessageOrigin;
 import java.util.*;
 
 import hre.util.ScalaHelper;
-import scala.collection.JavaConverters;
 import vct.col.ast.util.ASTMapping;
 import vct.col.ast.util.ASTMapping1;
 import vct.col.ast.generic.ASTNode;

--- a/col/src/main/java/vct/col/ast/stmt/terminal/AssignmentStatement.scala
+++ b/col/src/main/java/vct/col/ast/stmt/terminal/AssignmentStatement.scala
@@ -1,7 +1,6 @@
 package vct.col.ast.stmt.terminal
 
 import hre.ast.MessageOrigin
-import vct.col.ast._
 import vct.col.ast.expr.NameExpression
 import vct.col.ast.generic.ASTNode
 import vct.col.ast.util.{ASTMapping, ASTMapping1, ASTVisitor}

--- a/col/src/main/java/vct/col/ast/syntax/PVLSyntax.java
+++ b/col/src/main/java/vct/col/ast/syntax/PVLSyntax.java
@@ -3,13 +3,10 @@ package vct.col.ast.syntax;
 
 import hre.ast.TrackingOutput;
 import vct.col.ast.generic.ASTNode;
-import vct.col.ast.print.JavaPrinter;
 import vct.col.ast.print.PVLPrinter;
 import vct.col.ast.type.ASTReserved;
 import vct.col.ast.type.PrimitiveSort;
 import vct.col.ast.util.Parenthesize;
-
-import java.io.PrintWriter;
 
 import static vct.col.ast.expr.StandardOperator.*;
 import static vct.col.ast.type.ASTReserved.*;

--- a/col/src/main/java/vct/col/ast/type/PrimitiveType.java
+++ b/col/src/main/java/vct/col/ast/type/PrimitiveType.java
@@ -2,9 +2,6 @@ package vct.col.ast.type;
 
 import hre.util.ScalaHelper;
 import scala.collection.Iterable;
-import scala.collection.JavaConverters;
-import vct.col.ast.expr.OperatorExpression;
-import vct.col.ast.expr.StandardOperator;
 import vct.col.ast.expr.constant.ConstantExpression;
 import vct.col.ast.expr.NameExpression;
 import vct.col.ast.expr.constant.StructValue;
@@ -19,9 +16,6 @@ import static hre.lang.System.Abort;
 import static hre.lang.System.Debug;
 import static hre.lang.System.Fail;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 
 public final class PrimitiveType extends Type {

--- a/col/src/main/java/vct/col/ast/util/AbstractRewriter.java
+++ b/col/src/main/java/vct/col/ast/util/AbstractRewriter.java
@@ -4,8 +4,6 @@ import scala.jdk.javaapi.CollectionConverters;
 import hre.ast.MessageOrigin;
 import hre.ast.Origin;
 import scala.Option;
-import scala.collection.JavaConverters;
-import scala.collection.Seq;
 import vct.col.ast.expr.*;
 import vct.col.ast.expr.constant.ConstantExpression;
 import vct.col.ast.expr.constant.StructValue;

--- a/col/src/main/java/vct/col/ast/util/FieldAccessCollector.java
+++ b/col/src/main/java/vct/col/ast/util/FieldAccessCollector.java
@@ -1,12 +1,9 @@
 package vct.col.ast.util;
 
 import vct.col.ast.expr.Dereference;
-import vct.col.ast.expr.FieldAccess;
-import vct.col.ast.generic.ASTNode;
 import vct.col.ast.util.RecursiveVisitor;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 
 public class FieldAccessCollector extends RecursiveVisitor<Object> {

--- a/col/src/main/java/vct/col/ast/util/RecursiveVisitor.java
+++ b/col/src/main/java/vct/col/ast/util/RecursiveVisitor.java
@@ -4,8 +4,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import scala.collection.JavaConverters;
-import scala.collection.Seq;
 import vct.col.ast.langspecific.c.*;
 import vct.col.ast.stmt.composite.Switch.Case;
 import vct.col.ast.expr.*;

--- a/col/src/main/java/vct/col/ast/util/TypeMapping.java
+++ b/col/src/main/java/vct/col/ast/util/TypeMapping.java
@@ -1,7 +1,6 @@
 package vct.col.ast.util;
 
 import vct.col.ast.langspecific.c.CFunctionType;
-import vct.col.ast.type.TypeExpression;
 import vct.col.ast.type.*;
 
 public interface TypeMapping<R> {

--- a/col/src/main/java/vct/col/ast/util/UndefinedMapping.java
+++ b/col/src/main/java/vct/col/ast/util/UndefinedMapping.java
@@ -2,9 +2,6 @@ package vct.col.ast.util;
 
 import hre.lang.HREError;
 import vct.col.ast.langspecific.c.*;
-import vct.col.ast.langspecific.c.CFunctionType;
-import vct.col.ast.stmt.decl.VariableDeclaration;
-import vct.col.ast.stmt.composite.VectorBlock;
 import vct.col.ast.expr.*;
 import vct.col.ast.expr.constant.ConstantExpression;
 import vct.col.ast.expr.constant.StructValue;

--- a/hre/src/main/java/hre/ast/FileContext.java
+++ b/hre/src/main/java/hre/ast/FileContext.java
@@ -4,7 +4,6 @@ import java.awt.Color;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
 

--- a/hre/src/main/java/hre/ast/Origin.java
+++ b/hre/src/main/java/hre/ast/Origin.java
@@ -1,10 +1,7 @@
 // -*- tab-width:2 ; indent-tabs-mode:nil -*-
 package hre.ast;
 
-import static hre.lang.System.Output;
-import static hre.lang.System.Debug;
-
-/** 
+/**
  * This interface allows tracking the origin of
  * AST nodes through transformations to the original file(s).
  */

--- a/hre/src/main/java/hre/config/ChoiceSetting.java
+++ b/hre/src/main/java/hre/config/ChoiceSetting.java
@@ -1,9 +1,7 @@
 package hre.config;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedList;
 
 import static hre.lang.System.Abort;
 

--- a/hre/src/main/java/hre/config/CollectSetting.java
+++ b/hre/src/main/java/hre/config/CollectSetting.java
@@ -1,7 +1,6 @@
 package hre.config;
 
 import java.util.HashMap;
-import java.util.HashSet;
 
 public class CollectSetting {
     private HashMap<String, Integer> settings = new HashMap<>();

--- a/hre/src/main/java/hre/io/LogbackAppender.java
+++ b/hre/src/main/java/hre/io/LogbackAppender.java
@@ -1,10 +1,8 @@
 package hre.io;
 
 import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
-import org.slf4j.LoggerFactory;
 
 import static hre.lang.System.*;
 

--- a/hre/src/main/java/hre/io/MessageProcess.java
+++ b/hre/src/main/java/hre/io/MessageProcess.java
@@ -10,7 +10,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import static hre.lang.System.Debug;
-import static hre.lang.System.Warning;
 
 /**
  * Provides communication with a interactive external process.

--- a/hre/src/main/java/hre/util/LambdaHelper.java
+++ b/hre/src/main/java/hre/util/LambdaHelper.java
@@ -2,7 +2,7 @@ package hre.util;
 
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
+
 import scala.Function1;
 import scala.Function2;
 import scala.runtime.AbstractFunction1;

--- a/parsers/src/main/java/vct/parsers/ColCParser.java
+++ b/parsers/src/main/java/vct/parsers/ColCParser.java
@@ -7,7 +7,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import hre.config.Configuration;
-import hre.lang.HREExitException;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import scala.NotImplementedError;

--- a/parsers/src/main/java/vct/parsers/ColIParser.java
+++ b/parsers/src/main/java/vct/parsers/ColIParser.java
@@ -2,17 +2,10 @@ package vct.parsers;
 
 import hre.tools.TimeKeeper;
 import org.antlr.v4.runtime.CharStream;
-import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import vct.antlr4.generated.LangCLexer;
 import vct.antlr4.generated.CParser;
 import vct.col.ast.stmt.decl.ProgramUnit;
-import vct.col.ast.syntax.JavaDialect;
-import vct.col.ast.syntax.JavaSyntax;
-import vct.parsers.rewrite.*;
-import vct.col.ast.syntax.CSyntax;
-
-import java.io.*;
 
 import static hre.lang.System.*;
 

--- a/parsers/src/main/java/vct/parsers/ColJavaParser.java
+++ b/parsers/src/main/java/vct/parsers/ColJavaParser.java
@@ -4,21 +4,13 @@ package vct.parsers;
 
 import static hre.lang.System.*;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-
 import hre.tools.TimeKeeper;
 import org.antlr.v4.runtime.CharStream;
-import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.Lexer;
 
 import vct.antlr4.generated.*;
 import vct.col.ast.stmt.decl.ProgramUnit;
-import vct.parsers.rewrite.*;
-import vct.col.ast.syntax.JavaDialect;
-import vct.col.ast.syntax.JavaSyntax;
 
 /**
  * Parse specified code and convert the contents to COL. 

--- a/parsers/src/main/java/vct/parsers/rewrite/AnnotationInterpreter.java
+++ b/parsers/src/main/java/vct/parsers/rewrite/AnnotationInterpreter.java
@@ -7,9 +7,7 @@ import java.util.ArrayList;
 import vct.col.ast.generic.ASTNode;
 import vct.col.ast.type.ASTReserved;
 import vct.col.ast.util.AbstractRewriter;
-import vct.col.ast.util.ContractBuilder;
 import vct.col.ast.expr.NameExpression;
-import vct.col.ast.type.Type;
 import vct.col.ast.stmt.decl.*;
 
 public class AnnotationInterpreter extends AbstractRewriter {

--- a/parsers/src/main/java/vct/parsers/rewrite/JavaPostProcessor.java
+++ b/parsers/src/main/java/vct/parsers/rewrite/JavaPostProcessor.java
@@ -9,16 +9,9 @@ import vct.col.ast.stmt.decl.ASTSpecial.Kind;
 import vct.col.ast.stmt.composite.BlockStatement;
 import vct.col.ast.type.ClassType;
 import vct.col.ast.stmt.decl.Method;
-import vct.col.ast.expr.MethodInvokation;
-import vct.col.ast.expr.NameExpression;
-import vct.col.ast.expr.OperatorExpression;
 import vct.col.ast.stmt.decl.ProgramUnit;
-import vct.col.ast.expr.StandardOperator;
 import vct.col.ast.type.PrimitiveSort;
-import vct.col.ast.type.Type;
 import vct.col.ast.util.AbstractRewriter;
-import vct.col.ast.syntax.JavaDialect;
-import vct.col.ast.syntax.JavaSyntax;
 
 /**
  * Rewrite a Java AST, produced by parsing, to conform to the COL AST standard.  

--- a/parsers/src/main/java/vct/parsers/rewrite/KernelBodyRewriter.java
+++ b/parsers/src/main/java/vct/parsers/rewrite/KernelBodyRewriter.java
@@ -6,7 +6,6 @@ import vct.col.ast.expr.*;
 import vct.col.ast.generic.ASTNode;
 import vct.col.ast.stmt.composite.BlockStatement;
 import vct.col.ast.stmt.decl.Contract;
-import vct.col.ast.type.ASTReserved;
 import vct.col.ast.type.PrimitiveSort;
 import vct.col.ast.util.AbstractRewriter;
 import vct.col.ast.util.ContractBuilder;

--- a/src/main/java/vct/col/features/FeatureRainbow.scala
+++ b/src/main/java/vct/col/features/FeatureRainbow.scala
@@ -2,24 +2,23 @@ package vct.col.features
 
 import hre.ast.MessageOrigin
 import hre.lang.System.{LogLevel, Output, getLogLevelOutputWriter}
-import vct.col.ast.`type`.{ASTReserved, ClassType, PrimitiveSort, PrimitiveType, TypeExpression, TypeOperator, TypeVariable}
-import vct.col.ast.stmt
-import vct.col.ast.stmt.composite.{BlockStatement, CatchClause, ForEachLoop, IfStatement, LoopStatement, ParallelBarrier, ParallelBlock, ParallelInvariant, ParallelRegion, TryCatchBlock}
-import vct.col.ast.stmt.decl.{ASTClass, ASTDeclaration, ASTFlags, ASTSpecial, AxiomaticDataType, Contract, DeclarationStatement, Method, NameSpace, ProgramUnit, VariableDeclaration}
-import vct.col.ast.expr.{Binder, BindingExpression, KernelInvocation, MethodInvokation, NameExpression, NameExpressionKind, OperatorExpression, StandardOperator}
-import vct.col.ast.expr
+import vct.col.ast.`type`._
 import vct.col.ast.expr.constant.{ConstantExpression, StructValue}
-import vct.col.ast.util.{AbstractVisitor, RecursiveVisitor, SequenceUtils}
+import vct.col.ast.expr._
 import vct.col.ast.generic.{ASTNode, BeforeAfterAnnotations}
-import vct.col.ast.langspecific.c.{OMPFor, OMPForSimd, OMPParallel, OMPParallelFor, OMPSection, OMPSections}
+import vct.col.ast.langspecific.c._
+import vct.col.ast.{expr, stmt}
+import vct.col.ast.stmt.composite._
 import vct.col.ast.stmt.decl.ASTClass.ClassKind
-import vct.col.ast.stmt.terminal.{AssignmentStatement, ReturnStatement}
+import vct.col.ast.stmt.decl._
+import vct.col.ast.stmt.terminal.AssignmentStatement
+import vct.col.ast.util.{RecursiveVisitor, SequenceUtils}
 import vct.col.rewrite.{AddTypeADT, IntroExcVar, PVLEncoder}
 import vct.parsers.rewrite.InferADTTypes
 
-import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
+import scala.jdk.CollectionConverters._
 
 class RainbowVisitor(source: ProgramUnit) extends RecursiveVisitor(source, true) {
   val features: mutable.Set[Feature] = mutable.Set()

--- a/src/main/java/vct/col/rewrite/ADTOperatorRewriter.java
+++ b/src/main/java/vct/col/rewrite/ADTOperatorRewriter.java
@@ -2,9 +2,6 @@ package vct.col.rewrite;
 
 import vct.col.ast.expr.OperatorExpression;
 import vct.col.ast.expr.StandardOperator;
-import vct.col.ast.generic.ASTNode;
-import vct.col.ast.stmt.decl.ProgramUnit;
-import vct.col.ast.util.AbstractRewriter;
 
 import static vct.col.ast.type.PrimitiveSort.Map;
 

--- a/src/main/java/vct/col/rewrite/CSLencoder.java
+++ b/src/main/java/vct/col/rewrite/CSLencoder.java
@@ -10,9 +10,7 @@ import vct.col.ast.generic.ASTNode;
 import vct.col.ast.stmt.composite.BlockStatement;
 import vct.col.ast.stmt.decl.*;
 import vct.col.ast.type.ASTReserved;
-import vct.col.ast.type.Type;
 import vct.col.ast.util.AbstractRewriter;
-import vct.col.ast.util.ContractBuilder;
 import vct.logging.ErrorMapping;
 
 public class CSLencoder extends AbstractRewriter {

--- a/src/main/java/vct/col/rewrite/DesugarValidPointer.scala
+++ b/src/main/java/vct/col/rewrite/DesugarValidPointer.scala
@@ -1,7 +1,7 @@
 package vct.col.rewrite
 
 import vct.col.ast.`type`.{ASTReserved, PrimitiveSort, Type}
-import vct.col.ast.expr.{Dereference, OperatorExpression, StandardOperator}
+import vct.col.ast.expr.{OperatorExpression, StandardOperator}
 import vct.col.ast.generic.ASTNode
 import vct.col.ast.stmt.decl.{DeclarationStatement, ProgramUnit}
 import vct.col.ast.util.{AbstractRewriter, SequenceUtils}

--- a/src/main/java/vct/col/rewrite/GlobalizeStatics.java
+++ b/src/main/java/vct/col/rewrite/GlobalizeStatics.java
@@ -1,7 +1,6 @@
 package vct.col.rewrite;
 
 import hre.ast.MessageOrigin;
-import vct.col.ast.expr.Dereference$;
 import vct.col.ast.stmt.decl.ASTClass;
 import vct.col.ast.stmt.decl.ASTClass.ClassKind;
 import vct.col.ast.stmt.decl.AxiomaticDataType;

--- a/src/main/java/vct/col/rewrite/InlinePatternToTrigger.scala
+++ b/src/main/java/vct/col/rewrite/InlinePatternToTrigger.scala
@@ -5,7 +5,6 @@ import vct.col.ast.generic.ASTNode
 import vct.col.ast.stmt.decl.ProgramUnit
 import vct.col.ast.util.AbstractRewriter
 
-import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 class InlinePatternToTrigger(source: ProgramUnit) extends AbstractRewriter(source) {

--- a/src/main/java/vct/col/rewrite/InlinePredicatesAndFunctions.java
+++ b/src/main/java/vct/col/rewrite/InlinePredicatesAndFunctions.java
@@ -11,13 +11,10 @@ import vct.col.ast.stmt.decl.ProgramUnit;
 import vct.col.ast.expr.StandardOperator;
 import vct.col.ast.type.ASTReserved;
 import vct.col.ast.util.AbstractRewriter;
-import vct.test.ThreadPool;
 
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Stack;
-
-import static hre.lang.System.Output;
 
 public class InlinePredicatesAndFunctions extends AbstractRewriter {
 

--- a/src/main/java/vct/col/rewrite/JavaEncoder.java
+++ b/src/main/java/vct/col/rewrite/JavaEncoder.java
@@ -5,14 +5,12 @@ import java.util.Hashtable;
 import java.util.List;
 
 import hre.ast.MessageOrigin;
-import vct.col.ast.expr.Dereference$;
 import vct.col.ast.stmt.decl.ASTClass;
 import vct.col.ast.stmt.decl.ASTClass.ClassKind;
 import vct.col.ast.stmt.decl.ASTFlags;
 import vct.col.ast.type.*;
 import vct.col.ast.stmt.decl.ASTSpecial;
 import vct.col.ast.stmt.decl.AxiomaticDataType;
-import vct.col.ast.stmt.composite.BlockStatement;
 import vct.col.ast.stmt.decl.Contract;
 import vct.col.ast.expr.Dereference;
 import vct.col.ast.stmt.decl.Method.Kind;

--- a/src/main/java/vct/col/rewrite/KernelRewriter.java
+++ b/src/main/java/vct/col/rewrite/KernelRewriter.java
@@ -21,7 +21,6 @@ import vct.col.ast.stmt.composite.ParallelBarrier;
 import vct.col.ast.stmt.decl.ProgramUnit;
 import vct.col.ast.expr.StandardOperator;
 import vct.col.ast.type.Type;
-import vct.col.ast.util.ASTUtils;
 import vct.col.util.ControlFlowAnalyzer;
 
 public class KernelRewriter extends AbstractRewriter {

--- a/src/main/java/vct/col/rewrite/ProveLockInvariantInConstructors.scala
+++ b/src/main/java/vct/col/rewrite/ProveLockInvariantInConstructors.scala
@@ -2,7 +2,6 @@ package vct.col.rewrite
 
 import hre.ast.BranchOrigin
 import vct.col.ast.`type`.Type
-import vct.col.ast.generic.ASTNode
 import vct.col.ast.stmt.decl.{ASTClass, ASTSpecial, Method, ProgramUnit}
 import vct.col.ast.util.AbstractRewriter
 

--- a/src/main/java/vct/col/rewrite/SilverClassReduction.java
+++ b/src/main/java/vct/col/rewrite/SilverClassReduction.java
@@ -19,10 +19,6 @@ import vct.col.ast.generic.ASTNode;
 import vct.col.ast.type.*;
 import hre.config.Configuration;
 
-import vct.col.ast.util.ContractBuilder;
-import vct.col.ast.util.UndefinedMapping;
-import viper.carbon.boogie.Decl;
-
 /**
  * This rewriter converts a program with classes into
  * a program with records.

--- a/src/main/java/vct/col/rewrite/Standardize.java
+++ b/src/main/java/vct/col/rewrite/Standardize.java
@@ -1,17 +1,14 @@
 package vct.col.rewrite;
 
-import vct.col.ast.expr.constant.StructValue;
 import vct.col.ast.generic.ASTNode;
 import vct.col.ast.stmt.decl.ASTFlags;
 import vct.col.ast.type.ASTReserved;
 import vct.col.ast.stmt.decl.AxiomaticDataType;
-import vct.col.ast.stmt.composite.BlockStatement;
 import vct.col.ast.stmt.decl.Method;
 import vct.col.ast.expr.MethodInvokation;
 import vct.col.ast.expr.NameExpression;
 import vct.col.ast.expr.OperatorExpression;
 import vct.col.ast.stmt.decl.ProgramUnit;
-import vct.col.ast.expr.StandardOperator;
 import vct.col.ast.type.PrimitiveSort;
 import vct.col.ast.type.Type;
 import vct.col.ast.util.AbstractRewriter;

--- a/src/main/java/vct/col/util/AbstractTypeCheck.java
+++ b/src/main/java/vct/col/util/AbstractTypeCheck.java
@@ -4,13 +4,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import hre.lang.HREError;
 import hre.lang.HREExitException;
 import scala.Option;
-import scala.collection.JavaConverters;
-import scala.jdk.CollectionConverters;
-import scala.reflect.internal.Trees;
-import vct.col.ast.expr.NameExpressionKind;
 import vct.col.ast.expr.*;
 import vct.col.ast.expr.constant.ConstantExpression;
 import vct.col.ast.expr.constant.StructValue;

--- a/src/main/java/vct/main/AbstractPass.scala
+++ b/src/main/java/vct/main/AbstractPass.scala
@@ -4,8 +4,6 @@ import vct.col.ast.stmt.decl.ProgramUnit
 import vct.col.features.Feature
 import vct.logging.{ErrorMapping, PassAddVisitor, PassReport}
 
-import scala.annotation.varargs
-
 abstract class AbstractPass(val key: String, val description: String) {
   def removes: Set[Feature]
   def introduces: Set[Feature]

--- a/src/main/java/vct/main/Parsers.java
+++ b/src/main/java/vct/main/Parsers.java
@@ -1,8 +1,5 @@
 package vct.main;
 
-import hre.config.IntegerSetting;
-
-import java.io.File;
 import java.nio.file.Path;
 
 import vct.col.ast.stmt.decl.ProgramUnit;

--- a/src/main/java/vct/test/Task.scala
+++ b/src/main/java/vct/test/Task.scala
@@ -3,11 +3,9 @@ package vct.test
 import java.util.concurrent.Callable
 import java.util.regex.Pattern
 import hre.io.{Message, MessageProcessEnvironment}
-import hre.lang.System.Output
 import hre.util.TestReport.Verdict
 
 import scala.collection.mutable
-import scala.jdk.CollectionConverters._
 
 case class Task(env: MessageProcessEnvironment, conditions: Seq[TaskCondition]) extends Callable[Seq[FailReason]] {
   val TIME_PATTERN: Pattern = Pattern.compile("^(\\s*\\[[^\\]]*\\])*\\s*([a-zA-Z_ ]+) took\\s*([0-9]+)\\s*ms$")

--- a/src/main/java/vct/test/ThreadPool.scala
+++ b/src/main/java/vct/test/ThreadPool.scala
@@ -1,10 +1,6 @@
 package vct.test
 
 import java.util.concurrent.{Callable, LinkedBlockingDeque}
-
-import hre.lang.System.Output
-
-import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 
 /**

--- a/src/test/scala/vct/mock/TypeMock.scala
+++ b/src/test/scala/vct/mock/TypeMock.scala
@@ -1,6 +1,5 @@
 package vct.mock
 
-import vct.col.ast._
 import vct.col.ast.`type`.Type
 import vct.col.ast.generic.ASTNode
 import vct.col.ast.stmt.decl.ProgramUnit

--- a/src/test/scala/vct/rewrite/ArrayNullValuesSpec.scala
+++ b/src/test/scala/vct/rewrite/ArrayNullValuesSpec.scala
@@ -1,6 +1,5 @@
 package vct.rewrite
 
-import vct.col.ast._
 import vct.col.ast.`type`.{ASTReserved, PrimitiveSort}
 import vct.col.ast.expr.StandardOperator
 import vct.col.ast.generic.ASTNode

--- a/viper/src/main/scala/viper/api/Prog.scala
+++ b/viper/src/main/scala/viper/api/Prog.scala
@@ -1,17 +1,6 @@
 package viper.api
 
 import viper.silver.ast._
-import scala.jdk.CollectionConverters._
-import scala.jdk.CollectionConverters._
-import viper.silver.verifier.{Failure, Success, AbortedExceptionally, VerificationError}
-import java.util.List
-import java.util.Properties
-import java.util.SortedMap
-import scala.math.BigInt.int2bigInt
-import viper.silver.ast.SeqAppend
-import java.nio.file.Path
-import viper.silver.parser.PLocalVarDecl
-import scala.collection.mutable.WrappedArray
 
 class Prog {
   val domains = new java.util.ArrayList[Domain]()

--- a/viper/src/main/scala/viper/api/SilverImplementation.scala
+++ b/viper/src/main/scala/viper/api/SilverImplementation.scala
@@ -6,17 +6,10 @@ import scala.jdk.CollectionConverters._
 import viper.silver.verifier.{AbortedExceptionally, Failure, Success, VerificationError}
 import java.util.List
 import java.util.Properties
-import java.util.SortedMap
-
-import scala.math.BigInt.int2bigInt
-import viper.silver.ast.SeqAppend
 import java.nio.file.Path
 
 import hre.ast.OriginFactory
-import viper.silver.parser.PLocalVarDecl
-
-import scala.collection.mutable.WrappedArray
-import hre.lang.System.{Output, Warning}
+import hre.lang.System.{Warning}
 
 class SilverImplementation[O](o:OriginFactory[O])
   extends viper.api.ViperAPI[O,Type,Exp,Stmt,DomainFunc,DomainAxiom,Prog](o,

--- a/viper/src/main/scala/viper/api/SilverTreeCompare.scala
+++ b/viper/src/main/scala/viper/api/SilverTreeCompare.scala
@@ -1,9 +1,7 @@
 package viper.api
 
 import java.io.{File, FileOutputStream, OutputStreamWriter}
-import hre.lang.System.Warning
-import viper.silicon.SiliconFrontend
-import viper.silver.ast.{And, BinExp, DomainFuncApp, Exp, LocalVarDecl, Node, Or, Seqn, Typed}
+import viper.silver.ast.{And, DomainFuncApp, LocalVarDecl, Node, Or, Seqn, Typed}
 import viper.silver.frontend.{SilFrontend, SilFrontendConfig}
 import viper.silver.verifier.{AbstractError, NoVerifier, Verifier}
 

--- a/viper/src/main/scala/viper/api/SilverTypeFactory.scala
+++ b/viper/src/main/scala/viper/api/SilverTypeFactory.scala
@@ -2,16 +2,6 @@ package viper.api
 
 import viper.silver.ast._
 import scala.jdk.CollectionConverters._
-import scala.jdk.CollectionConverters._
-import viper.silver.verifier.{Failure, Success, AbortedExceptionally, VerificationError}
-import java.util.List
-import java.util.Properties
-import java.util.SortedMap
-import scala.math.BigInt.int2bigInt
-import viper.silver.ast.SeqAppend
-import java.nio.file.Path
-import viper.silver.parser.PLocalVarDecl
-import scala.collection.mutable.WrappedArray
 
 class SilverTypeFactory extends TypeFactory[Type] {
   


### PR DESCRIPTION
This pr removes all unused imports. I first tried to do this automatically however Intellij does not support this for Scala. It is not even possible to get a list of unused imports. I had to go through each file individually. 

I hoped I could integrate the optimization of imports to the workflow but that is unfortunately not possible