### PR TITLE
Parallel block syntax

### DIFF
--- a/col/src/main/java/vct/col/ast/family/parregion/ParBlockImpl.scala
+++ b/col/src/main/java/vct/col/ast/family/parregion/ParBlockImpl.scala
@@ -2,11 +2,12 @@ package vct.col.ast.family.parregion
 
 import vct.col.ast.util.Declarator
 import vct.col.ast.{Declaration, Expr, Local, ParBlock, Starall, Variable}
+import vct.col.check.CheckContext
 import vct.col.origin.{Blame, ReceiverNotInjective}
 import vct.col.util.AstBuildHelpers._
 import vct.col.util.Substitute
 
-trait ParBlockImpl[G] extends Declarator[G] { this: ParBlock[G] =>
+trait ParBlockImpl[G] extends ParRegionImpl[G] with Declarator[G] { this: ParBlock[G] =>
   override def declarations: Seq[Declaration[G]] = iters.map(_.variable)
 
   def quantify(expr: Expr[G], blame: Blame[ReceiverNotInjective]): Expr[G] = {
@@ -17,4 +18,8 @@ trait ParBlockImpl[G] extends Declarator[G] { this: ParBlock[G] =>
       Starall(Seq(v), Nil, (iter.from <= v.get && v.get < iter.to) ==> body)(blame)
     })
   }
+
+  override def enterCheckContext(context: CheckContext[G]): CheckContext[G] =
+    context.copy(roScopes = context.scopes.size, roScopeReason = Some(this)).withScope(declarations.toSet)
+
 }

--- a/examples/archive/known-problems/822/ParallelGCD.pvl
+++ b/examples/archive/known-problems/822/ParallelGCD.pvl
@@ -45,6 +45,7 @@ class ParallelGCD {
     F.split(1\2, F.tx(), 1\2, F.ty());
 
     invariant inv(HPerm(F.x,write) ** HPerm(F.y,write) ** F.x > 0 ** F.y > 0) {
+      Parallel {
       par T0
       requires F.state(1\2, F.tx());
       ensures F.state(1\2, empty);
@@ -64,7 +65,7 @@ class ParallelGCD {
           }
         }
       }
-      and T1
+      par T1
       requires F.state(1\2,F.ty());
       ensures F.state(1\2,empty);
       {
@@ -87,6 +88,7 @@ class ParallelGCD {
             }
           }
         }
+      }
       }
     }
 

