### PR TITLE
[VCLLVM] Add proper label, goto, and branch support to LlvmFunctionDefinitions

### DIFF
--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -925,11 +925,11 @@ final class LlvmFunctionContract[G](val value:String, val references:Seq[(String
 
 final class LlvmFunctionDefinition[G](val returnType: Type[G],
                                       val args: Seq[Variable[G]],
-                                      val body: Statement[G],
+                                      val functionBody: Statement[G],
                                       val contract: LlvmFunctionContract[G],
                                       val pure: Boolean = false)
                                      (val blame: Blame[CallableFailure])(implicit val o: Origin)
-  extends GlobalDeclaration[G] with LLVMFunctionDefinitionImpl[G]
+  extends GlobalDeclaration[G] with Applicable[G] with LLVMFunctionDefinitionImpl[G]
 
 final case class LlvmLoop[G](cond:Expr[G], contract:LlvmLoopContract[G], body:Statement[G])
                        (implicit val o: Origin) extends CompositeStatement[G] with LLVMLoopImpl[G]

--- a/src/col/vct/col/ast/lang/LLVMFunctionDefinitionImpl.scala
+++ b/src/col/vct/col/ast/lang/LLVMFunctionDefinitionImpl.scala
@@ -1,8 +1,11 @@
 package vct.col.ast.lang
 
-import vct.col.ast.{Declaration, LlvmFunctionDefinition}
+import vct.col.ast.declaration.category.ApplicableImpl
+import vct.col.ast.{Declaration, LlvmFunctionDefinition, Statement}
 import vct.col.ast.util.Declarator
 
-trait LLVMFunctionDefinitionImpl[G] extends Declarator[G] { this: LlvmFunctionDefinition[G] =>
+trait LLVMFunctionDefinitionImpl[G] extends Declarator[G] with ApplicableImpl[G] { this: LlvmFunctionDefinition[G] =>
   override def declarations: Seq[Declaration[G]] = args
+
+  override def body: Option[Statement[G]] = Some(functionBody)
 }

--- a/src/col/vct/col/print/Printer.scala
+++ b/src/col/vct/col/print/Printer.scala
@@ -1389,7 +1389,7 @@ case class Printer(out: Appendable,
         spec(definition.contract),
         definition.returnType, space, name(definition), "(", commas(definition.args.map(NodePhrase)), ")"
       )
-      control(header, definition.body)
+      control(header, definition.functionBody)
     case decl: LabelDecl[_] =>
       ???
     case decl: ParBlockDecl[_] =>

--- a/src/colhelper/ColDefs.scala
+++ b/src/colhelper/ColDefs.scala
@@ -70,6 +70,7 @@ object ColDefs {
       "JavaConstructor", "JavaMethod",
       "CFunctionDefinition",
       "PVLConstructor",
+      "LlvmFunctionDefinition"
       // Potentially ParBlocks and other execution contexts (lambdas?) should be a scope too.
     ),
     "SendDecl" -> Seq("ParBlock", "Loop"),

--- a/src/parsers/vct/parsers/ColLLVMParser.scala
+++ b/src/parsers/vct/parsers/ColLLVMParser.scala
@@ -15,7 +15,7 @@ case class ColLLVMParser(override val originProvider: OriginProvider, override v
     override def code: String = "LLVMParseError"
 
     override def text: String =
-      s"Parsing file $fileName failed with exit code $errorCode:\n$error"
+      s"[ERROR] Parsing file $fileName failed with exit code $errorCode:\n$error"
   }
 
   override def parse[G](stream: CharStream): ParseResult[G] = {

--- a/src/rewrite/vct/rewrite/ResolveExpressionSideEffects.scala
+++ b/src/rewrite/vct/rewrite/ResolveExpressionSideEffects.scala
@@ -220,7 +220,7 @@ case class ResolveExpressionSideEffects[Pre <: Generation]() extends Rewriter[Pr
   def doBranches(branches: Seq[(Expr[Pre], Statement[Pre])])(implicit o: Origin): Statement[Post] =
     branches match {
       case Nil => Branch(Nil)
-      case (cond, impl) :: tail =>
+      case (cond, impl) +: tail =>
         doBranches(tail) match {
           case Branch(branches) =>
             frame(cond, cond => Branch((cond, dispatch(impl)) +: branches))

--- a/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
@@ -23,18 +23,19 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre]) extends 
       decreases = None)(func.contract.blame)(func.contract.o)
 
 
-    rw.globalDeclarations.declare(
-      new Procedure[Post](
-        returnType = rw.dispatch(func.returnType),
-        args = rw.variables.collect {
-          func.args.foreach(rw.dispatch)
-        }._1,
-        outArgs = Nil,
-        typeArgs = Nil,
-        body = Some(rw.dispatch(func.body)),
-        contract = stubContract
-      )(func.blame)(func.o)
-    )
+    rw.labelDecls.scope {
+      rw.globalDeclarations.declare(
+        new Procedure[Post](
+          returnType = rw.dispatch(func.returnType),
+          args = rw.variables.collect {
+            func.args.foreach(rw.dispatch)
+          }._1,
+          outArgs = Nil,
+          typeArgs = Nil,
+          body = Some(rw.dispatch(func.functionBody)),
+          contract = stubContract
+        )(func.blame)(func.o)
+      )
+    }
   }
-
 }


### PR DESCRIPTION
Concretely changes the following:
- Makes `LlvmFunctionDefintion` an instance of `Applicable`.
- Wraps the generated `Procedure` into a `LabelDecl.scope` when transforming from a `LlvmFunctionDefinition` to a `Procedure`.