### PR TITLE
Move ConstantifyFinalFields up 

### DIFF
--- a/src/main/java/vct/main/stages/Transformation.scala
+++ b/src/main/java/vct/main/stages/Transformation.scala
@@ -196,12 +196,16 @@ case class SilverTransformation
     // Encode proof helpers
     EncodeProofHelpers,
 
+    // Make final fields constant functions. Explicitly before ResolveExpressionSideEffects, because that pass will
+    // flatten out functions in the rhs of assignments, making it harder to detect final field assignments where the
+    // value is pure and therefore be put in the contract of the constant function.
+    ConstantifyFinalFields,
+
     // Resolve side effects including method invocations, for encodetrythrowsignals.
     ResolveExpressionSideEffects,
     EncodeTryThrowSignals,
 
     // No more classes
-    ConstantifyFinalFields,
     ClassToRef,
 
     CheckContractSatisfiability.withArg(checkSat),


### PR DESCRIPTION
This is done so information removed by ResolveExpressionSideEffects is still present.