--- a/examples/archive/known-problems/840/binary-trees.pvl
+++ b/examples/archive/known-problems/840/binary-trees.pvl
@@ -38,18 +38,22 @@ class Main {
         s.check();
         //  System.out.println("stretch tree of depth " + s.stretchDepth + "\t check: "  +  s.check);
         l.init();
-        par 
-        context Perm(a,1\2) ** Perm(a.check,1) ** Perm(a.index,1) ** Perm(a.depth,1\2) ** Perm(a.MIN_DEPTH,1\2) ** Perm(a.iterations,1\2) ** a.iterations > 0;
-        {
-            a.check();
-        } and 
-        context Perm(b,1\2) ** Perm(b.check,1) ** Perm(b.index,1) ** Perm(b.depth,1\2) ** Perm(b.MIN_DEPTH,1\2) ** Perm(b.iterations,1\2) ** b.iterations > 0;
-        {
-            b.check();
-        }  and 
-        context Perm(c,1\2) ** Perm(c.check,1) ** Perm(c.index,1) ** Perm(c.depth,1\2) ** Perm(c.MIN_DEPTH,1\2) ** Perm(c.iterations,1\2) ** c.iterations > 0;
-        {
-            c.check();
+        parallel {
+            par
+            context Perm(a,1\2) ** Perm(a.check,1) ** Perm(a.index,1) ** Perm(a.depth,1\2) ** Perm(a.MIN_DEPTH,1\2) ** Perm(a.iterations,1\2) ** a.iterations > 0;
+            {
+                a.check();
+            }
+            par
+            context Perm(b,1\2) ** Perm(b.check,1) ** Perm(b.index,1) ** Perm(b.depth,1\2) ** Perm(b.MIN_DEPTH,1\2) ** Perm(b.iterations,1\2) ** b.iterations > 0;
+            {
+                b.check();
+            }
+            par
+            context Perm(c,1\2) ** Perm(c.check,1) ** Perm(c.index,1) ** Perm(c.depth,1\2) ** Perm(c.MIN_DEPTH,1\2) ** Perm(c.iterations,1\2) ** c.iterations > 0;
+            {
+                c.check();
+            }
         }
         //System.out.println(a.iterations + "\t trees of depth " + a.depth + "\t check: " + a.check);
         //System.out.println(b.iterations + "\t trees of depth " + b.depth + "\t check: " + b.check);

--- a/examples/archive/known-problems/840/k-nucleotide-2.pvl
+++ b/examples/archive/known-problems/840/k-nucleotide-2.pvl
@@ -26,15 +26,19 @@ class Main {
         m01.sequence = fr.sequence;
         m02.sequence = fr.sequence;
         m12.sequence = fr.sequence;
-        par
-        {
-            m01.result = m01.createFragmentMap(m01.sequence, m01.offset,m01.fragmentLength);            
-        } and
-        {
-            m02.result = m02.createFragmentMap(m02.sequence, m02.offset,m02.fragmentLength);
-        } and 
-        {
-            m12.result = m12.createFragmentMap(m12.sequence, m12.offset,m12.fragmentLength);
+        parallel {
+            par
+            {
+                m01.result = m01.createFragmentMap(m01.sequence, m01.offset,m01.fragmentLength);
+            }
+            par
+            {
+                m02.result = m02.createFragmentMap(m02.sequence, m02.offset,m02.fragmentLength);
+            }
+            par
+            {
+                m12.result = m12.createFragmentMap(m12.sequence, m12.offset,m12.fragmentLength);
+            }
         }
         w1.totalCount = fr.sequence.length;
         w1.frequencies = m01.result;

--- a/examples/archive/known-problems/840/k-nucleotide-3.pvl
+++ b/examples/archive/known-problems/840/k-nucleotide-3.pvl
@@ -37,24 +37,32 @@ class Main {
         m03.sequence = fr.sequence;
         m13.sequence = fr.sequence;
         m23.sequence = fr.sequence;
-        par
-        {
-            m01.result = m01.createFragmentMap(m01.sequence, m01.offset,m01.fragmentLength);            
-        } and
-        {
-            m02.result = m02.createFragmentMap(m02.sequence, m02.offset,m02.fragmentLength);
-        } and 
-        {
-            m12.result = m12.createFragmentMap(m12.sequence, m12.offset,m12.fragmentLength);
-        } and 
-        {
-            m03.result = m03.createFragmentMap(m03.sequence, m03.offset,m03.fragmentLength);
-        } and 
-        {
-            m13.result = m13.createFragmentMap(m13.sequence, m13.offset,m13.fragmentLength);
-        } and 
-        {
-            m23.result = m23.createFragmentMap(m23.sequence, m23.offset,m23.fragmentLength);
+        parallel
+            {
+            par
+            {
+                m01.result = m01.createFragmentMap(m01.sequence, m01.offset,m01.fragmentLength);
+            }
+            par
+            {
+                m02.result = m02.createFragmentMap(m02.sequence, m02.offset,m02.fragmentLength);
+            }
+            par
+            {
+                m12.result = m12.createFragmentMap(m12.sequence, m12.offset,m12.fragmentLength);
+            }
+            par
+            {
+                m03.result = m03.createFragmentMap(m03.sequence, m03.offset,m03.fragmentLength);
+            }
+            par
+            {
+                m13.result = m13.createFragmentMap(m13.sequence, m13.offset,m13.fragmentLength);
+            }
+            par
+            {
+                m23.result = m23.createFragmentMap(m23.sequence, m23.offset,m23.fragmentLength);
+            }
         }
         w1.totalCount = fr.sequence.length;
         w1.frequencies = m01.result;

--- a/examples/archive/known-problems/840/k-nucleotide-4.pvl
+++ b/examples/archive/known-problems/840/k-nucleotide-4.pvl
@@ -45,36 +45,38 @@ class Main {
         m14.sequence = fr.sequence;
         m24.sequence = fr.sequence;
         m34.sequence = fr.sequence;
-        par
-        {
-            m01.result = m01.createFragmentMap(m01.sequence, m01.offset,m01.fragmentLength);            
-        } and
-        {
-            m02.result = m02.createFragmentMap(m02.sequence, m02.offset,m02.fragmentLength);
-        } and 
-        {
-            m12.result = m12.createFragmentMap(m12.sequence, m12.offset,m12.fragmentLength);
-        } and 
-        {
-            m03.result = m03.createFragmentMap(m03.sequence, m03.offset,m03.fragmentLength);
-        } and 
-        {
-            m13.result = m13.createFragmentMap(m13.sequence, m13.offset,m13.fragmentLength);
-        } and 
-        {
-            m23.result = m23.createFragmentMap(m23.sequence, m23.offset,m23.fragmentLength);
-        } and 
-        {
-            m04.result = m04.createFragmentMap(m04.sequence, m04.offset,m04.fragmentLength);
-        } and 
-        {
-            m14.result = m14.createFragmentMap(m14.sequence, m14.offset,m14.fragmentLength);
-        } and 
-        {
-            m24.result = m24.createFragmentMap(m24.sequence, m24.offset,m24.fragmentLength);
-        } and 
-        {
-            m34.result = m34.createFragmentMap(m34.sequence, m34.offset,m34.fragmentLength);
+        parallel {
+            par
+            {
+                m01.result = m01.createFragmentMap(m01.sequence, m01.offset,m01.fragmentLength);
+            } par
+            {
+                m02.result = m02.createFragmentMap(m02.sequence, m02.offset,m02.fragmentLength);
+            } par
+            {
+                m12.result = m12.createFragmentMap(m12.sequence, m12.offset,m12.fragmentLength);
+            } par
+            {
+                m03.result = m03.createFragmentMap(m03.sequence, m03.offset,m03.fragmentLength);
+            } par
+            {
+                m13.result = m13.createFragmentMap(m13.sequence, m13.offset,m13.fragmentLength);
+            } par
+            {
+                m23.result = m23.createFragmentMap(m23.sequence, m23.offset,m23.fragmentLength);
+            } par
+            {
+                m04.result = m04.createFragmentMap(m04.sequence, m04.offset,m04.fragmentLength);
+            } par
+            {
+                m14.result = m14.createFragmentMap(m14.sequence, m14.offset,m14.fragmentLength);
+            } par
+            {
+                m24.result = m24.createFragmentMap(m24.sequence, m24.offset,m24.fragmentLength);
+            } par
+            {
+                m34.result = m34.createFragmentMap(m34.sequence, m34.offset,m34.fragmentLength);
+            }
         }
         w1.totalCount = fr.sequence.length;
         w1.frequencies = m01.result;

--- a/examples/archive/known-problems/840/paperscissorsrock.pvl
+++ b/examples/archive/known-problems/840/paperscissorsrock.pvl
@@ -50,33 +50,37 @@ class SeqProgram {
 		loop_invariant b.i - a.i <= 5;
 		loop_invariant a.draw() == b.draw() && b.draw() == c.draw();
 		while(a.draw() && b.draw() && c.draw()) {
-			par 
-			ensures a.i == \old(a.i) - 1;
-			ensures a.x == (\old(a.i) % 2 == 1 ? 1 : 0);
-			ensures b.x == a.x && c.x == a.x; 
-			{
-				a.x = a.i % 2 == 1 ? 1 : 0;
-				a.i = a.i-1;
-				b.x = a.x;
-				c.x = a.x;
-			} and
-			ensures b.i == \old(b.i) + 1;
-			ensures b.y == (\old(b.i) == 5 ? 0 : 1);
-			ensures b.y == a.y && b.y == c.y;
-			{
-				b.y = b.i == 5 ? 0 : 1;
-				b.i = b.i +1;
-				a.y = b.y;
-				c.y = b.y;
-			} and
-			context Perm( c.i , 1 );
-			ensures c.z == 2;
-			ensures c.z == a.z && c.z == b.z;
-			{
-				c.z = 2;
-				a.z = c.z;
-				b.z = c.z; //typo in paper hier
-			}
+			parallel {
+                par
+                ensures a.i == \old(a.i) - 1;
+                ensures a.x == (\old(a.i) % 2 == 1 ? 1 : 0);
+                ensures b.x == a.x && c.x == a.x;
+                {
+                    a.x = a.i % 2 == 1 ? 1 : 0;
+                    a.i = a.i-1;
+                    b.x = a.x;
+                    c.x = a.x;
+                }
+                par
+                ensures b.i == \old(b.i) + 1;
+                ensures b.y == (\old(b.i) == 5 ? 0 : 1);
+                ensures b.y == a.y && b.y == c.y;
+                {
+                    b.y = b.i == 5 ? 0 : 1;
+                    b.i = b.i +1;
+                    a.y = b.y;
+                    c.y = b.y;
+                }
+                par
+                context Perm( c.i , 1 );
+                ensures c.z == 2;
+                ensures c.z == a.z && c.z == b.z;
+                {
+                    c.z = 2;
+                    a.z = c.z;
+                    b.z = c.z; //typo in paper hier
+                }
+            }
 		}
 	}
 	

--- a/examples/archive/known-problems/840/parallel_while.pvl
+++ b/examples/archive/known-problems/840/parallel_while.pvl
@@ -30,18 +30,22 @@ class SeqProgram {
 	requires b.x - c.x == c.x - a.x;
 	ensures a.x == b.x && b.x == c.x; 
 	run {
-		par
-		ensures b.left == a.x;
-		{
-				b.left = a.x;
-		} and
-		ensures c.left == b.x;
-		{
-				c.left = b.x;
-		} and
-		ensures a.left == c.x;
-		{
-				a.left = c.x;
+		parallel {
+            par
+            ensures b.left == a.x;
+            {
+                    b.left = a.x;
+            }
+            par
+            ensures c.left == b.x;
+            {
+                    c.left = b.x;
+            }
+            par
+            ensures a.left == c.x;
+            {
+                    a.left = c.x;
+            }
 		}
 		
 		loop_invariant b.x - c.x == c.x - a.x;
@@ -49,22 +53,26 @@ class SeqProgram {
 		loop_invariant (a.left != a.x) == (b.left != b.x);
 		loop_invariant (b.left != b.x) == (c.left != c.x);
 		while(a.left != a.x && b.left != b.x && c.left != c.x) {
-			par
-			ensures a.x == \old(a.x) + 1;
-			ensures b.left == a.x;
-			{
-				a.x = a.x + 1;
-				b.left = a.x;
-			} and
-			ensures b.x == \old(b.x) - 1;
-			ensures c.left == b.x;
-			{
-				b.x = b.x - 1;
-				c.left = b.x;
-			} and
-			ensures a.left == c.x;
-			{ 
-				a.left = c.x;
+			parallel {
+			    par
+                ensures a.x == \old(a.x) + 1;
+                ensures b.left == a.x;
+                {
+                    a.x = a.x + 1;
+                    b.left = a.x;
+                }
+                par
+                ensures b.x == \old(b.x) - 1;
+                ensures c.left == b.x;
+                {
+                    b.x = b.x - 1;
+                    c.left = b.x;
+                }
+                par
+                ensures a.left == c.x;
+                {
+                    a.left = c.x;
+                }
 			}
 		}
 	}

--- a/examples/archive/known-problems/840/spectral-norm.pvl
+++ b/examples/archive/known-problems/840/spectral-norm.pvl
@@ -92,41 +92,49 @@ class Main {
     }
     
     void aTimesTransp() {
-         par
-        { 
+        parallel {
+            par
+            {
             t0.initv();
             t0.runn();
             c.t0 = t0.v;
-            
-        } and 
-        {
+
+            }
+            par
+            {
             t1.initv();
             t1.runn();
             c.t1 = t1.v;
-        } and 
-        {
+            }
+            par
+            {
             t2.initv();
             t2.runn();
             c.t1 = t1.v;
+            }
         }
         c.flatten(); // x in c.result
-        par
-        {
-            t0.initv();
-            t0.u = c.result;
-            t0.runn();
-            c.t0 = t0.v;
-        } and
-        {
-            t1.initv();
-            t1.u = c.result;
-            t1.runn();
-            c.t1 = t1.v;
-        } and {
-            t2.initv();
-            t2.u = c.result;
-            t2.runn();
-            c.t2 = t2.v;
+       parallel {
+            par
+            {
+                t0.initv();
+                t0.u = c.result;
+                t0.runn();
+                c.t0 = t0.v;
+            }
+            par
+            {
+                t1.initv();
+                t1.u = c.result;
+                t1.runn();
+                c.t1 = t1.v;
+            }
+            par {
+                t2.initv();
+                t2.u = c.result;
+                t2.runn();
+                c.t2 = t2.v;
+            }
         }
         c.flatten(); // v in c.result
     }

--- a/examples/concepts/futures/counteradd_2.pvl
+++ b/examples/concepts/futures/counteradd_2.pvl
@@ -33,22 +33,24 @@ class Program {
 		f.split(1\2, f.decr(), 1\2, f.decr());
 
 		invariant lockinv(HPerm(f.counter, write) ** HPerm(f.step, 1\2)) {
-			par T0
-      requires f.state(1\2, f.decr());
-      ensures f.state(1\2, empty);
-			{
-				atomic(lockinv) {
-					action(f, 1\2, empty, f.decr()) { f.counter = f.counter - f.step; }
-				}
-			}
-			and T1
-      requires f.state(1\2, f.decr());
-      ensures f.state(1\2, empty);
-			{
-				atomic(lockinv) {
-					action(f, 1\2, empty, f.decr()) { f.counter = f.counter - f.step; }
-				}
-			}
+		    parallel {
+                par T0
+                requires f.state(1\2, f.decr());
+                ensures f.state(1\2, empty);
+                {
+                    atomic(lockinv) {
+                        action(f, 1\2, empty, f.decr()) { f.counter = f.counter - f.step; }
+                    }
+                }
+                par T1
+                requires f.state(1\2, f.decr());
+                ensures f.state(1\2, empty);
+                {
+                    atomic(lockinv) {
+                        action(f, 1\2, empty, f.decr()) { f.counter = f.counter - f.step; }
+                    }
+                }
+            }
 		}
 
 		f.merge(1\2, empty, 1\2, empty);

--- a/examples/concepts/futures/unequalcounting.pvl
+++ b/examples/concepts/futures/unequalcounting.pvl
@@ -31,21 +31,24 @@ class Program {
 		f.split(1\2, f.plus(n), 1\2, f.mult(n));
 		
 		invariant lockinv(HPerm(f.counter, write)) {
-			par T0
-      requires f.state(1\2, f.plus(n));
-      ensures f.state(1\2, empty);
+		    parallel
 			{
-				atomic(lockinv) {
-					action(f, 1\2, empty, f.plus(n)) { f.counter = f.counter + n; }
-				}
-			}
-			and T1
-      requires f.state(1\2, f.mult(n));
-      ensures f.state(1\2, empty);
-			{
-				atomic(lockinv) {
-					action(f, 1\2, empty, f.mult(n)) { f.counter = f.counter * n; }
-				}
+                par T0
+                requires f.state(1\2, f.plus(n));
+                ensures f.state(1\2, empty);
+                {
+                atomic(lockinv) {
+                    action(f, 1\2, empty, f.plus(n)) { f.counter = f.counter + n; }
+                }
+                }
+                par T1
+                requires f.state(1\2, f.mult(n));
+                ensures f.state(1\2, empty);
+                {
+                    atomic(lockinv) {
+                        action(f, 1\2, empty, f.mult(n)) { f.counter = f.counter * n; }
+                    }
+                }
 			}
 		}
 		

--- a/examples/concepts/parallel/ParBothRead.pvl
+++ b/examples/concepts/parallel/ParBothRead.pvl
@@ -11,17 +11,19 @@ class C {
     void m() {
         int x = 3;
         int x_old = x;
-        par
-            context Perm(a, write);
-            ensures a == 2 * x;
-        {
-            a = 2 * x;
-        }
-        and
-            context Perm(b, write);
-            ensures b == 3 * x;
-        {
-            b = 3 * x;
+        parallel {
+            par
+                context Perm(a, write);
+                ensures a == 2 * x;
+            {
+                a = 2 * x;
+            }
+            par
+                context Perm(b, write);
+                ensures b == 3 * x;
+            {
+                b = 3 * x;
+            }
         }
 
         assert x == x_old;

--- a/examples/concepts/parallel/ParBothWrite.pvl
+++ b/examples/concepts/parallel/ParBothWrite.pvl
@@ -6,12 +6,15 @@
 class C {
     void m() {
         int x;
-        par
-        {
-            x = 1;
-        } and
-        {
-            x = 2;
+        parallel {
+            par
+            {
+                x = 1;
+            }
+            par
+            {
+                x = 2;
+            }
         }
     }
 }

--- a/examples/concepts/parallel/ParNestedInvariant.pvl
+++ b/examples/concepts/parallel/ParNestedInvariant.pvl
@@ -11,26 +11,27 @@ class C {
     void m() {
         int x = 10;
         int x_old = x;
-        par
-            context Perm(a, write);
-            requires x > 0;
-            ensures a > 0;
-        {
-            a = x;
-        }
-        and
-            context Perm(b, write);
-            requires x > 3;
-            ensures b > 3;
-        {
-            invariant inv(x > 3) {
-                atomic(inv) {
-                    assert x > 3;
-                    b = x;
+        parallel {
+            par
+                context Perm(a, write);
+                requires x > 0;
+                ensures a > 0;
+            {
+                a = x;
+            }
+            par
+                context Perm(b, write);
+                requires x > 3;
+                ensures b > 3;
+            {
+                invariant inv(x > 3) {
+                    atomic(inv) {
+                        assert x > 3;
+                        b = x;
+                    }
                 }
             }
         }
-
         assert x == x_old;
         assert a > 0;
         assert b > 3;

--- a/examples/concepts/parallel/ParNestedInvariantWrite.pvl
+++ b/examples/concepts/parallel/ParNestedInvariantWrite.pvl
@@ -6,15 +6,17 @@
 class C {
     void m() {
         boolean b = true;
-        par
-        {
-            b = false;
-        }
-        and
-            requires b;
-        {
-            invariant inv(b) {
-                atomic(inv) { }
+        parallel {
+            par
+            {
+                b = false;
+            }
+            par
+                requires b;
+            {
+                invariant inv(b) {
+                    atomic(inv) { }
+                }
             }
         }
     }

--- a/examples/concepts/parallel/block-par.pvl
+++ b/examples/concepts/parallel/block-par.pvl
@@ -8,6 +8,7 @@ class Ref {
   
   context Perm(x,1)**Perm(y,1)**Perm(z,1\2)**x+y==z;
   void main(int c){
+  parallel{
     par
       context Perm(x,1);
       requires x == \old(x);
@@ -15,12 +16,13 @@ class Ref {
     {
       x=x+c;
     }
-    and
+    par
       context Perm(y,1);
       requires y == \old(y);
       ensures y == \old(y)-c;
     {
       y=y-c;
     }
+  }
   }
 }

--- a/examples/concepts/parallel/parallel-example1.pvl
+++ b/examples/concepts/parallel/parallel-example1.pvl
@@ -14,13 +14,13 @@ class test {
     int[10] z=new int[10];
 
     sequential {
-      block fst(int i=0..10)
+      par fst(int i=0..10)
       context Perm(x[i],1) ** Perm(y[i],1) ** Perm(z[i],1);
       {
         x[i]=z[i];
         x[i]=0;
       }
-      block snd(int j=0..10)
+      par snd(int j=0..10)
       context Perm(y[j],1);
       context Perm(z[j],1);
       {

--- a/examples/concepts/parallel/zero-many.pvl
+++ b/examples/concepts/parallel/zero-many.pvl
@@ -18,23 +18,25 @@ class ZeroMany {
             (\forall int j3 ; 0 <= j3 && j3 < N ;
               matrix[i3][j3]==0));
   void initialise(int M, int N, int[N] ar, int[M][N] matrix){
-    par
-      context Perm(x,1);
-      ensures x==0;
-    {
-      x=0;
-    }
-    and (int i = 0 .. N)
-      context Perm(ar[i],write);
-      ensures ar[i]==0;
-    {
-      ar[i]=0;
-    }
-    and (int i=0..M,int j=0..N)
-      context Perm(matrix[i][j],write);
-      ensures matrix[i][j]==0;
-    {
-      matrix[i][j]=0;
+    parallel {
+      par
+        context Perm(x,1);
+        ensures x==0;
+      {
+        x=0;
+      }
+      par (int i = 0 .. N)
+        context Perm(ar[i],write);
+        ensures ar[i]==0;
+      {
+        ar[i]=0;
+      }
+      par (int i=0..M,int j=0..N)
+        context Perm(matrix[i][j],write);
+        ensures matrix[i][j]==0;
+      {
+        matrix[i][j]=0;
+      }
     }
   }
 

--- a/examples/demo/demo4.pvl
+++ b/examples/demo/demo4.pvl
@@ -39,23 +39,24 @@ class Program {
 			assert m.state(1\2, m.incr()) ** m.state(1\2, m.incr()); // now we are left with this
 
 			// fork and join both threads, and distribute the model accordingly
-			par Thread1
-      requires m.state(1\2, m.incr());
-      ensures m.state(1\2, empty);
-			{
-				atomic (inv) {
-					action(m, 1\2, empty, m.incr()) { m.x = m.x + 2; }
-				}
-			}
-			and Thread2
-      requires m.state(1\2, m.incr());
-      ensures m.state(1\2, empty);
-			{
-				atomic (inv) {
-					action(m, 1\2, empty, m.incr()) { m.x = m.x + 2; }
-				}
-			}
-
+			parallel {
+                par Thread1
+                    requires m.state(1\2, m.incr());
+                    ensures m.state(1\2, empty);
+                        {
+                            atomic (inv) {
+                                action(m, 1\2, empty, m.incr()) { m.x = m.x + 2; }
+                            }
+                        }
+                par Thread2
+                requires m.state(1\2, m.incr());
+                ensures m.state(1\2, empty);
+                {
+                    atomic (inv) {
+                        action(m, 1\2, empty, m.incr()) { m.x = m.x + 2; }
+                    }
+                }
+            }
 			assert m.state(1\2, empty) ** m.state(1\2, empty); // after both threads have terminated, we are left with this
 			m.merge(1\2, empty, 1\2, empty); // we may merge the two models back into one again
 			assert m.state(1, empty); // which gives us this

--- a/parsers/lib/antlr4/LangPVLParser.g4
+++ b/parsers/lib/antlr4/LangPVLParser.g4
@@ -187,18 +187,9 @@ forStatementList
 parRegion
  : 'parallel' '{' parRegion* '}' # pvlParallel
  | 'sequential' '{' parRegion* '}' # pvlSequential
- | 'block' identifier? parBlockIter? contract statement # pvlParBlock
- | 'par' parOldUnitList # pvlOldPar
+ | 'par' identifier? parBlockIter? contract statement # pvlParBlock
  ;
 
-parOldUnit
- : identifier? parBlockIter? contract statement # pvlOldParUnit
- ;
-
-parOldUnitList
- : parOldUnit
- | parOldUnit 'and' parOldUnitList
- ;
 
 
 declList

--- a/parsers/src/main/java/vct/parsers/transform/PVLToCol.scala
+++ b/parsers/src/main/java/vct/parsers/transform/PVLToCol.scala
@@ -342,7 +342,6 @@ case class PVLToCol[G](override val originProvider: OriginProvider, override val
           case None => new ParBlockDecl[G]()
           case Some(name) => new ParBlockDecl[G]()(SourceNameOrigin(convert(name), origin(region)))
         }
-
         ParBlock(
           decl,
           iter.map(convert(_)).getOrElse(Nil),
@@ -351,31 +350,6 @@ case class PVLToCol[G](override val originProvider: OriginProvider, override val
           AstBuildHelpers.foldStar(contract.consume(contract.ensures)),
           convert(impl),
         )(blame(region))
-      })
-    case PvlOldPar(_, pars) => ParParallel(convert(pars))(blame(region))
-  }
-
-  def convert(implicit pars: ParOldUnitListContext): Seq[ParBlock[G]] = pars match {
-    case ParOldUnitList0(par) => Seq(convert(par))
-    case ParOldUnitList1(par, _, pars) => convert(par) +: convert(pars)
-  }
-
-  def convert(implicit par: ParOldUnitContext): ParBlock[G] = par match {
-    case PvlOldParUnit(name, iter, contract, impl) =>
-      val decl = name match {
-        case None => new ParBlockDecl[G]()
-        case Some(name) => new ParBlockDecl[G]()(SourceNameOrigin(convert(name), origin(par)))
-      }
-
-      withContract(contract, contract => {
-        ParBlock(
-          decl,
-          iter.map(convert(_)).getOrElse(Nil),
-          AstBuildHelpers.foldStar(contract.consume(contract.context_everywhere)),
-          AstBuildHelpers.foldStar(contract.consume(contract.requires)),
-          AstBuildHelpers.foldStar(contract.consume(contract.ensures)),
-          convert(impl),
-        )(blame(par))
       })
   }
 


### PR DESCRIPTION
resolves #944 by deleting the old syntax and replacing the keyword `block` with the keyword `par`