### PR TITLE
Replace old in syntax with slash syntax

### DIFF
--- a/col/build.sbt
+++ b/col/build.sbt
@@ -2,5 +2,5 @@ name := "col"
 libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.1"
 
 // Disable documentation generation
-sources in (Compile, doc) := Seq()
-publishArtifact in (Compile, packageDoc) := false
+Compile / doc / sources := Seq()
+Compile / packageDoc / publishArtifact := false

--- a/hre/build.sbt
+++ b/hre/build.sbt
@@ -7,6 +7,6 @@ lazy val hre = (project in file("."))
     libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3",
 
     // Disable documentation generation
-    sources in (Compile, doc) := Seq(),
-    publishArtifact in (Compile, packageDoc) := false,
+    Compile / doc / sources := Seq(),
+    Compile / packageDoc / publishArtifact := false,
   )

--- a/parsers/build.sbt
+++ b/parsers/build.sbt
@@ -4,10 +4,10 @@ libraryDependencies += "antlr" % "antlr" % "4.8-extractors-2" from
   "https://github.com/niomaster/antlr4/releases/download/4.8-extractors-2/antlr4.jar"
 
 antlrTask := {
-    val cp = (dependencyClasspath in Compile).value.files
-    val src = (sourceDirectory in Compile).value / "antlr4"
-    val lib = (unmanagedBase in Compile).value / "antlr4"
-    val target = (sourceManaged in Compile).value / "antlr4" / "vct" / "antlr4" / "generated"
+    val cp = (Compile / dependencyClasspath ).value.files
+    val src = (Compile / sourceDirectory ).value / "antlr4"
+    val lib = (Compile / unmanagedBase ).value / "antlr4"
+    val target = (Compile / sourceManaged ).value / "antlr4" / "vct" / "antlr4" / "generated"
     val log = streams.value.log
 
     val compileSets: Seq[(java.io.File, Boolean, Set[java.io.File])] = Seq(
@@ -90,9 +90,9 @@ antlrTask := {
     cachedCompile(allInputFiles).toSeq
 }
 
-sourceGenerators in Compile += (antlrTask in Compile).taskValue
-managedSourceDirectories in Compile += (sourceManaged in Compile).value / "antlr4"
+Compile / sourceGenerators  += (Compile / antlrTask ).taskValue
+Compile / managedSourceDirectories  += (Compile / sourceManaged ).value / "antlr4"
 
 // Disable documentation generation
-sources in (Compile, doc) := Seq()
-publishArtifact in (Compile, packageDoc) := false
+Compile / doc / sources := Seq()
+Compile / packageDoc / publishArtifact := false

--- a/viper/build.sbt
+++ b/viper/build.sbt
@@ -3,5 +3,5 @@ organization := "vercors"
 version := "1.0-SNAPSHOT"
 
 // Disable documentation generation
-sources in (Compile, doc) := Seq()
-publishArtifact in (Compile, packageDoc) := false
+Compile / doc / sources := Seq()
+Compile / packageDoc / publishArtifact := false


### PR DESCRIPTION
Replace old in syntax with slash syntax. This gets rid of some warnings when building.