### PR TITLE
fix inline triggers with \unfolding

### DIFF
--- a/src/main/vct/main/stages/Transformation.scala
+++ b/src/main/vct/main/stages/Transformation.scala
@@ -250,6 +250,7 @@ case class SilverTransformation
     DesugarCollectionOperators,
     EncodeNdIndex,
 
+    ExtractInlineQuantifierPatterns,
     // Translate internal types to domains
     FloatToRat,
     EnumToDomain,


### PR DESCRIPTION
change Transformation.scala to _also_ extract inline triggers before importing arrays, so that ImportArray.rewriteTopLevelArraySubscriptsInTrigger may do away with references of array subscripts in inline triggers