### PR TITLE
[VCLLVM] LLVMFunctionContract & LLVMFunctionDefinition

### DIFF
--- a/col/src/main/java/vct/col/ast/Node.scala
+++ b/col/src/main/java/vct/col/ast/Node.scala
@@ -908,14 +908,14 @@ final case class BipInternal[G]()(implicit val o: Origin = DiagnosticOrigin) ext
 final case class BipPortSynchronization[G](ports: Seq[Ref[G, BipPort[G]]], wires: Seq[BipGlueDataWire[G]])(val blame: Blame[BipSynchronizationFailure])(implicit val o: Origin) extends GlobalDeclaration[G] with BipPortSynchronizationImpl[G]
 final case class BipTransitionSynchronization[G](transitions: Seq[Ref[G, BipTransition[G]]], wires: Seq[BipGlueDataWire[G]])(val blame: Blame[BipSynchronizationFailure])(implicit val o: Origin) extends GlobalDeclaration[G] with BipTransitionSynchronizationImpl[G]
 
-final class LLVMFunctionContract[G](val value:String, val references:Seq[(String, Ref[G, Declaration[G]])])(implicit val o: Origin) extends NodeFamily[G] with LLVMFunctionContractImpl[G]
+final class LlvmFunctionContract[G](val value:String, val references:Seq[(String, Ref[G, Declaration[G]])])(implicit val o: Origin) extends NodeFamily[G] with LLVMFunctionContractImpl[G]
 
-final class LLVMFunctionDefinition[G](val returnType: Type[G],
-                            val args: Seq[Variable[G]],
-                            val body: Statement[G],
-                            val contract: LLVMFunctionContract[G],
-                            val pure: Boolean = false)
-                           (val blame: Blame[CallableFailure])(implicit val o: Origin)
+final class LlvmFunctionDefinition[G](val returnType: Type[G],
+                                      val args: Seq[Variable[G]],
+                                      val body: Statement[G],
+                                      val contract: LlvmFunctionContract[G],
+                                      val pure: Boolean = false)
+                                     (val blame: Blame[CallableFailure])(implicit val o: Origin)
   extends GlobalDeclaration[G] with LLVMFunctionDefinitionImpl[G]
 
 sealed trait PVLType[G] extends Type[G] with PVLTypeImpl[G]

--- a/col/src/main/java/vct/col/ast/Node.scala
+++ b/col/src/main/java/vct/col/ast/Node.scala
@@ -908,7 +908,7 @@ final case class BipInternal[G]()(implicit val o: Origin = DiagnosticOrigin) ext
 final case class BipPortSynchronization[G](ports: Seq[Ref[G, BipPort[G]]], wires: Seq[BipGlueDataWire[G]])(val blame: Blame[BipSynchronizationFailure])(implicit val o: Origin) extends GlobalDeclaration[G] with BipPortSynchronizationImpl[G]
 final case class BipTransitionSynchronization[G](transitions: Seq[Ref[G, BipTransition[G]]], wires: Seq[BipGlueDataWire[G]])(val blame: Blame[BipSynchronizationFailure])(implicit val o: Origin) extends GlobalDeclaration[G] with BipTransitionSynchronizationImpl[G]
 
