### PR TITLE
Fix trigger generation for `\values`

### DIFF
--- a/src/main/java/vct/col/rewrite/RewriteArrayRef.scala
+++ b/src/main/java/vct/col/rewrite/RewriteArrayRef.scala
@@ -271,7 +271,7 @@ class RewriteArrayRef(source: ProgramUnit) extends AbstractRewriter(source) {
     contract.requires(create.starall(quantGuardAdd, create.expression(StandardOperator.Perm, create.pattern(quantArrayItem), create.reserved_name(ASTReserved.ReadPerm)), quantDecls:_*))
 
     contract.ensures(eq(seqLength, create.expression(StandardOperator.Minus, to, from)))
-    contract.ensures(create.forall(quantGuardAdd, eq(quantArrayItem, create.pattern(quantSeqItemSub)), quantDecls:_*))
+    contract.ensures(create.forall(quantGuardAdd, eq(create.pattern(quantArrayItem), quantSeqItemSub), quantDecls:_*))
     contract.ensures(create.forall(quantGuard, eq(quantArrayItemAdd, create.pattern(quantSeqItem)), quantDecls:_*))
 
     val arguments = List(


### PR DESCRIPTION
Ensure trigger for `\values(xs, start, end)` is not generated over a minus operator in the helper function's contract.