### PR TITLE
COL redesign: static method import

### DIFF
--- a/col/src/main/java/vct/col/resolve/Java.scala
+++ b/col/src/main/java/vct/col/resolve/Java.scala
@@ -297,7 +297,7 @@ case object Java {
       // From each class, get the method we are looking for
       potentialClasses.collect({
         case RefJavaClass(cls: JavaClass[G]) => cls.getMethods(method)
-      }) match {
+      }).filter(_.nonEmpty) match { // Discard any classes that have no matches
         // If we find only one set of methods, or no sets at all, then that's good.
         // Just pick the one that matches the signature we're looking for
         case Seq(methods) => methods.collectFirst(selectMatchingSignature)

--- a/col/src/main/java/vct/col/resolve/Resolve.scala
+++ b/col/src/main/java/vct/col/resolve/Resolve.scala
@@ -62,6 +62,13 @@ case object ResolveTypes {
     case cls: Class[G] =>
       // PB: needs to be in ResolveTypes if we want to support method inheritance at some point.
       cls.supports.foreach(_.tryResolve(name => Spec.findClass(name, ctx).getOrElse(throw NoSuchNameError("class", name, cls))))
+    case imp @ JavaImport(true, name, /* star = */ false) =>
+      Java.findJavaTypeName(name.names.init, ctx)
+        .getOrElse(throw NoSuchNameError("class", name.names.mkString("."), imp))
+    case imp @ JavaImport(true, name, /* star = */ true) =>
+      Java.findJavaTypeName(name.names, ctx)
+        .getOrElse(throw NoSuchNameError("class", name.names.mkString("."), imp))
+
     case _ =>
   }
 }

--- a/examples/concepts/import/Sqrt.java
+++ b/examples/concepts/import/Sqrt.java
@@ -1,0 +1,7 @@
+import static java.lang.Math.sqrt;
+
+class C {
+    void m() {
+        sqrt(3);
+    }
+}

--- a/examples/concepts/import/SqrtStar.java
+++ b/examples/concepts/import/SqrtStar.java
@@ -1,0 +1,7 @@
+import static java.lang.Math.*;
+
+class C {
+    void m() {
+        sqrt(3);
+    }
+}

--- a/src/main/java/vct/col/newrewrite/lang/LangJavaToCol.scala
+++ b/src/main/java/vct/col/newrewrite/lang/LangJavaToCol.scala
@@ -82,7 +82,7 @@ case class LangJavaToCol[Pre <: Generation](rw: LangSpecificToCol[Pre]) extends 
 
   val javaDefaultConstructor: SuccessionMap[JavaClassOrInterface[Pre], JavaConstructor[Pre]] = SuccessionMap()
 
-  val javaFieldsToJavaClass: mutable.Map[JavaFields[Pre], JavaClass[Pre]] = mutable.Map()
+  val javaClassDeclToJavaClass: mutable.Map[JavaClassDeclaration[Pre], JavaClassOrInterface[Pre]] = mutable.Map()
 
   val currentJavaClass: ScopedStack[JavaClassOrInterface[Pre]] = ScopedStack()
 
@@ -219,13 +219,10 @@ case class LangJavaToCol[Pre <: Generation](rw: LangSpecificToCol[Pre]) extends 
   def rewriteClass(cls: JavaClassOrInterface[Pre]): Unit = {
     implicit val o: Origin = cls.o
 
-    cls match {
-      case cls: JavaClass[Pre] =>
-        cls.decls.collect({
-          case fields: JavaFields[Pre] =>
-            javaFieldsToJavaClass(fields) = cls
-        })
-    }
+    cls.decls.collect({
+      case decl: JavaClassDeclaration[Pre] =>
+        javaClassDeclToJavaClass(decl) = cls
+    })
 
     currentJavaClass.having(cls) {
       val supports = cls.supports.map(rw.dispatch).flatMap {
@@ -306,7 +303,7 @@ case class LangJavaToCol[Pre <: Generation](rw: LangSpecificToCol[Pre]) extends 
       case RefJavaClass(decl) => throw NotAValue(local)
       case RefJavaField(decls, idx) =>
         if(decls.modifiers.contains(JavaStatic[Pre]())) {
-          val classStaticsFunction: LazyRef[Post, Function[Post]] = new LazyRef(javaStaticsFunctionSuccessor(javaFieldsToJavaClass(decls)))
+          val classStaticsFunction: LazyRef[Post, Function[Post]] = new LazyRef(javaStaticsFunctionSuccessor(javaClassDeclToJavaClass(decls)))
           Deref[Post](
             obj = FunctionInvocation[Post](classStaticsFunction, Nil, Nil, Nil, Nil)(PanicBlame("Statics singleton function requires nothing.")),
             ref = javaFieldsSuccessor.ref((decls, idx)),
@@ -369,8 +366,9 @@ case class LangJavaToCol[Pre <: Generation](rw: LangSpecificToCol[Pre]) extends 
         ActionApply[Post](rw.succ(decl), args.map(rw.dispatch))
       case RefJavaMethod(decl) =>
         if(decl.modifiers.contains(JavaStatic[Pre]())) {
+          val classStaticsFunction: LazyRef[Post, Function[Post]] = new LazyRef(javaStaticsFunctionSuccessor(javaClassDeclToJavaClass(decl)))
           MethodInvocation[Post](
-            obj = FunctionInvocation[Post](javaStaticsFunctionSuccessor.ref(currentJavaClass.top), Nil, Nil, Nil, Nil)(inv.blame),
+            obj = FunctionInvocation[Post](classStaticsFunction, Nil, Nil, Nil, Nil)(inv.blame),
             ref = rw.succ(decl),
             args = args.map(rw.dispatch), outArgs = Nil, typeParams.map(rw.dispatch),
             givenMap.map { case (Ref(v), e) => (rw.succ(v), rw.dispatch(e)) },

--- a/src/main/universal/res/jdk/java/lang/Math.java
+++ b/src/main/universal/res/jdk/java/lang/Math.java
@@ -1,0 +1,18 @@
+package java.lang;
+
+class Math {
+    /*@
+    ghost
+    public static pure double sqrt(double x) {
+        // Blatantly wrong!
+        return x;
+    }
+
+    // The standard doesn't have this one, but since int literals are not yet cast to doubles automatically, this one is in Math too.
+    ghost
+    public static pure int sqrt(int x) {
+        // Blatantly wrong!
+        return x;
+    }
+    */
+}


### PR DESCRIPTION
This PR contains stuff that I forgot to implement when adding support for static methods.

- A bug was fixed where classes that did not contain any relevant static method were considered
- For static methods, the appropriate "statics" constructor was not used, but instead the statics constructor of the current class was used.
- Static imports did not cause any classes to be loaded, so e.g. statically imported standard lib classes caused an error. Static imports now cause eager loading of those classes into the ast, so they can be found when resolving references.
- A test was added for static methods.