-final class LLVMFunctionContract[G](val value:String, val references:Set[(String, Ref[G, Declaration[G]])])(implicit val o: Origin) extends NodeFamily[G] with LLVMFunctionContractImpl[G]
+final class LLVMFunctionContract[G](val value:String, val references:Seq[(String, Ref[G, Declaration[G]])])(implicit val o: Origin) extends NodeFamily[G] with LLVMFunctionContractImpl[G]
 
 final class LLVMFunctionDefinition[G](val returnType: Type[G],
                             val args: Seq[Variable[G]],

--- a/col/src/main/java/vct/col/ast/Node.scala
+++ b/col/src/main/java/vct/col/ast/Node.scala
@@ -908,6 +908,9 @@ final case class BipInternal[G]()(implicit val o: Origin = DiagnosticOrigin) ext
 final case class BipPortSynchronization[G](ports: Seq[Ref[G, BipPort[G]]], wires: Seq[BipGlueDataWire[G]])(val blame: Blame[BipSynchronizationFailure])(implicit val o: Origin) extends GlobalDeclaration[G] with BipPortSynchronizationImpl[G]
 final case class BipTransitionSynchronization[G](transitions: Seq[Ref[G, BipTransition[G]]], wires: Seq[BipGlueDataWire[G]])(val blame: Blame[BipSynchronizationFailure])(implicit val o: Origin) extends GlobalDeclaration[G] with BipTransitionSynchronizationImpl[G]
 
+final class LLVMFunctionContract[G](val value:String, val references:Set[(String, Ref[G, Declaration[G]])])(implicit val o: Origin) extends NodeFamily[G] with LLVMFunctionContractImpl[G]
+
+
 sealed trait PVLType[G] extends Type[G] with PVLTypeImpl[G]
 final case class PVLNamedType[G](name: String, typeArgs: Seq[Type[G]])(implicit val o: Origin = DiagnosticOrigin) extends PVLType[G] with PVLNamedTypeImpl[G] {
   var ref: Option[PVLTypeNameTarget[G]] = None

--- a/col/src/main/java/vct/col/ast/Node.scala
+++ b/col/src/main/java/vct/col/ast/Node.scala
@@ -910,6 +910,13 @@ final case class BipTransitionSynchronization[G](transitions: Seq[Ref[G, BipTran
 
 final class LLVMFunctionContract[G](val value:String, val references:Set[(String, Ref[G, Declaration[G]])])(implicit val o: Origin) extends NodeFamily[G] with LLVMFunctionContractImpl[G]
 
+final class LLVMFunctionDefinition[G](val returnType: Type[G],
+                            val args: Seq[Variable[G]],
+                            val body: Statement[G],
+                            val contract: LLVMFunctionContract[G],
+                            val pure: Boolean = false)
+                           (val blame: Blame[CallableFailure])(implicit val o: Origin)
+  extends GlobalDeclaration[G] with LLVMFunctionDefinitionImpl[G]
 
 sealed trait PVLType[G] extends Type[G] with PVLTypeImpl[G]
 final case class PVLNamedType[G](name: String, typeArgs: Seq[Type[G]])(implicit val o: Origin = DiagnosticOrigin) extends PVLType[G] with PVLNamedTypeImpl[G] {

--- a/col/src/main/java/vct/col/ast/lang/LLVMFunctionContractImpl.scala
+++ b/col/src/main/java/vct/col/ast/lang/LLVMFunctionContractImpl.scala
@@ -1,0 +1,6 @@
+package vct.col.ast.lang
+
+import vct.col.ast.LLVMFunctionContract
+
+trait LLVMFunctionContractImpl[G] { this: LLVMFunctionContract[G] =>
+}

--- a/col/src/main/java/vct/col/ast/lang/LLVMFunctionContractImpl.scala
+++ b/col/src/main/java/vct/col/ast/lang/LLVMFunctionContractImpl.scala
@@ -1,6 +1,6 @@
 package vct.col.ast.lang
 
-import vct.col.ast.LLVMFunctionContract
+import vct.col.ast.LlvmFunctionContract
 
-trait LLVMFunctionContractImpl[G] { this: LLVMFunctionContract[G] =>
+trait LLVMFunctionContractImpl[G] { this: LlvmFunctionContract[G] =>
 }

--- a/col/src/main/java/vct/col/ast/lang/LLVMFunctionDefinitionImpl.scala
+++ b/col/src/main/java/vct/col/ast/lang/LLVMFunctionDefinitionImpl.scala
@@ -1,7 +1,7 @@
 package vct.col.ast.lang
 
-import vct.col.ast.LLVMFunctionDefinition
+import vct.col.ast.LlvmFunctionDefinition
 
-trait LLVMFunctionDefinitionImpl[G] { this: LLVMFunctionDefinition[G] =>
+trait LLVMFunctionDefinitionImpl[G] { this: LlvmFunctionDefinition[G] =>
 
 }

--- a/col/src/main/java/vct/col/ast/lang/LLVMFunctionDefinitionImpl.scala
+++ b/col/src/main/java/vct/col/ast/lang/LLVMFunctionDefinitionImpl.scala
@@ -1,0 +1,7 @@
+package vct.col.ast.lang
+
+import vct.col.ast.LLVMFunctionDefinition
+
+trait LLVMFunctionDefinitionImpl[G] { this: LLVMFunctionDefinition[G] =>
+
+}

--- a/col/src/main/java/vct/col/print/Printer.scala
+++ b/col/src/main/java/vct/col/print/Printer.scala
@@ -1145,7 +1145,7 @@ case class Printer(out: Appendable,
       phrase(decl.decl)
     case decl: CGlobalDeclaration[_] =>
       phrase(decl.decl)
-    case definition: LLVMFunctionDefinition[_] =>
+    case definition: LlvmFunctionDefinition[_] =>
       val header = phrase(
         spec(definition.contract),
         definition.returnType, space, name(definition), "(", commas(definition.args.map(NodePhrase)), ")"
@@ -1330,7 +1330,7 @@ case class Printer(out: Appendable,
     say(spaced(node.inits.map(NodePhrase)))
   }
 
-  def printLLVMFunctionContract(node: LLVMFunctionContract[_]): Unit = {
+  def printLLVMFunctionContract(node: LlvmFunctionContract[_]): Unit = {
     say(spec(phrase(node.value)))
   }
 
@@ -1361,7 +1361,7 @@ case class Printer(out: Appendable,
         case node: Verification[_] => printVerification(node)
         case node: VerificationContext[_] => printVerificationContext(node)
         case node: CDeclaration[_] => printCDeclaration(node)
-        case node: LLVMFunctionContract[_] => printLLVMFunctionContract(node)
+        case node: LlvmFunctionContract[_] => printLLVMFunctionContract(node)
         case x =>
           say(s"Unknown node type in Printer.scala: ${x.getClass.getCanonicalName}")
       }

--- a/col/src/main/java/vct/col/print/Printer.scala
+++ b/col/src/main/java/vct/col/print/Printer.scala
@@ -1145,6 +1145,12 @@ case class Printer(out: Appendable,
       phrase(decl.decl)
     case decl: CGlobalDeclaration[_] =>
       phrase(decl.decl)
+    case definition: LLVMFunctionDefinition[_] =>
+      val header = phrase(
+        spec(definition.contract),
+        definition.returnType, space, name(definition), "(", commas(definition.args.map(NodePhrase)), ")"
+      )
+      control(header, definition.body)
     case decl: LabelDecl[_] =>
       ???
     case decl: ParBlockDecl[_] =>

--- a/col/src/main/java/vct/col/print/Printer.scala
+++ b/col/src/main/java/vct/col/print/Printer.scala
@@ -1324,6 +1324,10 @@ case class Printer(out: Appendable,
     say(spaced(node.inits.map(NodePhrase)))
   }
 
+  def printLLVMFunctionContract(node: LLVMFunctionContract[_]): Unit = {
+    say(spec(phrase(node.value)))
+  }
+
   def print(node: Node[_]): Unit =
     try {
       node match {
@@ -1351,6 +1355,7 @@ case class Printer(out: Appendable,
         case node: Verification[_] => printVerification(node)
         case node: VerificationContext[_] => printVerificationContext(node)
         case node: CDeclaration[_] => printCDeclaration(node)
+        case node: LLVMFunctionContract[_] => printLLVMFunctionContract(node)
         case x =>
           say(s"Unknown node type in Printer.scala: ${x.getClass.getCanonicalName}")
       }

--- a/col/src/main/java/vct/col/rewrite/NonLatchingRewriter.scala
+++ b/col/src/main/java/vct/col/rewrite/NonLatchingRewriter.scala
@@ -49,5 +49,5 @@ class NonLatchingRewriter[Pre, Post]() extends AbstractRewriter[Pre, Post] {
   override def dispatch(node: Coercion[Pre]): Coercion[Post] = rewriteDefault(node)
   override def dispatch(node: Operator[Pre]): Operator[Post] = rewriteDefault(node)
 
-  override def dispatch(node: LLVMFunctionContract[Pre]): LLVMFunctionContract[Post] = rewriteDefault(node)
+  override def dispatch(node: LlvmFunctionContract[Pre]): LlvmFunctionContract[Post] = rewriteDefault(node)
 }

--- a/col/src/main/java/vct/col/rewrite/NonLatchingRewriter.scala
+++ b/col/src/main/java/vct/col/rewrite/NonLatchingRewriter.scala
@@ -48,4 +48,6 @@ class NonLatchingRewriter[Pre, Post]() extends AbstractRewriter[Pre, Post] {
 
   override def dispatch(node: Coercion[Pre]): Coercion[Post] = rewriteDefault(node)
   override def dispatch(node: Operator[Pre]): Operator[Post] = rewriteDefault(node)
+
+  override def dispatch(node: LLVMFunctionContract[Pre]): LLVMFunctionContract[Post] = rewriteDefault(node)
 }

--- a/col/src/main/java/vct/col/typerules/CoercingRewriter.scala
+++ b/col/src/main/java/vct/col/typerules/CoercingRewriter.scala
@@ -233,6 +233,7 @@ abstract class CoercingRewriter[Pre <: Generation]() extends AbstractRewriter[Pr
     case node: BipGlueAccepts[Pre] => node
     case node: BipGlueDataWire[Pre] => node
     case node: BipTransitionSignature[Pre] => node
+    case node: LLVMFunctionContract[Pre] => node
   }
 
   def preCoerce(e: Expr[Pre]): Expr[Pre] = e
@@ -394,6 +395,10 @@ abstract class CoercingRewriter[Pre <: Generation]() extends AbstractRewriter[Pr
   def preCoerce(node: JavaBipGlueName[Pre]): JavaBipGlueName[Pre] = node
   def postCoerce(node: JavaBipGlueName[Pre]): JavaBipGlueName[Post] = rewriteDefault(node)
   override final def dispatch(node: JavaBipGlueName[Pre]): JavaBipGlueName[Rewritten[Pre]] = postCoerce(coerce(preCoerce(node)))
+
+  def preCoerce(node: LLVMFunctionContract[Pre]): LLVMFunctionContract[Pre] = node
+  def postCoerce(node: LLVMFunctionContract[Pre]): LLVMFunctionContract[Post] = rewriteDefault(node)
+  override final def dispatch(node: LLVMFunctionContract[Pre]): LLVMFunctionContract[Rewritten[Pre]] = postCoerce(coerce(preCoerce(node)))
 
   def coerce(value: Expr[Pre], target: Type[Pre]): Expr[Pre] =
     ApplyCoercion(value, CoercionUtils.getCoercion(value.t, target) match {
@@ -1794,4 +1799,6 @@ abstract class CoercingRewriter[Pre <: Generation]() extends AbstractRewriter[Pr
 
   def coerce(node: JavaBipGlueElement[Pre]): JavaBipGlueElement[Pre] = node
   def coerce(node: JavaBipGlueName[Pre]): JavaBipGlueName[Pre] = node
+
+  def coerce(node: LLVMFunctionContract[Pre]): LLVMFunctionContract[Pre] = node
 }

--- a/col/src/main/java/vct/col/typerules/CoercingRewriter.scala
+++ b/col/src/main/java/vct/col/typerules/CoercingRewriter.scala
@@ -1506,6 +1506,7 @@ abstract class CoercingRewriter[Pre <: Generation]() extends AbstractRewriter[Pr
       case glue: BipGlue[Pre] => glue
       case synchronization: BipPortSynchronization[Pre] => synchronization
       case synchronization: BipTransitionSynchronization[Pre] => synchronization
+      case definition: LLVMFunctionDefinition[Pre] => definition
     }
   }
 

--- a/col/src/main/java/vct/col/typerules/CoercingRewriter.scala
+++ b/col/src/main/java/vct/col/typerules/CoercingRewriter.scala
@@ -233,7 +233,7 @@ abstract class CoercingRewriter[Pre <: Generation]() extends AbstractRewriter[Pr
     case node: BipGlueAccepts[Pre] => node
     case node: BipGlueDataWire[Pre] => node
     case node: BipTransitionSignature[Pre] => node
-    case node: LLVMFunctionContract[Pre] => node
+    case node: LlvmFunctionContract[Pre] => node
   }
 
   def preCoerce(e: Expr[Pre]): Expr[Pre] = e
@@ -396,9 +396,9 @@ abstract class CoercingRewriter[Pre <: Generation]() extends AbstractRewriter[Pr
   def postCoerce(node: JavaBipGlueName[Pre]): JavaBipGlueName[Post] = rewriteDefault(node)
   override final def dispatch(node: JavaBipGlueName[Pre]): JavaBipGlueName[Rewritten[Pre]] = postCoerce(coerce(preCoerce(node)))
 
-  def preCoerce(node: LLVMFunctionContract[Pre]): LLVMFunctionContract[Pre] = node
-  def postCoerce(node: LLVMFunctionContract[Pre]): LLVMFunctionContract[Post] = rewriteDefault(node)
-  override final def dispatch(node: LLVMFunctionContract[Pre]): LLVMFunctionContract[Rewritten[Pre]] = postCoerce(coerce(preCoerce(node)))
+  def preCoerce(node: LlvmFunctionContract[Pre]): LlvmFunctionContract[Pre] = node
+  def postCoerce(node: LlvmFunctionContract[Pre]): LlvmFunctionContract[Post] = rewriteDefault(node)
+  override final def dispatch(node: LlvmFunctionContract[Pre]): LlvmFunctionContract[Rewritten[Pre]] = postCoerce(coerce(preCoerce(node)))
 
   def coerce(value: Expr[Pre], target: Type[Pre]): Expr[Pre] =
     ApplyCoercion(value, CoercionUtils.getCoercion(value.t, target) match {
@@ -1506,7 +1506,7 @@ abstract class CoercingRewriter[Pre <: Generation]() extends AbstractRewriter[Pr
       case glue: BipGlue[Pre] => glue
       case synchronization: BipPortSynchronization[Pre] => synchronization
       case synchronization: BipTransitionSynchronization[Pre] => synchronization
-      case definition: LLVMFunctionDefinition[Pre] => definition
+      case definition: LlvmFunctionDefinition[Pre] => definition
     }
   }
 
@@ -1801,5 +1801,5 @@ abstract class CoercingRewriter[Pre <: Generation]() extends AbstractRewriter[Pr
   def coerce(node: JavaBipGlueElement[Pre]): JavaBipGlueElement[Pre] = node
   def coerce(node: JavaBipGlueName[Pre]): JavaBipGlueName[Pre] = node
 
-  def coerce(node: LLVMFunctionContract[Pre]): LLVMFunctionContract[Pre] = node
+  def coerce(node: LlvmFunctionContract[Pre]): LlvmFunctionContract[Pre] = node
 }


### PR DESCRIPTION
This PR creates two new node types in the COL AST. Their rewrite rules still need to be implemented, i.e. rules to convert `LLVMFunctionContract` => `ApplicableContract` and `LLVMFunctionDefinition` => `Procedure`.

I followed the the [guide](https://github.com/utwente-fmt/vercors/wiki/Nodes) to the best of my ability. It compiles but throws more warnings (specifically about coercion) than before I added the nodes so I wouldn't be surprised if I got something wrong. :see_no_evil: