### PR TITLE
More explicitly print the context if a name cannot be resolved

### DIFF
--- a/src/main/java/vct/col/util/AbstractTypeCheck.java
+++ b/src/main/java/vct/col/util/AbstractTypeCheck.java
@@ -505,7 +505,12 @@ public class AbstractTypeCheck extends RecursiveVisitor<Type> {
         kind = info.kind;
       } else {
         e.setType(new ClassType(e.name()));
-        e.getType().accept(this);
+        try {
+          e.getType().accept(this);
+        } catch (HREExitException exc) {
+          e.getOrigin().report("error", "Unknown name");
+          throw exc;
+        }
         return;
       }
     }


### PR DESCRIPTION
This PR improves the error message when a name cannot be resolved in some situations.

Example program:

```
class C {
    void m() {
        assert Perm(f, write);
    }
}
```

Old error:

```
At null: type error: defined type f not found
The final verdict is Error
```

New error:

```
At null: type error: defined type f not found
=== xx.pvl                         ===
   1 class C {
   2     void m() {
                        [-
   3         assert Perm(f, write);
                         -]
   4     }
   5 }
-----------------------------------------
  Unknown name
=========================================
The final verdict is Error
```