### PR TITLE
Ast safe usr1 signal

### DIFF
--- a/src/main/java/vct/main/modes/Verify.scala
+++ b/src/main/java/vct/main/modes/Verify.scala
@@ -53,7 +53,8 @@ case object Verify extends LazyLogging {
         }
       })
     } catch {
-      case _: IllegalArgumentException => logger.warn("Could not register USR1 debug hook. This is expected behaviour on windows.")
+      // Could not register USR1 debug hook. This is expected behaviour on windows.
+      case _: IllegalArgumentException =>
     }
 
     verifyWithOptions(options, options.inputs) match {

--- a/src/main/java/vct/main/modes/Verify.scala
+++ b/src/main/java/vct/main/modes/Verify.scala
@@ -44,12 +44,17 @@ case object Verify extends LazyLogging {
   }
 
   def runOptions(options: Options): Int = {
-    Signal.handle(new Signal("USR1"), _ => SymbExLogger.memberList.synchronized {
-      SymbExLogger.memberList.toSeq.map(_.listener).collect { case l: SiliconLogListener => l } match {
-        case Nil => logger.warn("Silicon is idle.")
-        case listeners => listeners.foreach(_.printDetailedState())
-      }
-    })
+    try {
+      // Wrapped in try because this seems to crash on windows
+      Signal.handle(new Signal("USR1"), _ => SymbExLogger.memberList.synchronized {
+        SymbExLogger.memberList.toSeq.map(_.listener).collect { case l: SiliconLogListener => l } match {
+          case Nil => logger.warn("Silicon is idle.")
+          case listeners => listeners.foreach(_.printDetailedState())
+        }
+      })
+    } catch {
+      case _: IllegalArgumentException => logger.warn("Could not register USR1 debug hook. This is expected behaviour on windows.")
+    }
 
     verifyWithOptions(options, options.inputs) match {
       case Left(err) =>


### PR DESCRIPTION
When registering for the usr1 signal on windows, the jdk throws an exception. This PR adds a try-catch that catches the exception and prints a warning if this happens.