### PR TITLE
Better support for static imports, fields, and methods

### DIFF
--- a/col/src/main/java/vct/col/resolve/Resolve.scala
+++ b/col/src/main/java/vct/col/resolve/Resolve.scala
@@ -32,7 +32,23 @@ case object ResolveTypes {
     case Program(decls, _) =>
       ctx.copy(stack=decls.flatMap(Referrable.from) +: ctx.stack)
     case ns: JavaNamespace[G] =>
-      ctx.copy(stack=ns.declarations.flatMap(Referrable.from) +: ctx.stack, namespace=Some(ns))
+      // Static imports need to be imported at this stage, because they influence how names are resolved.
+      // E.g.: in the expressio f.g, f is either a 1) variable, 2) parameter or 3) field. If none of those, it must be a
+      // 4) statically imported field or typename, or 5) a non-static imported typename. If it's not that, it's a package name.
+      // ctx.stack needs to be modified for this, and hence this importing is done in enterContext instead of in resolveOne.
+      val staticallyImportedTypes: Seq[Referrable[G]] = ns.imports.collect {
+        case imp @ JavaImport(/* static = */ true, JavaName(fullyQualifiedTypeName :+ staticMember), /* star = */ false) =>
+          val staticType = Java.findJavaTypeName(fullyQualifiedTypeName, ctx)
+            .getOrElse(throw NoSuchNameError("class", fullyQualifiedTypeName.mkString("."), imp))
+          Seq(Java.findStaticMember(staticType, staticMember)
+            .getOrElse(throw NoSuchNameError("static member", (fullyQualifiedTypeName :+ staticMember).mkString("."), imp)))
+        case imp @ JavaImport(/* static = */ true, JavaName(fullyQualifiedTypeName), /* star = */ true) =>
+          val typeName = Java.findJavaTypeName(fullyQualifiedTypeName, ctx)
+            .getOrElse(throw NoSuchNameError("class", fullyQualifiedTypeName.mkString("."), imp))
+          Java.getStaticMembers(typeName)
+        // Non-static imports are resolved on demand
+      }.flatten
+      ctx.copy(stack=(ns.declarations.flatMap(Referrable.from) ++ staticallyImportedTypes) +: ctx.stack, namespace=Some(ns))
     case decl: Declarator[G] =>
       ctx.copy(stack=decl.declarations.flatMap(Referrable.from) +: ctx.stack)
     case _ => ctx
@@ -40,12 +56,13 @@ case object ResolveTypes {
 
   // On static import: _definitely_ resolve type.
   // - If single: add one name to stack
-  // - Otherwise: add all static fields/methods/enum constants to stack
+  // - If wildcard: resolve, then add all static fields/methods/enum constants to stack
   // On JavaLocal:
   // - If variable, param, or field: leave empty.
   // - If available as static (wildcard) import: do not try to resolve as class
   // - If available as already imported type: done
   // - Otherwise: resolve, must be type that is not yet imported
+  // - Final otherwise: start of package name!
 
   def resolveOne[G](node: Node[G], ctx: TypeResolutionContext[G]): Unit = node match {
     case javaClass @ JavaNamedType(genericNames) =>
@@ -82,18 +99,34 @@ case object ResolveTypes {
       } else if (fqn.contains(Java.JAVA_LANG_CLASS)) {
         cls.pin = Some(JavaLangClass())
       }
-    case imp @ JavaImport(/* static = */ true, name, /* star = */ false) =>
-      Java.findJavaTypeName(name.names.init, ctx)
-        .getOrElse(throw NoSuchNameError("class", name.names.mkString("."), imp))
-    case imp @ JavaImport(/* static = */ true, name, /* star = */ true) =>
-      Java.findJavaTypeName(name.names, ctx)
-        .getOrElse(throw NoSuchNameError("class", name.names.mkString("."), imp))
-    case imp@JavaImport(/* static = */ false, name, /* star = */ false) =>
-      Java.findJavaTypeName(name.names, ctx)
-        .getOrElse(throw NoSuchNameError("class", name.names.mkString("."), imp))
-    case imp@JavaImport(/* static = */ false, pkg, /* star = */ true) =>
-      // TODO (RR): Pulls in everything, even though we prefer on demand...?
-      Java.findJavaTypeNamesInPackage(pkg.names, ctx)
+    case local: JavaLocal[G] =>
+      Java.findJavaName(local.name, ctx) match {
+        case Some(
+          _: RefVariable[G] | _: RefJavaField[G] | _: RefJavaLocalDeclaration[G] | // Regular names
+          _: RefJavaClass[G] | _: RefEnum[G] | _: RefEnumConstant[G] // Statically imported, or regular previously imported typename
+        ) => // Nothing to do. Local will get properly resolved next phase
+        case None =>
+          // Unknown what this local refers though. Try importing it as a type; otherwise, it's the start of a package
+          Java.findJavaTypeName(Seq(local.name), ctx)
+      }
+//    case imp @ JavaImport(/* static = */ true, name, /* star = */ false) =>
+//      val javaTypeName = Java.findJavaTypeName(name.names.init, ctx)
+//        .getOrElse(throw NoSuchNameError("class", name.names.mkString("."), imp))
+//      val staticDecls = javaTypeName match {
+//        case RefJavaClass(cls) => cls.decls.collect {
+//          case decl: JavaClassDeclaration[G] if decl.isStatic => decl
+//        }
+//      }
+//
+//    case imp @ JavaImport(/* static = */ true, name, /* star = */ true) =>
+//      Java.findJavaTypeName(name.names, ctx)
+//        .getOrElse(throw NoSuchNameError("class", name.names.mkString("."), imp))
+//    case imp@JavaImport(/* static = */ false, name, /* star = */ false) =>
+//      Java.findJavaTypeName(name.names, ctx)
+//        .getOrElse(throw NoSuchNameError("class", name.names.mkString("."), imp))
+//    case imp@JavaImport(/* static = */ false, pkg, /* star = */ true) =>
+//      // TODO (RR): Pulls in everything, even though we prefer on demand...?
+//      Java.findJavaTypeNamesInPackage(pkg.names, ctx)
     case _ =>
   }
 }
@@ -145,7 +178,19 @@ case object ResolveReferences {
 
   def enterContext[G](node: Node[G], ctx: ReferenceResolutionContext[G], inGPUKernel: Boolean = false): ReferenceResolutionContext[G] = (node match {
     case ns: JavaNamespace[G] => ctx
-      .copy(currentJavaNamespace=Some(ns)).declare(ns.declarations)
+      .copy(currentJavaNamespace=Some(ns))
+      .copy(stack = ns.imports.collect {
+        case imp @ JavaImport(/* static = */ true, JavaName(fullyQualifiedTypeName :+ staticMember), /* star = */ false) =>
+          val staticType = Java.findJavaTypeName(fullyQualifiedTypeName, ctx.asTypeResolutionContext)
+            .getOrElse(throw NoSuchNameError("class", fullyQualifiedTypeName.mkString("."), imp))
+          Seq(Java.findStaticMember(staticType, staticMember)
+            .getOrElse(throw NoSuchNameError("static member", (fullyQualifiedTypeName :+ staticMember).mkString("."), imp)))
+        case imp @ JavaImport(/* static = */ true, JavaName(fullyQualifiedTypeName), /* star = */ true) =>
+          val typeName = Java.findJavaTypeName(fullyQualifiedTypeName, ctx.asTypeResolutionContext)
+            .getOrElse(throw NoSuchNameError("class", fullyQualifiedTypeName.mkString("."), imp))
+          Java.getStaticMembers(typeName)
+      }.flatten +: ctx.stack)
+      .declare(ns.declarations)
     case cls: JavaClassOrInterface[G] => ctx
       .copy(currentJavaClass=Some(cls))
       .copy(currentThis=Some(RefJavaClass(cls)))
@@ -202,7 +247,13 @@ case object ResolveReferences {
     case local @ CLocal(name) =>
       local.ref = Some(C.findCName(name, ctx).getOrElse(throw NoSuchNameError("local", name, local)))
     case local @ JavaLocal(name) =>
-      local.ref = Some(Java.findJavaName(name, ctx).getOrElse(throw NoSuchNameError("local", name, local)))
+      local.ref = Some(
+        Java.findJavaName(name, ctx.asTypeResolutionContext)
+          .orElse(Java.findJavaTypeName(Seq(name), ctx.asTypeResolutionContext) match {
+              case Some(target: JavaNameTarget[G]) => Some(target)
+              case None => None
+          })
+          .getOrElse(RefUnloadedJavaNamespace(Seq(name))))
     case local @ PVLLocal(name) =>
       local.ref = Some(PVL.findName(name, ctx).getOrElse(throw NoSuchNameError("local", name, local)))
     case local @ Local(ref) =>

--- a/col/src/main/java/vct/col/resolve/lang/Java.scala
+++ b/col/src/main/java/vct/col/resolve/lang/Java.scala
@@ -1,5 +1,6 @@
 package vct.col.resolve.lang
 
+import com.typesafe.scalalogging.LazyLogging
 import hre.util.FuncTools
 import vct.col.ast.`type`.TFloats
 import vct.col.ast.{Any => _, Class => _, _}
@@ -15,7 +16,7 @@ import java.lang.reflect.{Modifier, Parameter}
 import scala.annotation.tailrec
 import scala.collection.mutable
 
-case object Java {
+case object Java extends LazyLogging {
   case class UnexpectedJreDefinition(expectedKind: String, fullyQualifiedName: Seq[String]) extends UserError {
     override def text: String = s"Did not get a $expectedKind when resolving $fullyQualifiedName"
     override def code: String = "unexpectedJreDefinition"
@@ -95,7 +96,7 @@ case object Java {
         ((t : JavaNamedType[_]).unsafeTransmuteGeneration[JavaNamedType, G] : JavaNamedType[G]).ref = Some(RefJavaClass(colClass))
       }
 
-      println(s"[warning] No specification was found for class ${potentialFQName.mkString(".")}, so a shim was loaded from the JRE.")
+      logger.warn(s"No specification was found for class ${potentialFQName.mkString(".")}, so a shim was loaded from the JRE.")
 
       Some(colClass)
     } catch {

--- a/rewrite/src/main/java/vct/col/rewrite/ConstantifyFinalFields.scala
+++ b/rewrite/src/main/java/vct/col/rewrite/ConstantifyFinalFields.scala
@@ -29,6 +29,7 @@ case class ConstantifyFinalFields[Pre <: Generation]() extends Rewriter[Pre] {
     case IntegerValue(_) => true
     case LiteralSeq(_, vals) => vals.forall(isAllowedValue)
     case FunctionInvocation(_, args, _, givenMap, _) => args.forall(isAllowedValue) && givenMap.forall { case (_, e) => isAllowedValue(e) }
+    case _ => false
   }
 
   override def dispatch(decl: Program[Pre]): Program[Post] = {

--- a/rewrite/src/main/java/vct/col/rewrite/lang/LangJavaToCol.scala
+++ b/rewrite/src/main/java/vct/col/rewrite/lang/LangJavaToCol.scala
@@ -330,7 +330,9 @@ case class LangJavaToCol[Pre <: Generation](rw: LangSpecificToCol[Pre]) extends 
       case RefAxiomaticDataType(decl) => throw NotAValue(local)
       case RefVariable(decl) => Local(rw.succ(decl))
       case RefUnloadedJavaNamespace(names) => throw NotAValue(local)
-      case RefJavaClass(decl) => throw NotAValue(local)
+      case RefJavaClass(decl) =>
+        FunctionInvocation(javaStaticsFunctionSuccessor.ref[Post, Function[Post]](decl), Seq(),
+          Seq(), Seq(), Seq())(TrueSatisfiable)
       case RefJavaField(decls, idx) =>
         if(decls.modifiers.contains(JavaStatic[Pre]())) {
           val classStaticsFunction: LazyRef[Post, Function[Post]] = new LazyRef(javaStaticsFunctionSuccessor(javaClassDeclToJavaClass(decls)))

--- a/src/main/universal/res/jdk/java/io/InputStream.java
+++ b/src/main/universal/res/jdk/java/io/InputStream.java
@@ -1,0 +1,5 @@
+package java.io;
+
+class InputStream {
+    public int read() throws IOException;
+}

--- a/src/main/universal/res/jdk/java/io/PrintStream.java
+++ b/src/main/universal/res/jdk/java/io/PrintStream.java
@@ -1,0 +1,9 @@
+package java.lang.io;
+
+class PrintStream {
+    /*@
+    ghost void println();
+    ghost void println(Object arg);
+    ghost void println(String arg);
+     @*/
+}

--- a/src/main/universal/res/jdk/java/lang/System.java
+++ b/src/main/universal/res/jdk/java/lang/System.java
@@ -1,0 +1,8 @@
+package java.lang;
+
+import java.io.PrintStream;
+
+class System {
+    public static final PrintStream out;
+    public static final PrintStream err;
+}

--- a/src/main/universal/res/jdk/java/lang/System.java
+++ b/src/main/universal/res/jdk/java/lang/System.java
@@ -1,8 +1,33 @@
 package java.lang;
 
 import java.io.PrintStream;
+import java.io.InputStream;
 
 class System {
     public static final PrintStream out;
     public static final PrintStream err;
+    public static final InputStream in;
+
+    /*@
+    ghost
+    ensures out != null ** err != null;
+    public void staticInvariant() {
+        //@ assume false;
+    }
+    */
+
+    //@ requires in != null;
+    public static void setIn(InputStream in) {
+        //@ assume false;
+    }
+
+    //@ requires out != null;
+    public static void setOut(PrintStream out) {
+        //@ assume false;
+    }
+
+    //@ requires err != null;
+    public static void setErr(PrintStream err) {
+        //@ assume false;
+    }
 }

--- a/src/test/scala/vct/test/integration/examples/TechnicalEnumSpec.scala
+++ b/src/test/scala/vct/test/integration/examples/TechnicalEnumSpec.scala
@@ -19,6 +19,17 @@ class Test {
 
 """
 
+  vercors should verify using silicon in "java/use builtin enums through static imports, without stating the actual type" java
+"""
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+class Test {
+    void m() {
+        //@ assert SOURCE != null;
+    }
+}
+"""
+
   vercors should verify using silicon in "java/use builtin enums" java
     """
       |import java.lang.annotation.RetentionPolicy;

--- a/src/test/scala/vct/test/integration/examples/TechnicalJavaSpec.scala
+++ b/src/test/scala/vct/test/integration/examples/TechnicalJavaSpec.scala
@@ -3,13 +3,14 @@ package vct.test.integration.examples
 import vct.test.integration.helper.VercorsSpec
 
 class TechnicalJavaSpec extends VercorsSpec {
-//  vercors should verify using silicon example "technical/java/JavaAnnotation.java"
-//  vercors should verify using silicon example "technical/java/JavaString.java"
+  vercors should verify using silicon example "technical/java/JavaAnnotation.java"
+  vercors should verify using silicon example "technical/java/JavaString.java"
 
   vercors should verify using silicon in "java.lang classes should be reachable without imports" java
 """
 class C {
   int m() {
+    //@ ghost System.staticInvariant();
     System.out.println("Hello world!");
     return Math.sqrt(2);
   }

--- a/src/test/scala/vct/test/integration/examples/TechnicalJavaSpec.scala
+++ b/src/test/scala/vct/test/integration/examples/TechnicalJavaSpec.scala
@@ -3,6 +3,16 @@ package vct.test.integration.examples
 import vct.test.integration.helper.VercorsSpec
 
 class TechnicalJavaSpec extends VercorsSpec {
-  vercors should verify using silicon example "technical/java/JavaAnnotation.java"
-  vercors should verify using silicon example "technical/java/JavaString.java"
+//  vercors should verify using silicon example "technical/java/JavaAnnotation.java"
+//  vercors should verify using silicon example "technical/java/JavaString.java"
+
+  vercors should verify using silicon in "java.lang classes should be reachable without imports" java
+"""
+class C {
+  int m() {
+    System.out.println("Hello world!");
+    return Math.sqrt(2);
+  }
+}
+""".stripMargin
 }

--- a/src/test/scala/vct/test/integration/examples/TechnicalJavaSpec.scala
+++ b/src/test/scala/vct/test/integration/examples/TechnicalJavaSpec.scala
@@ -1,5 +1,6 @@
 package vct.test.integration.examples
 
+import org.scalatest.flatspec.AnyFlatSpecLike
 import vct.test.integration.helper.VercorsSpec
 
 class TechnicalJavaSpec extends VercorsSpec {

--- a/src/test/scala/vct/test/integration/helper/VercorsSpec.scala
+++ b/src/test/scala/vct/test/integration/helper/VercorsSpec.scala
@@ -38,18 +38,6 @@ abstract class VercorsSpec extends AnyFlatSpecLike {
   case object ErrorVerdict
 
   private def registerTest(verdict: Verdict, desc: String, tags: Seq[Tag], backend: Backend, inputs: Seq[Readable]): Unit = {
-    // Reflection use for registertest!
-//    val fTrait = new AnyFlatSpecLike{}.getClass.getDeclaredFields.toList.find(_.getName.contains("engine")).get
-//    val f = this.getClass.getSuperclass.getDeclaredField(fTrait.getName)
-//    f.setAccessible(true)
-//    val engine = f.get(this)
-//    val engineClass = engine.getClass
-//    val method = engineClass.getSuperclass.getDeclaredMethods.toList.find(_.getName.contains("registerTest")).get
-//    method.setAccessible(true)
-//    method.invoke(engine,
-//      null
-//    )
-
     registerTest(s"${desc.capitalize} should $verdict with $backend", tags: _*) {
       LoggerFactory.getLogger("viper").asInstanceOf[Logger].setLevel(Level.OFF)
       LoggerFactory.getLogger("vct").asInstanceOf[Logger].setLevel(Level.INFO)

--- a/src/test/scala/vct/test/integration/helper/VercorsSpec.scala
+++ b/src/test/scala/vct/test/integration/helper/VercorsSpec.scala
@@ -18,7 +18,7 @@ import vct.result.VerificationError.UserError
 
 import java.nio.file.{Path, Paths}
 
-abstract class VercorsSpec extends AnyFlatSpec {
+abstract class VercorsSpec extends AnyFlatSpecLike {
   var coveredExamples: Seq[Path] = Nil
 
   sealed trait Verdict {
@@ -38,6 +38,18 @@ abstract class VercorsSpec extends AnyFlatSpec {
   case object ErrorVerdict
 
   private def registerTest(verdict: Verdict, desc: String, tags: Seq[Tag], backend: Backend, inputs: Seq[Readable]): Unit = {
+    // Reflection use for registertest!
+//    val fTrait = new AnyFlatSpecLike{}.getClass.getDeclaredFields.toList.find(_.getName.contains("engine")).get
+//    val f = this.getClass.getSuperclass.getDeclaredField(fTrait.getName)
+//    f.setAccessible(true)
+//    val engine = f.get(this)
+//    val engineClass = engine.getClass
+//    val method = engineClass.getSuperclass.getDeclaredMethods.toList.find(_.getName.contains("registerTest")).get
+//    method.setAccessible(true)
+//    method.invoke(engine,
+//      null
+//    )
+
     registerTest(s"${desc.capitalize} should $verdict with $backend", tags: _*) {
       LoggerFactory.getLogger("viper").asInstanceOf[Logger].setLevel(Level.OFF)
       LoggerFactory.getLogger("vct").asInstanceOf[Logger].setLevel(Level.INFO)


### PR DESCRIPTION
This PR refactors Resolution & ResolveTypes so it's possible to distinguish between local names and imported names and types. This also allows static method calls like `System.sqrt` to work.

It was a problem that vercors could not derive that `System.out` is non-null, which is guaranteed by the JVM. ~This information can be encoded on a case by case basis (some sort of static field annotation) or by generalizing this use case (some sort of static class (for System.out) and/or immutable class (for java.lang.String) invariant).~ This problem was solved ad-hoc by assuming this information where it is needed.
