### PR TITLE
[VCLLVM] Add function call support for LLVM

### DIFF
--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -1088,11 +1088,16 @@ final class LlvmFunctionDefinition[G](val returnType: Type[G],
                                      (val blame: Blame[CallableFailure])(implicit val o: Origin)
   extends GlobalDeclaration[G] with Applicable[G] with LLVMFunctionDefinitionImpl[G]
 
+final case class LlvmFunctionInvocation[G](ref: Ref[G, LlvmFunctionDefinition[G]],
+                                     args: Seq[Expr[G]],
+                                     givenMap: Seq[(Ref[G, Variable[G]], Expr[G])],
+                                     yields: Seq[(Expr[G], Ref[G, Variable[G]])])
+                                    (val blame: Blame[InvocationFailure])(implicit val o: Origin) extends Apply[G] with LLVMFunctionInvocationImpl[G]
+
 final case class LlvmLoop[G](cond:Expr[G], contract:LlvmLoopContract[G], body:Statement[G])
                        (implicit val o: Origin) extends CompositeStatement[G] with LLVMLoopImpl[G]
+
 sealed trait LlvmLoopContract[G] extends NodeFamily[G] with LLVMLoopContractImpl[G]
-
-
 final case class LlvmLoopInvariant[G](value:String, references:Seq[(String, Ref[G, Declaration[G]])])
                                      (val blame: Blame[LoopInvariantFailure])
                                      (implicit val o: Origin) extends LlvmLoopContract[G] with LLVMLoopInvariantImpl[G]

--- a/src/col/vct/col/ast/lang/LLVMFunctionInvocationImpl.scala
+++ b/src/col/vct/col/ast/lang/LLVMFunctionInvocationImpl.scala
@@ -1,0 +1,14 @@
+package vct.col.ast.lang
+
+import vct.col.ast.LlvmFunctionInvocation
+import vct.col.print.{Ctx, Doc, DocUtil, Empty, Group, Precedence, Text}
+
+trait LLVMFunctionInvocationImpl[G] { this: LlvmFunctionInvocation[G] =>
+  override def precedence: Int = Precedence.POSTFIX
+
+  override def layout(implicit ctx: Ctx): Doc =
+    Group(
+      Group(
+        Text(ctx.name(ref)) <> "(") <> Doc.args(args) <> ")" <> DocUtil.givenYields(givenMap, yields)
+    )
+}

--- a/src/col/vct/col/typerules/CoercingRewriter.scala
+++ b/src/col/vct/col/typerules/CoercingRewriter.scala
@@ -1185,6 +1185,8 @@ abstract class CoercingRewriter[Pre <: Generation]() extends AbstractRewriter[Pr
         PredicateApply(ref, coerceArgs(args, ref.decl), rat(perm))
       case inv @ ProcedureInvocation(ref, args, outArgs, typeArgs, givenMap, yields) =>
         ProcedureInvocation(ref, coerceArgs(args, ref.decl, typeArgs), outArgs, typeArgs, coerceGiven(givenMap), coerceYields(yields, inv))(inv.blame)
+      case inv @ LlvmFunctionInvocation(ref, args, givenMap, yields) =>
+        LlvmFunctionInvocation(ref, args, givenMap, yields)(inv.blame)
       case ProcessApply(process, args) =>
         ProcessApply(process, coerceArgs(args, process.decl))
       case ProcessChoice(left, right) =>

--- a/src/hre/hre/stages/Stages.scala
+++ b/src/hre/hre/stages/Stages.scala
@@ -55,6 +55,5 @@ case class StagesPair[-Input, Mid, +Output](left: Stages[Input, Mid], right: Sta
     progressNext()
     right.runUnsafely(mid, progressNext)
   }
-
   override def flatNames: Seq[(String, Int)] = left.flatNames ++ right.flatNames
 }

--- a/src/rewrite/vct/rewrite/lang/LangSpecificToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangSpecificToCol.scala
@@ -157,6 +157,8 @@ case class LangSpecificToCol[Pre <: Generation]() extends Rewriter[Pre] with Laz
     case inv: SilverPartialADTFunctionInvocation[Pre] => silver.adtInvocation(inv)
     case map: SilverUntypedNonemptyLiteralMap[Pre] => silver.nonemptyMap(map)
 
+    case inv: LlvmFunctionInvocation[Pre] => llvm.rewriteFunctionInvocation(inv)
+
     case other => rewriteDefault(other)
   }
 


### PR DESCRIPTION
This PR adds support for function calls for the LLVM IR language in VerCors.

Testing if all the rewrite steps are executed correctly, is kind of hard at the moment as that's most easily tested by writing a program with some contracts on which PR #1034 will need to be merged first.

At least there are no build errors :)