### PR TITLE
Generic parameters java

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,10 @@ import sbt.internal._
 
 ThisBuild / turbo := true // en wat is daar het praktisch nut van?
 ThisBuild / scalaVersion := "2.13.5"
+ThisBuild / javacOptions :=Seq("-source", "17",
+                               "-target", "17",
+                               "-Xlint:deprecation", "-Xlint:unchecked",
+                               "-deprecation")
 ThisBuild / fork := true
 
 ThisBuild / pushRemoteCacheTo := Some(MavenCache("local-cache", file("tmp/vercors-build-cache")))
@@ -121,6 +125,7 @@ lazy val vercors: Project = (project in file("."))
     libraryDependencies += "org.jacoco" % "org.jacoco.agent" % "0.8.7" classifier "runtime",
 
     ThisBuild / scalacOptions ++= Seq(
+      "-target:jvm-1.17",
       "-deprecation",
       "-feature",
       "-unchecked",
@@ -134,24 +139,6 @@ lazy val vercors: Project = (project in file("."))
 //      "-P:scalac-profiling:show-profiles",
 //      "-P:scalac-profiling:sourceroot:/home/pieter/vercors/",
 //      "-Ypatmat-debug",
-    ),
-
-    Compile / javacOptions ++= Seq(
-      "-Xlint:deprecation",
-      "-Xlint:unchecked",
-      "-deprecation"
-    ),
-
-    Runtime / javacOptions ++= Seq(
-      "-Xlint:deprecation",
-      "-Xlint:unchecked",
-      "-deprecation"
-    ),
-
-    Test / javacOptions ++= Seq(
-      "-Xlint:deprecation",
-      "-Xlint:unchecked",
-      "-deprecation"
     ),
 
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion,

--- a/col/src/main/java/vct/col/resolve/lang/Java.scala
+++ b/col/src/main/java/vct/col/resolve/lang/Java.scala
@@ -264,11 +264,20 @@ case object Java extends LazyLogging {
       case moreNames => Seq(moreNames)
     }
 
-    FuncTools.firstOption(potentialFQNames, findLoadedJavaTypeName[G](_, ctx))
+
+
+    FuncTools.firstOption(potentialFQNames, findJavaTypeInStack[G](_, ctx))
+      .orElse(FuncTools.firstOption(potentialFQNames, findLoadedJavaTypeName[G](_, ctx)))
       .orElse(FuncTools.firstOption(potentialFQNames, findLibraryJavaType[G](_, ctx)))
       .orElse(FuncTools.firstOption(potentialFQNames, findRuntimeJavaType[G](_, ctx)).map(RefJavaClass[G]))
   }
 
+
+  def findJavaTypeInStack[G](name: Seq[String], ctx: TypeResolutionContext[G]): Option[JavaTypeNameTarget[G]] = {
+      ctx.stack.flatten.collectFirst{
+        case ref: JavaTypeNameTarget[G] if Seq(ref.name) == name => ref
+      }
+  }
 
   def findJavaName[G](name: String, ctx: TypeResolutionContext[G]): Option[JavaNameTarget[G]] = {
     ctx.stack.flatten.collectFirst {


### PR DESCRIPTION
Closes #928  by adding a function that looks for JavaTypeNames in the stack, before loading shims or checking elsewhere. This makes it possible to identify java generic types in the parameters of methods