### PR TITLE
Take `synchronized` into account when computing features

### DIFF
--- a/examples/abrupt/SynchronizedReturn.java
+++ b/examples/abrupt/SynchronizedReturn.java
@@ -1,0 +1,31 @@
+//:: cases SynchronizedReturn
+//:: tools silicon
+//:: verdict Fail
+
+/*
+In this file it is tested if the return statement below is not accidentally encoded using a goto-oblivious encoding,
+which would turn the return statement into "inhale false;", since control flow does not proceed to after the return
+statement. However, the synchronized keyword requires the intrinsic lock of the class to be unlocked, so in fact other
+code _is_ executed after the return statement. Since the method n() steals the held predicate, this synchronized-related
+clean-up code should fail in the normal case, but if the goto-oblivious encoding is used this is not the case.
+*/
+
+final class C {
+    /*@
+        resource lock_invariant() = Perm(f, 1);
+     @*/
+
+    int f;
+
+    synchronized void m() {
+        n();
+        return;
+    }
+
+    /*@
+    requires held(this); // Steal the lock
+     @*/
+    void n() {
+
+    }
+}

--- a/src/main/java/vct/col/features/FeatureRainbow.scala
+++ b/src/main/java/vct/col/features/FeatureRainbow.scala
@@ -559,7 +559,7 @@ class RainbowVisitor(source: ProgramUnit) extends RecursiveVisitor(source) {
 
   override def visit(returnStatement: vct.col.ast.stmt.terminal.ReturnStatement): Unit = {
     super.visit(returnStatement)
-    if(!lastMethodStatements.contains(returnStatement) || current_method().isSynchronized) {
+    if(!lastMethodStatements.contains(returnStatement)) {
       addFeature(ExceptionalReturn, returnStatement)
     }
   }

--- a/src/main/java/vct/col/features/FeatureRainbow.scala
+++ b/src/main/java/vct/col/features/FeatureRainbow.scala
@@ -559,7 +559,7 @@ class RainbowVisitor(source: ProgramUnit) extends RecursiveVisitor(source) {
 
   override def visit(returnStatement: vct.col.ast.stmt.terminal.ReturnStatement): Unit = {
     super.visit(returnStatement)
-    if(!lastMethodStatements.contains(returnStatement)) {
+    if(!lastMethodStatements.contains(returnStatement) || current_method().isSynchronized) {
       addFeature(ExceptionalReturn, returnStatement)
     }
   }

--- a/src/main/java/vct/main/Passes.scala
+++ b/src/main/java/vct/main/Passes.scala
@@ -305,7 +305,7 @@ object Passes {
       new UnfoldSynchronized(_).rewriteAll(),
       permits = Feature.DEFAULT_PERMIT + features.Synchronized + features.NotJavaEncoded + features.PVLSugar + features.NullAsOptionValue ++ Feature.OPTION_GATES + features.ArgumentAssignment,
       removes = Set(features.Synchronized),
-      introduces = Set(features.Exceptions, features.NoExcVar, features.Finally, features.PVLSugar)
+      introduces = Set(features.Exceptions, features.NoExcVar, features.Finally, features.PVLSugar, features.ExceptionalReturn)
     ),
     SimplePass("introExcVar",
       "Introduces the auxiliary sys__exc variable for use by exceptional control flow",
@@ -772,7 +772,13 @@ object Passes {
     ErrorMapPass("returnTypeToOutParameter",
       "Replace return value by out parameter.",
       new CreateReturnParameter(_, _).rewriteAll,
-      permits=Feature.DEFAULT_PERMIT - features.NotFlattened + features.TopLevelImplementedMethod + features.TopLevelMethod - features.Constructors,
+      permits=Feature.DEFAULT_PERMIT
+        - features.NotFlattened
+        + features.TopLevelImplementedMethod
+        + features.TopLevelMethod
+        - features.Constructors
+        - features.ExceptionalReturn
+        - features.Synchronized,
       removes=Set(features.NonVoidMethods),
       introduces=Feature.NO_POLY_INTRODUCE -- Set(
         features.NotFlattened,


### PR DESCRIPTION
Currently the feature system does not detect that the `synchronized` modifier in java causes exceptional code to be added to the AST later on, which results in a faulty encoding of return. This PR ensures that the feature system takes `synchronized` fully into account by adding that having `synchronized` might also cause exceptional returns be present in the AST.