### PR TITLE
[VCLLVM] setup LLVM as supported VerCors language

### DIFF
--- a/parsers/src/main/java/vct/parsers/ColLLVMParser.scala
+++ b/parsers/src/main/java/vct/parsers/ColLLVMParser.scala
@@ -1,0 +1,47 @@
+package vct.parsers
+
+import com.typesafe.scalalogging.LazyLogging
+import hre.io.Readable
+import org.antlr.v4.runtime.CharStream
+import vct.parsers.transform.{BlameProvider, OriginProvider}
+import vct.result.VerificationError.{SystemError, Unreachable, UserError}
+
+import java.io.{InputStreamReader, OutputStreamWriter, StringWriter}
+import java.nio.charset.StandardCharsets
+
+case class ColLLVMParser(override val originProvider: OriginProvider, override val blameProvider: BlameProvider) extends Parser(originProvider, blameProvider) with LazyLogging {
+  case class LLVMParseError(fileName: String, errorCode: Int, error: String) extends UserError {
+    override def code: String = "LLVMParseError"
+
+    override def text: String =
+      s"Parsing file $fileName failed with exit code $errorCode:\n$error"
+  }
+
+  case class LLVMStubError(message: String) extends SystemError {
+    override def text: String = message
+  }
+
+  override def parse[G](stream: CharStream): ParseResult[G] = {
+    throw Unreachable("LLVM IR files should be parsed from an not ANTLR CharStream, use VCLLVM instead!")
+  }
+
+  override def parse[G](readable: Readable): ParseResult[G] = {
+    var command = Seq("VCLLVM", "--sample-col") //TODO convert --sample-col to actual file at some point
+    val process = new ProcessBuilder(command:_*).start()
+    process.waitFor()
+    if (process.exitValue() != 0) {
+      val writer = new StringWriter()
+      new InputStreamReader(process.getInputStream).transferTo(writer)
+      new InputStreamReader(process.getErrorStream).transferTo(writer)
+      writer.close()
+      throw LLVMParseError(readable.fileName, process.exitValue(), writer.toString)
+    }
+    //TODO implement Protobuf -> ParseResult
+    val writer = new StringWriter()
+    new InputStreamReader(process.getInputStream).transferTo(writer)
+    writer.close()
+    val buffer = writer.toString
+    throw LLVMStubError(s"Protobuf interpreter not yet implemented. Dumping buffer...\n$buffer")
+  }
+
+}

--- a/src/main/java/vct/main/stages/Parsing.scala
+++ b/src/main/java/vct/main/stages/Parsing.scala
@@ -25,6 +25,7 @@ case object Parsing {
         case "java" => Some(Java)
         case "pvl" => Some(PVL)
         case "sil" | "vpr" => Some(Silver)
+        case "ll" => Some(LLVM)
         case _ => None
       }
 
@@ -33,6 +34,7 @@ case object Parsing {
     case object Java extends Language
     case object PVL extends Language
     case object Silver extends Language
+    case object LLVM extends Language
   }
 
   case class UnknownFileExtension(extension: String) extends UserError {
@@ -77,6 +79,7 @@ case class Parsing[G <: Generation]
         case Language.Java => ColJavaParser(originProvider, blameProvider)
         case Language.PVL => ColPVLParser(originProvider, blameProvider)
         case Language.Silver => ColSilverParser(originProvider, blameProvider)
+        case Language.LLVM => ColLLVMParser(originProvider, blameProvider)
       }
 
       parser.parse[G](readable)

--- a/src/main/java/vct/options/types/ReadLanguage.scala
+++ b/src/main/java/vct/options/types/ReadLanguage.scala
@@ -9,5 +9,6 @@ case object ReadLanguage extends ReadEnum[Language] {
     "i" -> Language.InterpretedC,
     "pvl" -> Language.PVL,
     "silver" -> Language.Silver,
+    "llvm" -> Language.LLVM
   )
 }


### PR DESCRIPTION
A lot is still missing such as passing an actual file to VCLLVM and parsing the buffer back to a `ParseResult`, but at least it compiles :).