### PR TITLE
Improve compilation performance for generated sources

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -109,7 +109,7 @@ lazy val vercors: Project = (project in file("."))
       "-feature",
       "-unchecked",
 //      "-Xno-patmat-analysis",
-//      "-Ystatistics",
+//      "-Ystatistics:typer",
 //      "-Xprint:typer",
 //      "-Ycache-plugin-class-loader:last-modified",
 //      "-Xplugin:/home/pieter/.cache/coursier/v1/https/repo1.maven.org/maven2/io/leonard/scalac-profiling_2.13/0.0.1/scalac-profiling_2.13-0.0.1.jar",

--- a/col/build.sbt
+++ b/col/build.sbt
@@ -18,7 +18,7 @@ generateHelpersTask := {
 
   val compile = FileFunction.cached(streams.value.cacheDirectory / "removeThisToGenerate-src_managed", FilesInfo.hash)(changedSet => {
     if(changedSet.nonEmpty) {
-      ColHelper().generate(files, gen).toSet
+      ColHelper().generate(files, gen, (f: File, c: String) => IO.write(f, c)).toSet
     } else {
       Set()
     }

--- a/col/src/main/java/vct/col/ast/Node.scala
+++ b/col/src/main/java/vct/col/ast/Node.scala
@@ -490,9 +490,6 @@ final case class InstancePredicateLocation[G](predicate: Ref[G, InstancePredicat
 final case class AmbiguousLocation[G](expr: Expr[G])(val blame: Blame[PointerLocationError])(implicit val o: Origin) extends Location[G] with AmbiguousLocationImpl[G]
 
 
-final case class Chunk[G](test: Expr[G])(implicit val o: Origin) extends Expr[G] {
-  override def t: Type[G] = TInt()
-}
 final case class Perm[G](loc: Location[G], perm: Expr[G])(implicit val o: Origin) extends Expr[G] with PermImpl[G]
 final case class PointsTo[G](loc: Location[G], perm: Expr[G], value: Expr[G])(implicit val o: Origin) extends Expr[G] with PointsToImpl[G]
 final case class CurPerm[G](loc: Location[G])(implicit val o: Origin) extends Expr[G] with CurPermImpl[G]

--- a/col/src/main/java/vct/col/ast/Node.scala
+++ b/col/src/main/java/vct/col/ast/Node.scala
@@ -490,6 +490,9 @@ final case class InstancePredicateLocation[G](predicate: Ref[G, InstancePredicat
 final case class AmbiguousLocation[G](expr: Expr[G])(val blame: Blame[PointerLocationError])(implicit val o: Origin) extends Location[G] with AmbiguousLocationImpl[G]
 
 
+final case class Chunk[G](test: Expr[G])(implicit val o: Origin) extends Expr[G] {
+  override def t: Type[G] = TInt()
+}
 final case class Perm[G](loc: Location[G], perm: Expr[G])(implicit val o: Origin) extends Expr[G] with PermImpl[G]
 final case class PointsTo[G](loc: Location[G], perm: Expr[G], value: Expr[G])(implicit val o: Origin) extends Expr[G] with PointsToImpl[G]
 final case class CurPerm[G](loc: Location[G])(implicit val o: Origin) extends Expr[G] with CurPermImpl[G]

--- a/project/ColDefs.scala
+++ b/project/ColDefs.scala
@@ -1,3 +1,4 @@
+import scala.collection.mutable
 import scala.meta._
 
 /**
@@ -40,7 +41,7 @@ object ColDefs {
   def scopes(kind: String): Term.Name =
     Term.Name(kind.charAt(0).toLower + kind.substring(1) + "s")
 
-  val DECLARATION_NAMESPACE: Map[String, Seq[String]] = Map(
+  val DECLARATION_NAMESPACE: mutable.ListMap[String, Seq[String]] = mutable.ListMap(
     "GlobalDeclaration" -> Seq("Program"),
     "ClassDeclaration" -> Seq("Program"),
     "ADTDeclaration" -> Seq("Program"),

--- a/project/ColDefs.scala
+++ b/project/ColDefs.scala
@@ -20,12 +20,6 @@ object ColDefs {
   )
 
   /**
-   * The root type of declarations
-   */
-  val DECLARATION: String = "Declaration"
-  val DECLARATION_TYPE: Type.Name = Type.Name(DECLARATION)
-
-  /**
    * The different kinds of declaration that exist, as well as a mapping to their corresponding default scope.
    */
   val DECLARATION_KINDS: Seq[String] = Seq(
@@ -89,20 +83,4 @@ object ColDefs {
   )
 
   assert(DECLARATION_NAMESPACE.keys.toSet == DECLARATION_KINDS.toSet)
-
-  /**
-   * The type that is the direct superclass of AbstractRewriter, and contains the default scopes mentioned above.
-   */
-  val PRE: Type.Name = Type.Name("Pre")
-  val POST: Type.Name = Type.Name("Post")
-
-  /**
-   * The fields that occupy blame and the origin of the node respectively.
-   */
-  val BLAME: String = "blame"
-  val BLAME_TERM: Term.Name = Term.Name(BLAME)
-  val BLAME_PAT: Pat.Var = Pat.Var(BLAME_TERM)
-  val ORIGIN: String = "o"
-  val ORIGIN_TERM: Term.Name = Term.Name(ORIGIN)
-  val ORIGIN_PAT: Pat.Var = Pat.Var(ORIGIN_TERM)
 }

--- a/project/ColDescription.scala
+++ b/project/ColDescription.scala
@@ -66,8 +66,8 @@ case class ClassDef(names: Seq[String], params: List[Term.Param], blameType: Opt
 
 class ColDescription {
   val defs: ArrayBuffer[ClassDef] = ArrayBuffer()
-  val bases: mutable.Map[String, List[String]] = mutable.Map()
-  val families: mutable.Set[String] = mutable.Set()
+  val bases: mutable.ListMap[String, List[String]] = mutable.ListMap()
+  val families: ArrayBuffer[String] = ArrayBuffer()
 
   def supports(baseType: String)(cls: String): Boolean = {
     baseType == cls || bases.getOrElse(cls, Seq()).exists(supports(baseType))

--- a/project/ColDescription.scala
+++ b/project/ColDescription.scala
@@ -18,7 +18,7 @@ case class ClassDef(names: Seq[String], params: List[Term.Param], blameType: Opt
   for(param <- params) {
     // PB: sorry if this breaks; can't find the list of keywords elsewhere...
     if(internal.tokenizers.keywords.contains(param.name.value)) {
-      MetaUtil.fail(
+      ColHelperUtil.fail(
         s"Class ${names.mkString(".")} has a parameter named ${param.name.value}, which is a keyword in Scala.\n" +
           "Although this is possible, this leads to incorrectly generated patterns in match statements, so please pick a different name.\n" +
           "(The keyword may be a soft keyword, or only a keyword as of Scala 3, but will be generated incorrectly nonetheless.)",
@@ -87,7 +87,7 @@ class ColDescription {
     case Type.Tuple(List(t1, t2, t3)) =>
       q"(${rewriteDefault(q"$term._1", t1)}, ${rewriteDefault(q"$term._2", t2)}, ${rewriteDefault(q"$term._3", t3)})"
     case Type.Tuple(other) =>
-      MetaUtil.fail(s"Oops, this tuple is too long for me! size=${other.size}", node=Some(typ))
+      ColHelperUtil.fail(s"Oops, this tuple is too long for me! size=${other.size}", node=Some(typ))
 
     case Type.Apply(Type.Name(declKind), List(Type.Name("G"))) if DECLARATION_KINDS.contains(declKind) =>
       q"rewriter.${ColDefs.scopes(declKind)}.dispatch($term)"
@@ -103,7 +103,7 @@ class ColDescription {
       term
 
     case _ =>
-      MetaUtil.fail(
+      ColHelperUtil.fail(
         s"Encountered an unknown type while generating default rewriters: $typ\n" +
           "Perhaps there is an 'extends Expr' or so missing, or ColDefs.DECLARATION_KINDS is incomplete?",
         node=Some(typ)
@@ -141,7 +141,7 @@ class ColDescription {
         case _ =>
       }
     case otherCls: Defn.Class if otherCls.mods.collectFirst { case Mod.Abstract() => () }.isEmpty =>
-      MetaUtil.fail("Could not parse the following class. Is the class in the right format?", node = Some(otherCls))
+      ColHelperUtil.fail("Could not parse the following class. Is the class in the right format?", node = Some(otherCls))
     case Defn.Object(_, name, Template(_, _, _, stats)) =>
       stats.foreach(collectNode(path :+ name.value))
     case _ =>
@@ -198,7 +198,7 @@ class ColDescription {
         stats.foreach(collectBases)
         stats.foreach(collectFamily)
       case other =>
-        MetaUtil.fail(
+        ColHelperUtil.fail(
           s"Source file $file did not parse in the expected pattern Source(List(Pkg(_, stats))), but instead as:\n" +
             other.toString,
           node=Some(other)

--- a/project/ColHelper.scala
+++ b/project/ColHelper.scala
@@ -1,6 +1,8 @@
 import java.io.File
 import java.nio.file.{Files, Path}
 import scala.meta._
+import scala.meta.internal.prettyprinters.TreeSyntax
+import scala.meta.prettyprinters.Show
 
 case class ColHelper() {
   import ColDefs._
@@ -31,9 +33,10 @@ case class ColHelper() {
     ).flatten.map {
       case (fileName, stats) =>
         val out = packageOutput.resolve(fileName + ".scala").toFile
+        val pkg = Pkg(packageName, ColDefs.IMPORTS /*++ List(warner)*/ ++ stats)
         i += 1
 //        val warner = q"class ${Type.Name("Warner" + i.toString)}{ 1 == 'c' }"
-        writer(out, Pkg(packageName, ColDefs.IMPORTS /*++ List(warner)*/ ++ stats).toString())
+        writer(out, pkg.toString())
         out
     }
   }

--- a/project/ColHelper.scala
+++ b/project/ColHelper.scala
@@ -6,7 +6,7 @@ case class ColHelper() {
   import ColDefs._
   val info = new ColDescription()
 
-  def generate(input: Seq[File], output: File): Seq[File] = {
+  def generate(input: Seq[File], output: File, writer: (File, String) => Unit): Seq[File] = {
     // Collect the structure of COL into ColDescription
     input.foreach(info.collectInfo)
     println(s"Generating helpers for ${info.defs.size} node types")
@@ -16,22 +16,25 @@ case class ColHelper() {
     packageOutput.toFile.mkdirs()
     val packageName = PACKAGE.tail.foldLeft[Term.Ref](Term.Name(PACKAGE.head))((t, n) => Term.Select(t, Term.Name(n)))
 
+    var i = 0
+
     // Generate the helper files
-    Seq[(String, () => List[Stat])](
-      ("AbstractRewriter", ColHelperAbstractRewriter(info).make),
-      ("RewriteHelpers", ColHelperRewriteHelpers(info).make),
-      ("RewriteBuilders", ColHelperRewriteBuilders(info).make),
-      ("JavaRewriter", ColHelperJavaRewriter(info).make),
-      ("Subnodes", ColHelperSubnodes(info).make),
-      ("Comparator", ColHelperComparator(info).make),
-      ("AllScopes", ColHelperAllScopes(info).make),
-      ("SuccessorsProvider", ColHelperSuccessorsProvider(info).make),
-    ).map {
-      case (fileName, maker) =>
-        val out = packageOutput.resolve(fileName + ".scala")
-        Files.deleteIfExists(out)
-        Files.writeString(out, Pkg(packageName, ColDefs.IMPORTS ++ maker()).toString())
-        out.toFile
+    Seq[List[(String, List[Stat])]](
+      ColHelperAbstractRewriter(info).make(),
+      ColHelperRewriteHelpers(info).make(),
+      ColHelperRewriteBuilders(info).make(),
+      ColHelperJavaRewriter(info).make(),
+      ColHelperSubnodes(info).make(),
+      ColHelperComparator(info).make(),
+      ColHelperAllScopes(info).make(),
+      ColHelperSuccessorsProvider(info).make(),
+    ).flatten.map {
+      case (fileName, stats) =>
+        val out = packageOutput.resolve(fileName + ".scala").toFile
+        i += 1
+//        val warner = q"class ${Type.Name("Warner" + i.toString)}{ 1 == 'c' }"
+        writer(out, Pkg(packageName, ColDefs.IMPORTS /*++ List(warner)*/ ++ stats).toString())
+        out
     }
   }
 }

--- a/project/ColHelperAbstractRewriter.scala
+++ b/project/ColHelperAbstractRewriter.scala
@@ -11,8 +11,8 @@ case class ColHelperAbstractRewriter(info: ColDescription) {
       classOf[${cls.typ}[_]] -> new RWFunc[${Type.Name(baseType)}] {
         def apply[Pre, Post](node: ${Type.Name(baseType)}[Pre], rw: AbstractRewriter[Pre, Post]): ${Type.Name(baseType)}[Post] =
           ${ColDefs.DECLARATION_KINDS.find(info.supports(_)(cls.baseName)) match {
-            case None => q"new ${cls.rewriteHelperName}(node.asInstanceOf[${cls.typ}[Pre]])(rw).rewrite()"
-            case Some(decl) => q"rw.${ColDefs.scopes(decl)}.succeed(node.asInstanceOf[${cls.typ}[Pre]], new ${cls.rewriteHelperName}(node.asInstanceOf[${cls.typ}[Pre]])(rw).rewrite())"
+            case None => q"new ${cls.rewriteHelperName}(node.asInstanceOf[${cls.typ}[Pre]])(rw).rewriteDefault()"
+            case Some(decl) => q"rw.${ColDefs.scopes(decl)}.succeed(node.asInstanceOf[${cls.typ}[Pre]], new ${cls.rewriteHelperName}(node.asInstanceOf[${cls.typ}[Pre]])(rw).rewriteDefault())"
           }}
       }
     """}.toList

--- a/project/ColHelperAbstractRewriter.scala
+++ b/project/ColHelperAbstractRewriter.scala
@@ -1,5 +1,5 @@
 import ColDefs._
-import MetaUtil.NonemptyMatch
+import ColHelperUtil.NonemptyMatch
 
 import scala.meta._
 
@@ -18,7 +18,7 @@ case class ColHelperAbstractRewriter(info: ColDescription) {
     """}.toList
   }
 
-  def make(): List[Stat] = q"""
+  def make(): List[(String, List[Stat])] = List("AbstractRewriter" -> q"""
     import scala.reflect.ClassTag
     import RewriteHelpers._
     import vct.col.util.Scopes
@@ -59,7 +59,7 @@ case class ColHelperAbstractRewriter(info: ColDescription) {
       def succProvider: SuccessorsProvider[Pre, Post] = allScopes.freeze
 
       def anySucc[RefDecl <: Declaration[Post]](decl: Declaration[Pre])(implicit tag: ClassTag[RefDecl]): Ref[Post, RefDecl] =
-        ${MetaUtil.NonemptyMatch("decl succ kind cases", q"decl", ColDefs.DECLARATION_KINDS.map(decl =>
+        ${ColHelperUtil.NonemptyMatch("decl succ kind cases", q"decl", ColDefs.DECLARATION_KINDS.map(decl =>
           Case(p"decl: ${Type.Name(decl)}[Pre]", None, q"succ(decl)")
         ).toList)}
 
@@ -81,5 +81,5 @@ case class ColHelperAbstractRewriter(info: ColDescription) {
           AbstractRewriter.${Term.Name(s"rewriteDefault${family}LookupTable")}(node.getClass)(node, this)
       """)).toList}
     }
-  """.stats
+  """.stats)
 }

--- a/project/ColHelperAbstractRewriter.scala
+++ b/project/ColHelperAbstractRewriter.scala
@@ -30,9 +30,9 @@ case class ColHelperAbstractRewriter(info: ColDescription) {
       }
 
       ${Defn.Val(Nil,
-        List(Pat.Var(Term.Name(s"rewriteDefault${DECLARATION}LookupTable"))),
-        Some(t"Map[java.lang.Class[_], RWFunc[$DECLARATION_TYPE]]"),
-        q"Map(..${rewriteDefaultCases(DECLARATION)})",
+        List(Pat.Var(Term.Name(s"rewriteDefaultDeclarationLookupTable"))),
+        Some(t"Map[java.lang.Class[_], RWFunc[Declaration]]"),
+        q"Map(..${rewriteDefaultCases("Declaration")})",
       )}
 
       ..${info.families.map(family => Defn.Val(Nil,
@@ -47,10 +47,10 @@ case class ColHelperAbstractRewriter(info: ColDescription) {
 
       def dispatch(o: Origin): Origin = o
 
-      def dispatch(decl: $DECLARATION_TYPE[Pre]): Unit
+      def dispatch(decl: Declaration[Pre]): Unit
 
-      def rewriteDefault(decl: $DECLARATION_TYPE[Pre]): Unit =
-        AbstractRewriter.${Term.Name(s"rewriteDefault${DECLARATION}LookupTable")}(decl.getClass)(decl, this)
+      def rewriteDefault(decl: Declaration[Pre]): Unit =
+        AbstractRewriter.${Term.Name(s"rewriteDefaultDeclarationLookupTable")}(decl.getClass)(decl, this)
 
       def porcelainRefSucc[RefDecl <: Declaration[Post]](ref: Ref[Pre, _])(implicit tag: ClassTag[RefDecl]): Option[Ref[Post, RefDecl]] = None
       def porcelainRefSeqSucc[RefDecl <: Declaration[Post]](refs: Seq[Ref[Pre, _]])(implicit tag: ClassTag[RefDecl]): Option[Seq[Ref[Post, RefDecl]]] = None

--- a/project/ColHelperAllScopes.scala
+++ b/project/ColHelperAllScopes.scala
@@ -1,7 +1,7 @@
 import scala.meta._
 
 case class ColHelperAllScopes(info: ColDescription) {
-  def make(): List[Stat] = q"""
+  def make(): List[(String, List[Stat])] = List("AllScopes" -> q"""
     import vct.col.util.Scopes
     import scala.reflect.ClassTag
 
@@ -20,12 +20,12 @@ case class ColHelperAllScopes(info: ColDescription) {
       def freeze: AllFrozenScopes = new AllFrozenScopes
 
       def anyDeclare[T <: Declaration[Post]](decl1: T): T =
-        ${MetaUtil.NonemptyMatch("decl declare kind cases", q"decl1", ColDefs.DECLARATION_KINDS.map(decl =>
+        ${ColHelperUtil.NonemptyMatch("decl declare kind cases", q"decl1", ColDefs.DECLARATION_KINDS.map(decl =>
           Case(p"decl: ${Type.Name(decl)}[Post]", None, q"${ColDefs.scopes(decl)}.declare(decl); decl1")
         ).toList)}
 
       def anySucceedOnly[T <: Declaration[Post]](pre1: Declaration[Pre], post1: T)(implicit tag: ClassTag[T]): T =
-        ${MetaUtil.NonemptyMatch("decl succeed kind cases", q"(pre1, post1)", ColDefs.DECLARATION_KINDS.map(decl =>
+        ${ColHelperUtil.NonemptyMatch("decl succeed kind cases", q"(pre1, post1)", ColDefs.DECLARATION_KINDS.map(decl =>
           Case(p"(pre: ${Type.Name(decl)}[Pre], post: ${Type.Name(decl)}[Post])", None, q"${ColDefs.scopes(decl)}.succeedOnly(pre, post); post1")
         ).toList)}
 
@@ -38,5 +38,5 @@ case class ColHelperAllScopes(info: ColDescription) {
           ${ColDefs.scopes(decl)}.freeze.succ(decl)
       """).toList}
     }
-  """.stats
+  """.stats)
 }

--- a/project/ColHelperJavaRewriter.scala
+++ b/project/ColHelperJavaRewriter.scala
@@ -29,11 +29,11 @@ case class ColHelperJavaRewriter(info: ColDescription) {
 
   def make(): List[Stat] = List(q"""
     abstract class JavaRewriter[Pre, Post] extends AbstractRewriter[Pre, Post] {
-      def dispatch(decl: $DECLARATION_TYPE[Pre]): Unit =
-        ${NonemptyMatch("declaration dispatch", q"decl", info.defs.filter(cls => info.supports(DECLARATION)(cls.baseName)).map(dispatchCase).toList)}
+      def dispatch(decl: Declaration[Pre]): Unit =
+        ${NonemptyMatch("declaration dispatch", q"decl", info.defs.filter(cls => info.supports("Declaration")(cls.baseName)).map(dispatchCase).toList)}
 
       ..${
-        val elems = info.defs.filter(cls => info.supports(DECLARATION)(cls.baseName))
+        val elems = info.defs.filter(cls => info.supports("Declaration")(cls.baseName))
         elems.map(javaRewriteDecl).toList ++ elems.map(javaRewriteBuilder).toList
       }
 

--- a/project/ColHelperJavaRewriter.scala
+++ b/project/ColHelperJavaRewriter.scala
@@ -1,15 +1,24 @@
 import ColDefs._
-import MetaUtil.NonemptyMatch
+import ColHelperUtil.NonemptyMatch
 
 import scala.meta._
 
 case class ColHelperJavaRewriter(info: ColDescription) {
-  def dispatchCase(cls: ClassDef): Case =
-    Case(Pat.Typed(Pat.Var(q"node"), t"${cls.typ}[Pre]"), None, q"rewrite(node)")
+  def makeMapEntry(family: String)(cls: ClassDef): Term =
+    q"""classOf[${cls.typ}[_]] -> new RWFunc[${Type.Name(family)}] {
+      def apply[Pre, Post](node: ${Type.Name(family)}[Pre], rw: JavaRewriter[Pre, Post]): ${Type.Name(family)}[Post] =
+        rw.rewrite(node.asInstanceOf[${cls.typ}[Pre]])
+    }"""
+
+  def makeDeclMapEntry(cls: ClassDef): Term =
+    q"""classOf[${cls.typ}[_]] -> new DeclRWFunc {
+      def apply[Pre, Post](node: Declaration[Pre], rw: JavaRewriter[Pre, Post]): Unit =
+        rw.rewrite(node.asInstanceOf[${cls.typ}[Pre]])
+    }"""
 
   def javaRewrite(ret: Type.Name)(cls: ClassDef): Stat = q"""
     def rewrite(node: ${cls.typ}[Pre]): $ret[Post] = {
-      val builder = new RewriteBuilders.${cls.rewriteBuilderName}(node)
+      val builder = new ${cls.rewriteBuilderName}(node)
       rewrite(builder)
       builder.build()
     }
@@ -17,7 +26,7 @@ case class ColHelperJavaRewriter(info: ColDescription) {
 
   def javaRewriteDecl(cls: ClassDef): Stat = q"""
     def rewrite(node: ${cls.typ}[Pre]): Unit = {
-      val builder = new RewriteBuilders.${cls.rewriteBuilderName}[Pre, Post](node)
+      val builder = new ${Init(cls.rewriteBuilderName, Name.Anonymous(), Nil)}[Pre, Post](node)
       rewrite(builder)
       ${ColDefs.scopes(ColDefs.DECLARATION_KINDS.find(info.supports(_)(cls.baseName)).get)}
         .succeed(node, builder.build())
@@ -25,12 +34,34 @@ case class ColHelperJavaRewriter(info: ColDescription) {
   """
 
   def javaRewriteBuilder(cls: ClassDef): Stat =
-    q"def rewrite(builder: RewriteBuilders.${cls.rewriteBuilderName}[Pre, Post]): Unit = {}"
+    q"def rewrite(builder: ${cls.rewriteBuilderName}[Pre, Post]): Unit = {}"
 
-  def make(): List[Stat] = List(q"""
+  def make(): List[(String, List[Stat])] = List("JavaRewriter" -> q"""
+    object JavaRewriter {
+      trait RWFunc[N[_] <: Node[_]] {
+        def apply[Pre, Post](node: N[Pre], rw: JavaRewriter[Pre, Post]): N[Post]
+      }
+
+      trait DeclRWFunc {
+        def apply[Pre, Post](node: Declaration[Pre], rw: JavaRewriter[Pre, Post]): Unit
+      }
+
+      ${Defn.Val(Nil,
+        List(Pat.Var(Term.Name(s"rewriteDefaultDeclarationLookupTable"))),
+        Some(t"Map[java.lang.Class[_], DeclRWFunc]"),
+        q"Map(..${info.defs.filter(cls => info.supports("Declaration")(cls.baseName)).map(makeDeclMapEntry).toList})",
+      )}
+
+      ..${info.families.map(family => Defn.Val(Nil,
+        List(Pat.Var(Term.Name(s"rewriteDefault${family}LookupTable"))),
+        Some(t"Map[java.lang.Class[_], RWFunc[${Type.Name(family)}]]"),
+        q"Map(..${info.defs.filter(cls => info.supports(family)(cls.baseName)).map(makeMapEntry(family)).toList})",
+      )).toList}
+    }
+
     abstract class JavaRewriter[Pre, Post] extends AbstractRewriter[Pre, Post] {
       def dispatch(decl: Declaration[Pre]): Unit =
-        ${NonemptyMatch("declaration dispatch", q"decl", info.defs.filter(cls => info.supports("Declaration")(cls.baseName)).map(dispatchCase).toList)}
+        JavaRewriter.rewriteDefaultDeclarationLookupTable(decl.getClass)(decl, this)
 
       ..${
         val elems = info.defs.filter(cls => info.supports("Declaration")(cls.baseName))
@@ -39,7 +70,7 @@ case class ColHelperJavaRewriter(info: ColDescription) {
 
       ..${info.families.map(family => q"""
         def dispatch(node: ${Type.Name(family)}[Pre]): ${Type.Name(family)}[Post] =
-          ${NonemptyMatch(s"$family dispatch", q"node", info.defs.filter(cls => info.supports(family)(cls.baseName)).map(dispatchCase).toList)}
+          JavaRewriter.${Term.Name(s"rewriteDefault${family}LookupTable")}(node.getClass)(node, this)
       """).toList}
 
       ..${info.families.flatMap(family => {
@@ -47,5 +78,5 @@ case class ColHelperJavaRewriter(info: ColDescription) {
         elems.map(javaRewrite(Type.Name(family))).toList ++ elems.map(javaRewriteBuilder).toList
       }).toList}
     }
-  """)
+  """.stats)
 }

--- a/project/ColHelperRewriteBuilders.scala
+++ b/project/ColHelperRewriteBuilders.scala
@@ -4,11 +4,11 @@ import scala.meta._
 
 case class ColHelperRewriteBuilders(info: ColDescription) {
   def builderVar(param: Term.Param): Stat =
-    q"var ${Pat.Var(Term.Name(param.name.value))}: Option[${MetaUtil.substituteTypeName("G", t"Post")(param.decltpe.get)}] = None"
+    q"var ${Pat.Var(Term.Name(param.name.value))}: Option[${ColHelperUtil.substituteTypeName("G", t"Post")(param.decltpe.get)}] = None"
 
   def setBuilderVar(param: Term.Param): Stat = {
     val term = Term.Name(param.name.value)
-    q"def $term(replacementValue: ${MetaUtil.substituteTypeName("G", t"Post")(param.decltpe.get)}): this.type = { $term = Some(replacementValue); this }"
+    q"def $term(replacementValue: ${ColHelperUtil.substituteTypeName("G", t"Post")(param.decltpe.get)}): this.type = { $term = Some(replacementValue); this }"
   }
 
   def builderMakeArg(param: Term.Param): Term = {
@@ -16,7 +16,7 @@ case class ColHelperRewriteBuilders(info: ColDescription) {
     q"$term.getOrElse(${info.rewriteDefault(q"subject.$term", param.decltpe.get)})"
   }
 
-  def rewriteBuilder(cls: ClassDef): Stat = q"""
+  def rewriteBuilder(cls: ClassDef): (String, List[Stat]) = cls.rewriteBuilderName.value -> List(q"""
     class ${cls.rewriteBuilderName}[Pre, Post](subject: ${cls.typ}[Pre])(implicit val rewriter: AbstractRewriter[Pre, Post]) {
       def build(): ${cls.typ}[Post] = {
         ${cls.make(cls.params.map(builderMakeArg), q"blame.getOrElse(subject.blame)", q"o.getOrElse(rewriter.dispatch(subject.o))")}
@@ -39,12 +39,7 @@ case class ColHelperRewriteBuilders(info: ColDescription) {
       ..${cls.params.map(setBuilderVar)}
       ..${cls.params.map(builderVar)}
     }
-  """
+  """)
 
-  def make(): List[Stat] = q"""
-    import RewriteHelpers._
-    object RewriteBuilders {
-      ..${info.defs.map(rewriteBuilder).toList}
-    }
-  """.stats
+  def make(): List[(String, List[Stat])] = info.defs.map(rewriteBuilder).toList
 }

--- a/project/ColHelperRewriteBuilders.scala
+++ b/project/ColHelperRewriteBuilders.scala
@@ -19,18 +19,18 @@ case class ColHelperRewriteBuilders(info: ColDescription) {
   def rewriteBuilder(cls: ClassDef): Stat = q"""
     class ${cls.rewriteBuilderName}[Pre, Post](subject: ${cls.typ}[Pre])(implicit val rewriter: AbstractRewriter[Pre, Post]) {
       def build(): ${cls.typ}[Post] = {
-        ${cls.make(cls.params.map(builderMakeArg), q"$BLAME_TERM.getOrElse(subject.$BLAME_TERM)", q"$ORIGIN_TERM.getOrElse(rewriter.dispatch(subject.$ORIGIN_TERM))")}
+        ${cls.make(cls.params.map(builderMakeArg), q"blame.getOrElse(subject.blame)", q"o.getOrElse(rewriter.dispatch(subject.o))")}
       }
 
-      var $ORIGIN_PAT: Option[Origin] = None
-      def $ORIGIN_TERM(replacementValue: Origin): this.type = { $ORIGIN_TERM = Some(replacementValue); this }
+      var o: Option[Origin] = None
+      def o(replacementValue: Origin): this.type = { o = Some(replacementValue); this }
 
       ..${
         cls.blameType match {
           case Some(t) =>
             q"""
-            var $BLAME_PAT: Option[$t] = None
-            def $BLAME_TERM(replacementValue: $t): this.type = { $BLAME_TERM = Some(replacementValue); this }
+            var blame: Option[$t] = None
+            def blame(replacementValue: $t): this.type = { blame = Some(replacementValue); this }
             """.stats
           case None => List()
         }

--- a/project/ColHelperRewriteHelpers.scala
+++ b/project/ColHelperRewriteHelpers.scala
@@ -11,6 +11,8 @@ case class ColHelperRewriteHelpers(info: ColDescription) {
 
   def makeRewriteHelperImpl(cls: ClassDef): (String, List[Stat]) = ("Rewrite" + cls.baseName + "Impl") -> List(q"""
     trait ${Type.Name("Rewrite" + cls.baseName + "Impl")}[Pre, Post] { this: RewriteHelpers.${cls.rewriteHelperName}[Pre, Post] =>
+      def rewriteDefault(): ${cls.typ}[Post] = rewrite()
+
       def rewrite(..${cls.params.map(rewriteHelperParam) ++
         cls.blameType.toSeq.map(t => Term.Param(Nil, q"blame", Some(t), Some(q"subject.blame"))) :+
         Term.Param(List(), q"o", Some(t"Origin"), Some(q"rewriter.dispatch(subject.o)"))}): ${cls.typ}[Post] = {

--- a/project/ColHelperRewriteHelpers.scala
+++ b/project/ColHelperRewriteHelpers.scala
@@ -12,10 +12,10 @@ case class ColHelperRewriteHelpers(info: ColDescription) {
   def makeRewriteHelper(cls: ClassDef): Stat = q"""
     implicit class ${cls.rewriteHelperName}[Pre, Post](val subject: ${cls.typ}[Pre])(implicit val rewriter: AbstractRewriter[Pre, Post]) {
       def rewrite(..${cls.params.map(rewriteHelperParam) ++
-        cls.blameType.toSeq.map(t => Term.Param(Nil, BLAME_TERM, Some(t), Some(q"subject.$BLAME_TERM"))) :+
-        Term.Param(List(), ORIGIN_TERM, Some(t"Origin"), Some(q"rewriter.dispatch(subject.o)"))}): ${cls.typ}[Post] = {
+        cls.blameType.toSeq.map(t => Term.Param(Nil, q"blame", Some(t), Some(q"subject.blame"))) :+
+        Term.Param(List(), q"o", Some(t"Origin"), Some(q"rewriter.dispatch(subject.o)"))}): ${cls.typ}[Post] = {
         ${ColDefs.DECLARATION_NAMESPACE.foldLeft(
-          cls.make(cls.params.map(p => Term.Name(p.name.value)), BLAME_TERM, q"o")
+          cls.make(cls.params.map(p => Term.Name(p.name.value)), q"blame", q"o")
         ){
           case (e, (kind, nodes)) if nodes.contains(cls.baseName) =>
             q"rewriter.${ColDefs.scopes(kind)}.scope { $e }"

--- a/project/ColHelperSubnodes.scala
+++ b/project/ColHelperSubnodes.scala
@@ -1,5 +1,5 @@
 import ColDefs._
-import MetaUtil.NonemptyMatch
+import ColHelperUtil.NonemptyMatch
 
 import scala.meta._
 
@@ -28,16 +28,15 @@ case class ColHelperSubnodes(info: ColDescription) {
       case Type.Name("Int") | Type.Name("String") | Type.Name("Boolean") | Type.Name("BigInt") | Type.Apply(Type.Name("Referrable"), List(Type.Name("G"))) | Type.Apply(Type.Name("Ref"), _) | Type.Name("ExpectedError") =>
         None
       case other =>
-        MetaUtil.fail(
+        ColHelperUtil.fail(
           s"Tried to derive the subnodes for unknown type: $other",
           node=Some(other)
         )
     }
 
-  def subnodeMapping(cls: ClassDef): Term = q"""
-    classOf[${cls.typ}[_]] -> ((anyNode: Node[_]) => {
-      val node = anyNode.asInstanceOf[${cls.typ}[_]]
-      ${
+  def subnodesObject(cls: ClassDef): (String, List[Stat]) = (cls.baseName + "Subnodes") -> List(q"""
+    object ${Term.Name(cls.baseName + "Subnodes")} {
+      def subnodes[G](node: ${cls.typ}[G]): Seq[Node[G]] = ${
         cls.params.zip(cls.params.map(param => subnodePatternByType(param.decltpe.get))).collect {
           case (param, Some(nodes)) => nodes(Term.Select(q"node", Term.Name(param.name.value)))
         } match {
@@ -45,14 +44,18 @@ case class ColHelperSubnodes(info: ColDescription) {
           case nonEmpty => nonEmpty.tail.foldLeft(nonEmpty.head)((left, right) => q"$left ++ $right")
         }
       }
-    })
+    }
+  """)
+
+  def subnodeMapping(cls: ClassDef): Term = q"""
+    classOf[${cls.typ}[_]] -> ((anyNode: Node[_]) => ${Term.Name(cls.baseName + "Subnodes")}.subnodes(anyNode.asInstanceOf[${cls.typ}[_]]))
   """
 
-  def make(): List[Stat] = List(q"""
+  def make(): List[(String, List[Stat])] = List("Subnodes" -> List(q"""
     object Subnodes {
       val subnodesLookupTable: Map[java.lang.Class[_], Node[_] => Seq[Node[_]]] = Map(..${info.defs.map(subnodeMapping).toList})
 
       def subnodes[G](node: Node[G]): Seq[Node[G]] = subnodesLookupTable(node.getClass)(node).asInstanceOf[Seq[Node[G]]]
     }
-  """)
+  """)) ++ info.defs.map(subnodesObject).toList
 }

--- a/project/ColHelperSubnodes.scala
+++ b/project/ColHelperSubnodes.scala
@@ -23,7 +23,7 @@ case class ColHelperSubnodes(info: ColDescription) {
           case Nil => None
           case x :: xs => Some(arg => xs.foldLeft(x(arg))((init, next) => q"$init ++ ${next(arg)}"))
         }
-      case Type.Apply(Type.Name(typ), List(Type.Name("G"))) if info.supports("NodeFamily")(typ) || info.supports(DECLARATION)(typ) =>
+      case Type.Apply(Type.Name(typ), List(Type.Name("G"))) if info.supports("NodeFamily")(typ) || info.supports("Declaration")(typ) =>
         Some(node => q"Seq($node)")
       case Type.Name("Int") | Type.Name("String") | Type.Name("Boolean") | Type.Name("BigInt") | Type.Apply(Type.Name("Referrable"), List(Type.Name("G"))) | Type.Apply(Type.Name("Ref"), _) | Type.Name("ExpectedError") =>
         None

--- a/project/ColHelperSuccessorsProvider.scala
+++ b/project/ColHelperSuccessorsProvider.scala
@@ -1,7 +1,7 @@
 import scala.meta._
 
 case class ColHelperSuccessorsProvider(info: ColDescription) {
-  def make(): List[Stat] = q"""
+  def make(): List[(String, List[Stat])] = List("SuccessorsProvider" -> q"""
     import vct.col.util.Scopes
     import scala.reflect.ClassTag
     import vct.col.ref.LazyRef
@@ -33,5 +33,5 @@ case class ColHelperSuccessorsProvider(info: ColDescription) {
           preTransform(decl).orElse(postTransform(decl, inner.computeSucc(decl)))
       """).toList}
     }
-  """.stats
+  """.stats)
 }

--- a/project/ColHelperUtil.scala
+++ b/project/ColHelperUtil.scala
@@ -1,6 +1,6 @@
 import scala.meta._
 
-object MetaUtil {
+object ColHelperUtil {
   def NonemptyMatch(context: String, expr: Term, cases: List[Case]): Term.Match = {
     if(cases.nonEmpty) Term.Match(expr, cases)
     else {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.1
+sbt.version=1.7.2

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,1 +1,1 @@
-libraryDependencies += "org.scalameta" %% "scalameta" % "4.4.9"
+libraryDependencies += "org.scalameta" %% "scalameta" % "4.4.9" withSources()

--- a/rewrite/src/main/java/vct/col/rewrite/DesugarPermissionOperators.scala
+++ b/rewrite/src/main/java/vct/col/rewrite/DesugarPermissionOperators.scala
@@ -2,7 +2,6 @@ package vct.col.rewrite
 
 import vct.col.ast._
 import vct.col.util.AstBuildHelpers._
-import RewriteBuilders._
 import vct.col.rewrite.DesugarPermissionOperators.{FramedArraySubscriptBlame, FramedPointerDerefBlame, PredicateValueError}
 import vct.col.origin.{ArrayInsufficientPermission, ArrayLocationError, ArraySubscriptError, Blame, FramedArrIndex, FramedArrLength, FramedArrLoc, IteratedArrayInjective, Origin, PointerBounds, PointerDerefError, PointerInsufficientPermission, PointerLocationError, PointerSubscriptError, PointsToDeref}
 import vct.col.origin.{FramedArrIndex, FramedArrLength, FramedPtrBlockLength, FramedPtrBlockOffset, FramedPtrOffset, IteratedArrayInjective, IteratedPtrInjective, Origin}

--- a/util/bench/bench-col-compilation.sh
+++ b/util/bench/bench-col-compilation.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+SCRIPT=$(realpath $0)
+BENCH=$(dirname $SCRIPT)
+UTIL=$(dirname $BENCH)
+ROOT=$(dirname $UTIL)
+
+rm -rf $ROOT/col/target
+(cd $ROOT; time sbt "col / compile")


### PR DESCRIPTION
Split out all functionality into separate files for all generated helpers. This marginally hurts compilation performance for the first build, but subsequently speeds up changes to `Node.scala` significantly.