### PR TITLE
VeyMont: resolution improvements

### DIFF
--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -1242,7 +1242,7 @@ final case class PVLNew[G](t: Type[G], args: Seq[Expr[G]], givenMap: Seq[(Ref[G,
 
 sealed trait PVLClassDeclaration[G] extends ClassDeclaration[G] with PVLClassDeclarationImpl[G]
 final class PVLConstructor[G](val contract: ApplicableContract[G], val args: Seq[Variable[G]], val body: Option[Statement[G]])(val blame: Blame[ConstructorFailure])(implicit val o: Origin) extends PVLClassDeclaration[G] with PVLConstructorImpl[G]
-final class PVLEndpoint[G](val name: String, val t: Type[G], val args: Seq[Expr[G]])(implicit val o: Origin) extends ClassDeclaration[G] {
+final class PVLEndpoint[G](val name: String, val cls: Ref[G, Class[G]], val args: Seq[Expr[G]])(implicit val o: Origin) extends ClassDeclaration[G] {
   var ref: Option[PVLConstructorTarget[G]] = None
 }
 

--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -474,7 +474,7 @@ final case class DerefHeapVariable[G](ref: Ref[G, HeapVariable[G]])(val blame: B
 final case class Deref[G](obj: Expr[G], ref: Ref[G, InstanceField[G]])(val blame: Blame[InsufficientPermission])(implicit val o: Origin) extends Expr[G] with HeapDeref[G] with DerefImpl[G]
 final case class ModelDeref[G](obj: Expr[G], ref: Ref[G, ModelField[G]])(val blame: Blame[ModelInsufficientPermission])(implicit val o: Origin) extends Expr[G] with ModelDerefImpl[G]
 final case class DerefPointer[G](pointer: Expr[G])(val blame: Blame[PointerDerefError])(implicit val o: Origin) extends Expr[G] with DerefPointerImpl[G]
-final case class DerefEndpoint[G](ref: Ref[G, Endpoint[G]])(implicit val o: Origin) extends Expr[G] with DerefEndpointImpl[G]
+final case class EndpointUse[G](ref: Ref[G, Endpoint[G]])(implicit val o: Origin) extends Expr[G] with EndpointUseImpl[G]
 final case class PointerAdd[G](pointer: Expr[G], offset: Expr[G])(val blame: Blame[PointerAddError])(implicit val o: Origin) extends Expr[G] with PointerAddImpl[G]
 final case class AddrOf[G](e: Expr[G])(implicit val o: Origin) extends Expr[G] with AddrOfImpl[G]
 final case class FunctionOf[G](binding: Ref[G, Variable[G]], vars: Seq[Ref[G, Variable[G]]])(implicit val o: Origin) extends Expr[G] with FunctionOfImpl[G]
@@ -682,7 +682,7 @@ final case class SuperType[G](left: Expr[G], right: Expr[G])(implicit val o: Ori
 final case class IndeterminateInteger[G](min: Expr[G], max: Expr[G])(implicit val o: Origin) extends Expr[G] with IndeterminateIntegerImpl[G]
 
 sealed trait AssignExpression[G] extends Expr[G] with AssignExpressionImpl[G]
-final case class VeyMontCommExpression[G](receiver: Ref[G, Endpoint[G]], sender: Ref[G, Endpoint[G]], chanType: Type[G], assign: Statement[G])(implicit val o: Origin) extends Statement[G] with VeyMontCommImpl[G]
+final case class Communicate[G](receiver: Ref[G, Endpoint[G]], sender: Ref[G, Endpoint[G]], chanType: Type[G], assign: Statement[G])(implicit val o: Origin) extends Statement[G] with CommunicateImpl[G]
 final case class VeyMontAssignExpression[G](thread: Ref[G, Endpoint[G]], assign: Statement[G])(implicit val o: Origin) extends Statement[G] with VeyMontAssignExpressionImpl[G]
 final case class PreAssignExpression[G](target: Expr[G], value: Expr[G])(val blame: Blame[AssignFailed])(implicit val o: Origin) extends AssignExpression[G] with PreAssignExpressionImpl[G]
 final case class PostAssignExpression[G](target: Expr[G], value: Expr[G])(val blame: Blame[AssignFailed])(implicit val o: Origin) extends AssignExpression[G] with PostAssignExpressionImpl[G]

--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -1242,19 +1242,21 @@ final case class PVLNew[G](t: Type[G], args: Seq[Expr[G]], givenMap: Seq[(Ref[G,
 
 sealed trait PVLClassDeclaration[G] extends ClassDeclaration[G] with PVLClassDeclarationImpl[G]
 final class PVLConstructor[G](val contract: ApplicableContract[G], val args: Seq[Variable[G]], val body: Option[Statement[G]])(val blame: Blame[ConstructorFailure])(implicit val o: Origin) extends PVLClassDeclaration[G] with PVLConstructorImpl[G]
-final class PVLEndpoint[G](val name: String, val t: Type[G], val args: Seq[Expr[G]])(implicit val o: Origin) extends ClassDeclaration[G]
+final class PVLEndpoint[G](val name: String, val t: Type[G], val args: Seq[Expr[G]])(implicit val o: Origin) extends ClassDeclaration[G] {
+  var ref: Option[PVLConstructorTarget[G]] = None
+}
 
 final class PVLSeqProg[G](val name: String, val declarations: Seq[ClassDeclaration[G]], val contract: ApplicableContract[G], val args: Seq[Variable[G]])(implicit val o: Origin) extends GlobalDeclaration[G] with PVLSeqProgImpl[G] with Declarator[G]
 
 sealed trait PVLCommunicateSubject[G] extends NodeFamily[G] with PVLCommunicateSubjectImpl[G]
 case class PVLEndpointName[G](name: String)(implicit val o: Origin) extends PVLCommunicateSubject[G] with PVLEndpointNameImpl[G] {
-  var ref: Option[PVLNameTarget[G]] = None
+  var ref: Option[RefPVLEndpoint[G]] = None
 }
 case class PVLIndexedFamilyName[G](family: String, index: Expr[G])(implicit val o: Origin) extends PVLCommunicateSubject[G] with PVLIndexedFamilyNameImpl[G] {
-  var ref: Option[PVLNameTarget[G]] = None
+  var ref: Option[RefPVLEndpoint[G]] = None
 }
 case class PVLFamilyRange[G](family: String, binder: String, start: Expr[G], end: Expr[G])(implicit val o: Origin) extends PVLCommunicateSubject[G] with PVLFamilyRangeImpl[G] {
-  var ref: Option[PVLNameTarget[G]] = None
+  var ref: Option[RefPVLEndpoint[G]] = None
 }
 case class PVLCommunicateAccess[G](subject: PVLCommunicateSubject[G], field: String)(implicit val o: Origin) extends NodeFamily[G] with PVLCommunicateAccessImpl[G] {
   var ref: Option[PVLDerefTarget[G]] = None

--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -223,7 +223,7 @@ final class HeapVariable[G](val t: Type[G])(implicit val o: Origin) extends Glob
 final class SimplificationRule[G](val axiom: Expr[G])(implicit val o: Origin) extends GlobalDeclaration[G] with SimplificationRuleImpl[G]
 final class AxiomaticDataType[G](val decls: Seq[ADTDeclaration[G]], val typeArgs: Seq[Variable[G]])(implicit val o: Origin) extends GlobalDeclaration[G] with AxiomaticDataTypeImpl[G]
 final class Class[G](val declarations: Seq[ClassDeclaration[G]], val supports: Seq[Ref[G, Class[G]]], val intrinsicLockInvariant: Expr[G])(implicit val o: Origin) extends GlobalDeclaration[G] with ClassImpl[G]
-final class SeqProg[G](val contract: ApplicableContract[G], val args : Seq[Variable[G]], val threads: Seq[Endpoint[G]], val run: ClassDeclaration[G], val decls: Seq[ClassDeclaration[G]])(implicit val o: Origin) extends GlobalDeclaration[G] with SeqProgImpl[G] with Declarator[G]
+final class SeqProg[G](val contract: ApplicableContract[G], val args : Seq[Variable[G]], val threads: Seq[Endpoint[G]], val run: SeqRun[G], val decls: Seq[ClassDeclaration[G]])(implicit val o: Origin) extends GlobalDeclaration[G] with SeqProgImpl[G] with Declarator[G]
 final class Endpoint[G](val cls: Ref[G, Class[G]], val args: Seq[Expr[G]])(implicit val o: Origin) extends Declaration[G] with EndpointImpl[G]
 final class Model[G](val declarations: Seq[ModelDeclaration[G]])(implicit val o: Origin) extends GlobalDeclaration[G] with Declarator[G] with ModelImpl[G]
 final class Function[G](val returnType: Type[G], val args: Seq[Variable[G]], val typeArgs: Seq[Variable[G]],
@@ -474,11 +474,11 @@ final case class DerefHeapVariable[G](ref: Ref[G, HeapVariable[G]])(val blame: B
 final case class Deref[G](obj: Expr[G], ref: Ref[G, InstanceField[G]])(val blame: Blame[InsufficientPermission])(implicit val o: Origin) extends Expr[G] with HeapDeref[G] with DerefImpl[G]
 final case class ModelDeref[G](obj: Expr[G], ref: Ref[G, ModelField[G]])(val blame: Blame[ModelInsufficientPermission])(implicit val o: Origin) extends Expr[G] with ModelDerefImpl[G]
 final case class DerefPointer[G](pointer: Expr[G])(val blame: Blame[PointerDerefError])(implicit val o: Origin) extends Expr[G] with DerefPointerImpl[G]
-final case class EndpointUse[G](ref: Ref[G, Endpoint[G]])(implicit val o: Origin) extends Expr[G] with EndpointUseImpl[G]
 final case class PointerAdd[G](pointer: Expr[G], offset: Expr[G])(val blame: Blame[PointerAddError])(implicit val o: Origin) extends Expr[G] with PointerAddImpl[G]
 final case class AddrOf[G](e: Expr[G])(implicit val o: Origin) extends Expr[G] with AddrOfImpl[G]
 final case class FunctionOf[G](binding: Ref[G, Variable[G]], vars: Seq[Ref[G, Variable[G]]])(implicit val o: Origin) extends Expr[G] with FunctionOfImpl[G]
 final case class ApplyCoercion[G](e: Expr[G], coercion: Coercion[G])(implicit val o: Origin) extends Expr[G] with ApplyCoercionImpl[G]
+final case class EndpointUse[G](ref: Ref[G, Endpoint[G]])(implicit val o: Origin) extends Expr[G] with EndpointUseImpl[G]
 
 sealed trait Apply[G] extends Expr[G] with ApplyImpl[G]
 final case class ADTFunctionInvocation[G](typeArgs: Option[(Ref[G, AxiomaticDataType[G]], Seq[Type[G]])], ref: Ref[G, ADTFunction[G]], args: Seq[Expr[G]])(implicit val o: Origin) extends Apply[G] with ADTFunctionInvocationImpl[G]
@@ -682,7 +682,6 @@ final case class SuperType[G](left: Expr[G], right: Expr[G])(implicit val o: Ori
 final case class IndeterminateInteger[G](min: Expr[G], max: Expr[G])(implicit val o: Origin) extends Expr[G] with IndeterminateIntegerImpl[G]
 
 sealed trait AssignExpression[G] extends Expr[G] with AssignExpressionImpl[G]
-final case class Communicate[G](receiver: Ref[G, Endpoint[G]], sender: Ref[G, Endpoint[G]], chanType: Type[G], assign: Statement[G])(implicit val o: Origin) extends Statement[G] with CommunicateImpl[G]
 final case class VeyMontAssignExpression[G](thread: Ref[G, Endpoint[G]], assign: Statement[G])(implicit val o: Origin) extends Statement[G] with VeyMontAssignExpressionImpl[G]
 final case class PreAssignExpression[G](target: Expr[G], value: Expr[G])(val blame: Blame[AssignFailed])(implicit val o: Origin) extends AssignExpression[G] with PreAssignExpressionImpl[G]
 final case class PostAssignExpression[G](target: Expr[G], value: Expr[G])(val blame: Blame[AssignFailed])(implicit val o: Origin) extends AssignExpression[G] with PostAssignExpressionImpl[G]
@@ -1262,6 +1261,15 @@ case class PVLCommunicateAccess[G](subject: PVLCommunicateSubject[G], field: Str
   var ref: Option[PVLDerefTarget[G]] = None
 }
 case class PVLCommunicate[G](sender: PVLCommunicateAccess[G], receiver: PVLCommunicateAccess[G])(implicit val o: Origin) extends Statement[G] with PVLCommunicateImpl[G]
+
+sealed trait Subject[G] extends NodeFamily[G]
+final case class EndpointName[G](ref: Ref[G, Endpoint[G]])(implicit val o: Origin) extends Subject[G]
+case class Access[G](subject: Subject[G], field: Ref[G, InstanceField[G]])(implicit val o: Origin) extends NodeFamily[G]
+final case class Communicate[G](receiver: Access[G], sender: Access[G])(implicit val o: Origin) extends Statement[G]
+
+final case class CommunicateX[G](receiver: Ref[G, Endpoint[G]], sender: Ref[G, Endpoint[G]], chanType: Type[G], assign: Statement[G])(implicit val o: Origin) extends Statement[G] with CommunicateXImpl[G]
+
+final case class SeqRun[G](body: Statement[G], contract: ApplicableContract[G])(val blame: Blame[CallableFailure])(implicit val o: Origin) extends NodeFamily[G]
 
 sealed trait SilverExpr[G] extends Expr[G] with SilverExprImpl[G]
 final case class SilverDeref[G](obj: Expr[G], field: Ref[G, SilverField[G]])(val blame: Blame[InsufficientPermission])(implicit val o: Origin) extends SilverExpr[G] with HeapDeref[G] with SilverDerefImpl[G]

--- a/src/col/vct/col/ast/declaration/global/SeqProgImpl.scala
+++ b/src/col/vct/col/ast/declaration/global/SeqProgImpl.scala
@@ -7,8 +7,7 @@ import vct.col.origin.Origin
 import vct.col.print._
 
 trait SeqProgImpl[G] { this: SeqProg[G] =>
-  def members: Seq[Declaration[G]] = threads ++ Seq(run) ++ decls
-  override def declarations: Seq[Declaration[G]] = args ++ members
+  override def declarations: Seq[Declaration[G]] = args ++ threads ++ decls
 
   override def layout(implicit ctx: Ctx): Doc =
     Doc.stack(Seq(

--- a/src/col/vct/col/ast/expr/heap/read/EndpointUseImpl.scala
+++ b/src/col/vct/col/ast/expr/heap/read/EndpointUseImpl.scala
@@ -1,9 +1,9 @@
 package vct.col.ast.expr.heap.read
 
-import vct.col.ast.{DerefEndpoint, TClass, Type}
+import vct.col.ast.{EndpointUse, TClass, Type}
 import vct.col.print.{Ctx, Doc, Precedence, Text}
 
-trait DerefEndpointImpl[G] { this: DerefEndpoint[G] =>
+trait EndpointUseImpl[G] { this: EndpointUse[G] =>
   // TODO: Shouldn't there be the field that is dereferenced be involved somehow...?
   override def t: Type[G] = ref.decl.t
 

--- a/src/col/vct/col/ast/family/pvlcommunicate/PVLCommunicateSubjectImpl.scala
+++ b/src/col/vct/col/ast/family/pvlcommunicate/PVLCommunicateSubjectImpl.scala
@@ -1,9 +1,9 @@
 package vct.col.ast.family.pvlcommunicate
 
-import vct.col.ast.{PVLCommunicateSubject, TClass, Type}
+import vct.col.ast.{PVLCommunicateSubject, TClass, Class, Type}
 import vct.col.resolve.ctx.RefPVLEndpoint
 
 trait PVLCommunicateSubjectImpl[G] { this: PVLCommunicateSubject[G] =>
-  def t: Type[G]
+  def cls: Class[G] = ref.get.decl.cls.decl
   def ref: Option[RefPVLEndpoint[G]]
 }

--- a/src/col/vct/col/ast/family/pvlcommunicate/PVLCommunicateSubjectImpl.scala
+++ b/src/col/vct/col/ast/family/pvlcommunicate/PVLCommunicateSubjectImpl.scala
@@ -1,6 +1,9 @@
 package vct.col.ast.family.pvlcommunicate
 
 import vct.col.ast.{PVLCommunicateSubject, TClass, Type}
+import vct.col.resolve.ctx.RefPVLEndpoint
 
 trait PVLCommunicateSubjectImpl[G] { this: PVLCommunicateSubject[G] =>
+  def t: Type[G]
+  def ref: Option[RefPVLEndpoint[G]]
 }

--- a/src/col/vct/col/ast/family/pvlcommunicate/PVLEndpointNameImpl.scala
+++ b/src/col/vct/col/ast/family/pvlcommunicate/PVLEndpointNameImpl.scala
@@ -1,8 +1,7 @@
 package vct.col.ast.family.pvlcommunicate
 
-import vct.col.ast.{PVLEndpointName, TClass, Type}
+import vct.col.ast.{PVLEndpointName, TClass, Class, Type}
 import vct.col.resolve.ctx.RefEndpoint
 
 trait PVLEndpointNameImpl[G] { this: PVLEndpointName[G] =>
-  def t: Type[G] = ref.get.decl.t
 }

--- a/src/col/vct/col/ast/family/pvlcommunicate/PVLEndpointNameImpl.scala
+++ b/src/col/vct/col/ast/family/pvlcommunicate/PVLEndpointNameImpl.scala
@@ -4,4 +4,5 @@ import vct.col.ast.{PVLEndpointName, TClass, Type}
 import vct.col.resolve.ctx.RefEndpoint
 
 trait PVLEndpointNameImpl[G] { this: PVLEndpointName[G] =>
+  def t: Type[G] = ref.get.decl.t
 }

--- a/src/col/vct/col/ast/family/pvlcommunicate/PVLEndpointNameImpl.scala
+++ b/src/col/vct/col/ast/family/pvlcommunicate/PVLEndpointNameImpl.scala
@@ -1,7 +1,6 @@
 package vct.col.ast.family.pvlcommunicate
 
-import vct.col.ast.{PVLEndpointName, TClass, Class, Type}
-import vct.col.resolve.ctx.RefEndpoint
+import vct.col.ast.PVLEndpointName
 
 trait PVLEndpointNameImpl[G] { this: PVLEndpointName[G] =>
 }

--- a/src/col/vct/col/ast/family/pvlcommunicate/PVLFamilyRangeImpl.scala
+++ b/src/col/vct/col/ast/family/pvlcommunicate/PVLFamilyRangeImpl.scala
@@ -1,7 +1,6 @@
 package vct.col.ast.family.pvlcommunicate
 
-import vct.col.ast.{PVLFamilyRange, TClass, Type}
+import vct.col.ast.{PVLFamilyRange, TClass, Class, Type}
 
 trait PVLFamilyRangeImpl[G] { this: PVLFamilyRange[G] =>
-  def t: Type[G] = ref.get.decl.t
 }

--- a/src/col/vct/col/ast/family/pvlcommunicate/PVLFamilyRangeImpl.scala
+++ b/src/col/vct/col/ast/family/pvlcommunicate/PVLFamilyRangeImpl.scala
@@ -1,6 +1,6 @@
 package vct.col.ast.family.pvlcommunicate
 
-import vct.col.ast.{PVLFamilyRange, TClass, Class, Type}
+import vct.col.ast.PVLFamilyRange
 
 trait PVLFamilyRangeImpl[G] { this: PVLFamilyRange[G] =>
 }

--- a/src/col/vct/col/ast/family/pvlcommunicate/PVLFamilyRangeImpl.scala
+++ b/src/col/vct/col/ast/family/pvlcommunicate/PVLFamilyRangeImpl.scala
@@ -1,6 +1,7 @@
 package vct.col.ast.family.pvlcommunicate
 
-import vct.col.ast.{PVLFamilyRange, TClass}
+import vct.col.ast.{PVLFamilyRange, TClass, Type}
 
 trait PVLFamilyRangeImpl[G] { this: PVLFamilyRange[G] =>
+  def t: Type[G] = ref.get.decl.t
 }

--- a/src/col/vct/col/ast/family/pvlcommunicate/PVLIndexedFamilyNameImpl.scala
+++ b/src/col/vct/col/ast/family/pvlcommunicate/PVLIndexedFamilyNameImpl.scala
@@ -1,6 +1,7 @@
 package vct.col.ast.family.pvlcommunicate
 
-import vct.col.ast.{PVLIndexedFamilyName, TClass}
+import vct.col.ast.{PVLIndexedFamilyName, TClass, Type}
 
 trait PVLIndexedFamilyNameImpl[G] { this: PVLIndexedFamilyName[G] =>
+  def t: Type[G] = ref.get.decl.t
 }

--- a/src/col/vct/col/ast/family/pvlcommunicate/PVLIndexedFamilyNameImpl.scala
+++ b/src/col/vct/col/ast/family/pvlcommunicate/PVLIndexedFamilyNameImpl.scala
@@ -1,6 +1,6 @@
 package vct.col.ast.family.pvlcommunicate
 
-import vct.col.ast.{PVLIndexedFamilyName, TClass, Class, Type}
+import vct.col.ast.PVLIndexedFamilyName
 
 trait PVLIndexedFamilyNameImpl[G] { this: PVLIndexedFamilyName[G] =>
 }

--- a/src/col/vct/col/ast/family/pvlcommunicate/PVLIndexedFamilyNameImpl.scala
+++ b/src/col/vct/col/ast/family/pvlcommunicate/PVLIndexedFamilyNameImpl.scala
@@ -1,7 +1,6 @@
 package vct.col.ast.family.pvlcommunicate
 
-import vct.col.ast.{PVLIndexedFamilyName, TClass, Type}
+import vct.col.ast.{PVLIndexedFamilyName, TClass, Class, Type}
 
 trait PVLIndexedFamilyNameImpl[G] { this: PVLIndexedFamilyName[G] =>
-  def t: Type[G] = ref.get.decl.t
 }

--- a/src/col/vct/col/ast/lang/PVLLocalImpl.scala
+++ b/src/col/vct/col/ast/lang/PVLLocalImpl.scala
@@ -1,6 +1,6 @@
 package vct.col.ast.lang
 
-import vct.col.ast.{PVLLocal, TEnum, TNotAValue, Type}
+import vct.col.ast.{PVLLocal, TClass, TEnum, TNotAValue, Type}
 import vct.col.print.{Ctx, Doc, Text}
 import vct.col.resolve.ctx._
 import vct.col.typerules.Types
@@ -14,7 +14,7 @@ trait PVLLocalImpl[G] { this: PVLLocal[G] =>
     case ref: RefField[G] => ref.decl.t
     case ref: RefModelField[G] => ref.decl.t
     case ref: RefEndpoint[G] => ref.decl.t
-    case ref: RefPVLEndpoint[G] => ref.decl.t
+    case ref: RefPVLEndpoint[G] => TClass[G](ref.decl.cls.decl.ref)
     case RefEnumConstant(enum, _) => TEnum(enum.get.ref)
   }
 

--- a/src/col/vct/col/ast/statement/composite/LoopImpl.scala
+++ b/src/col/vct/col/ast/statement/composite/LoopImpl.scala
@@ -81,7 +81,7 @@ trait LoopImpl[G] { this: Loop[G] =>
     case Eval(e) => Some(e.show)
     case a: Assign[G] => Some(a.layoutAsExpr)
     case e: VeyMontAssignExpression[G] => simpleControlElements(e.assign)
-    case e: VeyMontCommExpression[G] => simpleControlElements(e.assign)
+    case e: Communicate[G] => simpleControlElements(e.assign)
     case LocalDecl(local) => Some(local.show)
     case JavaLocalDeclarationStatement(local) => Some(local.show)
 

--- a/src/col/vct/col/ast/statement/composite/LoopImpl.scala
+++ b/src/col/vct/col/ast/statement/composite/LoopImpl.scala
@@ -81,7 +81,7 @@ trait LoopImpl[G] { this: Loop[G] =>
     case Eval(e) => Some(e.show)
     case a: Assign[G] => Some(a.layoutAsExpr)
     case e: VeyMontAssignExpression[G] => simpleControlElements(e.assign)
-    case e: Communicate[G] => simpleControlElements(e.assign)
+    case e: CommunicateX[G] => simpleControlElements(e.assign)
     case LocalDecl(local) => Some(local.show)
     case JavaLocalDeclarationStatement(local) => Some(local.show)
 

--- a/src/col/vct/col/ast/statement/veymont/CommunicateImpl.scala
+++ b/src/col/vct/col/ast/statement/veymont/CommunicateImpl.scala
@@ -1,8 +1,8 @@
 package vct.col.ast.statement.veymont
 
-import vct.col.ast.VeyMontCommExpression
+import vct.col.ast.Communicate
 import vct.col.print.{Ctx, Doc}
 
-trait VeyMontCommImpl[G] { this: VeyMontCommExpression[G] =>
+trait CommunicateImpl[G] { this: Communicate[G] =>
   override def layout(implicit ctx: Ctx): Doc = assign.show
 }

--- a/src/col/vct/col/ast/statement/veymont/CommunicateXImpl.scala
+++ b/src/col/vct/col/ast/statement/veymont/CommunicateXImpl.scala
@@ -1,8 +1,8 @@
 package vct.col.ast.statement.veymont
 
-import vct.col.ast.Communicate
+import vct.col.ast.CommunicateX
 import vct.col.print.{Ctx, Doc}
 
-trait CommunicateImpl[G] { this: Communicate[G] =>
+trait CommunicateXImpl[G] { this: CommunicateX[G] =>
   override def layout(implicit ctx: Ctx): Doc = assign.show
 }

--- a/src/col/vct/col/ref/UnresolvedRef.scala
+++ b/src/col/vct/col/ref/UnresolvedRef.scala
@@ -13,6 +13,8 @@ class UnresolvedRef[G, Decl <: Declaration[G]](val name: String)(implicit tag: C
 
   def resolve(decl: Declaration[G]): Unit = resolvedDecl = Some(decl)
 
+  def isResolved: Boolean = resolvedDecl.isDefined
+
   def decl: Decl = resolvedDecl match {
     case None =>
       throw NotResolved(this, tag)

--- a/src/col/vct/col/resolve/ResolutionError.scala
+++ b/src/col/vct/col/resolve/ResolutionError.scala
@@ -76,3 +76,8 @@ case class ForbiddenEndpointType(endpoint: PVLEndpoint[_]) extends ResolutionErr
   override def text: String = endpoint.o.messageInContext(s"This endpoint is not of class type")
 }
 
+case class ConstructorNotFound(endpoint: PVLEndpoint[_]) extends ResolutionError {
+  override def code: String = "constructorNotFound"
+  override def text: String = endpoint.o.messageInContext(s"Could not find a constructor that matches the types of the arguments of this endpoint.")
+}
+

--- a/src/col/vct/col/resolve/ResolutionError.scala
+++ b/src/col/vct/col/resolve/ResolutionError.scala
@@ -65,3 +65,14 @@ case class WrongThisPosition[G](diz: AmbiguousThis[G]) extends ResolutionError {
   override def code: String = "wrongThisPosition"
   override def text: String = diz.o.messageInContext("The `this` keyword does not refer to anything in this position.")
 }
+
+case class ForbiddenEndpointNameType(endpoint: PVLEndpointName[_]) extends ResolutionError {
+  override def code: String = "forbiddenEndpointNameType"
+  override def text: String = endpoint.o.messageInContext(s"In this endpoint position, a name is referred that is not an endpoint")
+}
+
+case class ForbiddenEndpointType(endpoint: PVLEndpoint[_]) extends ResolutionError {
+  override def code: String = "forbiddenEndpointType"
+  override def text: String = endpoint.o.messageInContext(s"This endpoint is not of class type")
+}
+

--- a/src/col/vct/col/resolve/ctx/Referrable.scala
+++ b/src/col/vct/col/resolve/ctx/Referrable.scala
@@ -308,7 +308,7 @@ case class RefPVLSeqProg[G](decl: PVLSeqProg[G]) extends Referrable[G] with This
 
 case class RefLlvmSpecFunction[G](decl: LlvmSpecFunction[G]) extends Referrable[G] with LlvmInvocationTarget[G] with ResultTarget[G]
 case class RefSeqProg[G](decl: SeqProg[G]) extends Referrable[G] with ThisTarget[G]
-case class RefEndpoint[G](decl: Endpoint[G]) extends Referrable[G] with PVLNameTarget[G]
+case class RefEndpoint[G](decl: Endpoint[G]) extends Referrable[G]
 case class RefProverType[G](decl: ProverType[G]) extends Referrable[G] with SpecTypeNameTarget[G]
 case class RefProverFunction[G](decl: ProverFunction[G]) extends Referrable[G] with SpecInvocationTarget[G]
 

--- a/src/col/vct/col/rewrite/NonLatchingRewriter.scala
+++ b/src/col/vct/col/rewrite/NonLatchingRewriter.scala
@@ -67,4 +67,7 @@ class NonLatchingRewriter[Pre, Post]() extends AbstractRewriter[Pre, Post] {
 
   override def dispatch(node: PVLCommunicateAccess[Pre]): PVLCommunicateAccess[Post] = rewriteDefault(node)
   override def dispatch(node: PVLCommunicateSubject[Pre]): PVLCommunicateSubject[Post] = rewriteDefault(node)
+  override def dispatch(node: SeqRun[Pre]): SeqRun[Post] = rewriteDefault(node)
+  override def dispatch(node: Access[Pre]): Access[Post] = rewriteDefault(node)
+  override def dispatch(node: Subject[Pre]): Subject[Post] = rewriteDefault(node)
 }

--- a/src/col/vct/col/typerules/CoercingRewriter.scala
+++ b/src/col/vct/col/typerules/CoercingRewriter.scala
@@ -950,7 +950,7 @@ abstract class CoercingRewriter[Pre <: Generation]() extends AbstractRewriter[Pr
         DerefHeapVariable(ref)(deref.blame)
       case deref @ DerefPointer(p) =>
         DerefPointer(pointer(p)._1)(deref.blame)
-      case deref @ DerefEndpoint(_) => deref
+      case deref @ EndpointUse(_) => deref
       case div @ Div(left, right) =>
         firstOk(e, s"Expected both operands to be rational.",
           // PB: horrible hack: Div ends up being silver.PermDiv, which expects an integer divisor. In other cases,
@@ -1654,7 +1654,7 @@ abstract class CoercingRewriter[Pre <: Generation]() extends AbstractRewriter[Pr
       case w @ WandApply(assn) => WandApply(res(assn))(w.blame)
       case w @ WandPackage(expr, stat) => WandPackage(res(expr), stat)(w.blame)
       case VeyMontAssignExpression(t,a) => VeyMontAssignExpression(t,a)
-      case VeyMontCommExpression(r,s,t,a) => VeyMontCommExpression(r,s,t,a)
+      case Communicate(r,s,t,a) => Communicate(r,s,t,a)
       case PVLCommunicate(s, r) => PVLCommunicate(s, r)
     }
   }

--- a/src/col/vct/col/typerules/CoercingRewriter.scala
+++ b/src/col/vct/col/typerules/CoercingRewriter.scala
@@ -254,6 +254,9 @@ abstract class CoercingRewriter[Pre <: Generation]() extends AbstractRewriter[Pr
     case node: SmtlibFunctionSymbol[Pre] => node
     case node: PVLCommunicateAccess[Pre] => node
     case node: PVLCommunicateSubject[Pre] => node
+    case node: SeqRun[Pre] => node
+    case node: Access[Pre] => node
+    case node: Subject[Pre] => node
   }
 
   def preCoerce(e: Expr[Pre]): Expr[Pre] = e
@@ -459,6 +462,18 @@ abstract class CoercingRewriter[Pre <: Generation]() extends AbstractRewriter[Pr
   def preCoerce(node: PVLCommunicateSubject[Pre]): PVLCommunicateSubject[Pre] = node
   def postCoerce(node: PVLCommunicateSubject[Pre]): PVLCommunicateSubject[Post] = rewriteDefault(node)
   override final def dispatch(node: PVLCommunicateSubject[Pre]): PVLCommunicateSubject[Post] = postCoerce(coerce(preCoerce(node)))
+
+  def preCoerce(node: Access[Pre]): Access[Pre] = node
+  def postCoerce(node: Access[Pre]): Access[Post] = rewriteDefault(node)
+  override final def dispatch(node: Access[Pre]): Access[Post] = postCoerce(coerce(preCoerce(node)))
+
+  def preCoerce(node: Subject[Pre]): Subject[Pre] = node
+  def postCoerce(node: Subject[Pre]): Subject[Post] = rewriteDefault(node)
+  override final def dispatch(node: Subject[Pre]): Subject[Post] = postCoerce(coerce(preCoerce(node)))
+
+  def preCoerce(node: SeqRun[Pre]): SeqRun[Pre] = node
+  def postCoerce(node: SeqRun[Pre]): SeqRun[Post] = rewriteDefault(node)
+  override final def dispatch(node: SeqRun[Pre]): SeqRun[Post] = postCoerce(coerce(preCoerce(node)))
 
   def coerce(value: Expr[Pre], target: Type[Pre]): Expr[Pre] =
     ApplyCoercion(value, CoercionUtils.getCoercion(value.t, target) match {
@@ -1654,8 +1669,9 @@ abstract class CoercingRewriter[Pre <: Generation]() extends AbstractRewriter[Pr
       case w @ WandApply(assn) => WandApply(res(assn))(w.blame)
       case w @ WandPackage(expr, stat) => WandPackage(res(expr), stat)(w.blame)
       case VeyMontAssignExpression(t,a) => VeyMontAssignExpression(t,a)
-      case Communicate(r,s,t,a) => Communicate(r,s,t,a)
+      case CommunicateX(r,s,t,a) => CommunicateX(r,s,t,a)
       case PVLCommunicate(s, r) => PVLCommunicate(s, r)
+      case Communicate(r, s) => Communicate(r, s)
     }
   }
 
@@ -2132,4 +2148,7 @@ abstract class CoercingRewriter[Pre <: Generation]() extends AbstractRewriter[Pr
 
   def coerce(node: PVLCommunicateAccess[Pre]): PVLCommunicateAccess[Pre] = node
   def coerce(node: PVLCommunicateSubject[Pre]): PVLCommunicateSubject[Pre] = node
+  def coerce(node: SeqRun[Pre]): SeqRun[Pre] = node
+  def coerce(node: Access[Pre]): Access[Pre] = node
+  def coerce(node: Subject[Pre]): Subject[Pre] = node
 }

--- a/src/colhelper/ColDefs.scala
+++ b/src/colhelper/ColDefs.scala
@@ -100,7 +100,7 @@ object ColDefs {
       "JavaConstructor", "JavaMethod",
       "Scope",
     ),
-    "Endpoint" -> Seq("VeyMontSeqProg"),
+    "Endpoint" -> Seq("SeqProg"),
     "JavaParam" -> Seq("JavaMethod", "JavaAnnotationMethod", "JavaConstructor"),
   )
 

--- a/src/parsers/antlr4/LangPVLParser.g4
+++ b/src/parsers/antlr4/LangPVLParser.g4
@@ -17,7 +17,7 @@ declClass
 declVeyMontSeqProg : contract 'seq_program' identifier '(' args? ')' '{' seqProgDecl* '}';
 
 seqProgDecl
- : 'endpoint' identifier '=' type '(' exprList? ')' ';' # pvlEndpoint
+ : 'endpoint' identifier '=' classType '(' exprList? ')' ';' # pvlEndpoint
  | runMethod # seqProgRunMethod
  | method # seqProgMethod
  ;

--- a/src/parsers/vct/parsers/transform/PVLToCol.scala
+++ b/src/parsers/vct/parsers/transform/PVLToCol.scala
@@ -46,8 +46,13 @@ case class PVLToCol[G](override val baseOrigin: Origin,
   def convert(implicit decl: SeqProgDeclContext): ClassDeclaration[G] = decl match {
     case SeqProgMethod(method) => convert(method)
     case SeqProgRunMethod(runMethod) => convert(runMethod).head
-    case PvlEndpoint(_, name, _, threadType, _, args, _, _) =>
-      new PVLEndpoint(convert(name), convert(threadType), args.map(convert(_)).getOrElse(Nil))(origin(decl).replacePrefName(convert(name)))
+    case PvlEndpoint(_, name, _, ClassType0(endpointType, None), _, args, _, _) =>
+      new PVLEndpoint(
+        convert(name),
+        new UnresolvedRef[G, Class[G]](convert(endpointType)),
+        args.map(convert(_)).getOrElse(Nil))(origin(decl).replacePrefName(convert(name))
+      )
+    case PvlEndpoint(_, name, _, t@ClassType0(_, Some(_)), _, args, _, _) => ??(t)
   }
 
   def convertVeyMontProg(implicit cls: DeclVeyMontSeqProgContext): PVLSeqProg[G] = cls match {

--- a/src/rewrite/vct/rewrite/ResolveExpressionSideEffects.scala
+++ b/src/rewrite/vct/rewrite/ResolveExpressionSideEffects.scala
@@ -346,7 +346,7 @@ case class ResolveExpressionSideEffects[Pre <: Generation]() extends Rewriter[Pr
         }
       case rangedFor: RangedFor[Pre] => rewriteDefault(rangedFor)
       case assign: VeyMontAssignExpression[Pre] => rewriteDefault(assign)
-      case expr: VeyMontCommExpression[Pre] => rewriteDefault(expr)
+      case expr: Communicate[Pre] => rewriteDefault(expr)
       case comm: PVLCommunicate[Pre] => rewriteDefault(comm)
       case _: CStatement[Pre] => throw ExtraNode
       case _: CPPStatement[Pre] => throw ExtraNode

--- a/src/rewrite/vct/rewrite/ResolveExpressionSideEffects.scala
+++ b/src/rewrite/vct/rewrite/ResolveExpressionSideEffects.scala
@@ -346,8 +346,9 @@ case class ResolveExpressionSideEffects[Pre <: Generation]() extends Rewriter[Pr
         }
       case rangedFor: RangedFor[Pre] => rewriteDefault(rangedFor)
       case assign: VeyMontAssignExpression[Pre] => rewriteDefault(assign)
-      case expr: Communicate[Pre] => rewriteDefault(expr)
+      case comm: CommunicateX[Pre] => rewriteDefault(comm)
       case comm: PVLCommunicate[Pre] => rewriteDefault(comm)
+      case comm: Communicate[Pre] => rewriteDefault(comm)
       case _: CStatement[Pre] => throw ExtraNode
       case _: CPPStatement[Pre] => throw ExtraNode
       case _: JavaStatement[Pre] => throw ExtraNode

--- a/src/rewrite/vct/rewrite/lang/LangPVLToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangPVLToCol.scala
@@ -8,7 +8,7 @@ import vct.col.util.AstBuildHelpers._
 import vct.col.ast.RewriteHelpers._
 import vct.col.rewrite.lang.LangSpecificToCol.{NotAValue, ThisVar}
 import vct.col.ref.Ref
-import vct.col.resolve.ctx.{BuiltinField, BuiltinInstanceMethod, ImplicitDefaultPVLConstructor, PVLBuiltinInstanceMethod, RefADTFunction, RefAxiomaticDataType, RefClass, RefEnum, RefEnumConstant, RefField, RefFunction, RefInstanceFunction, RefInstanceMethod, RefInstancePredicate, RefModel, RefModelAction, RefModelField, RefModelProcess, RefPVLConstructor, RefPredicate, RefProcedure, RefProverFunction, RefVariable, RefEndpoint, SpecDerefTarget, SpecInvocationTarget, SpecNameTarget}
+import vct.col.resolve.ctx.{BuiltinField, BuiltinInstanceMethod, ImplicitDefaultPVLConstructor, PVLBuiltinInstanceMethod, RefADTFunction, RefAxiomaticDataType, RefClass, RefEndpoint, RefEnum, RefEnumConstant, RefField, RefFunction, RefInstanceFunction, RefInstanceMethod, RefInstancePredicate, RefModel, RefModelAction, RefModelField, RefModelProcess, RefPVLConstructor, RefPVLEndpoint, RefPredicate, RefProcedure, RefProverFunction, RefVariable, SpecDerefTarget, SpecInvocationTarget, SpecNameTarget}
 import vct.col.util.{AstBuildHelpers, SuccessionMap}
 
 case object LangPVLToCol {
@@ -84,7 +84,7 @@ case class LangPVLToCol[Pre <: Generation](rw: LangSpecificToCol[Pre]) extends L
             Or: integrate actualy dereferencing into this node, since that is the only use case anyway
             So: EndpointDeref. Like ModelDeref
       */
-      case RefEndpoint(decl) => DerefEndpoint[Post](rw.succ(decl))
+      case RefPVLEndpoint(decl) => EndpointUse[Post](rw.succ(decl))
     }
   }
 

--- a/src/rewrite/vct/rewrite/lang/LangPVLToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangPVLToCol.scala
@@ -80,11 +80,7 @@ case class LangPVLToCol[Pre <: Generation](rw: LangSpecificToCol[Pre]) extends L
     local.ref.get match {
       case spec: SpecNameTarget[Pre] => rw.specLocal(spec, local, local.blame)
       case RefField(decl) => Deref[Post](rw.currentThis.top, rw.succ(decl))(local.blame)
-      /* TODO: I don't like the "Deref" word here, as no field is being dereferenced... It should be more like "Local"?
-            Or: integrate actualy dereferencing into this node, since that is the only use case anyway
-            So: EndpointDeref. Like ModelDeref
-      */
-      case RefPVLEndpoint(decl) => EndpointUse[Post](rw.succ(decl))
+      case endpoint: RefPVLEndpoint[Pre] => rw.veymont.rewriteEndpointUse(endpoint, local)
     }
   }
 

--- a/src/rewrite/vct/rewrite/lang/LangTypesToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangTypesToCol.scala
@@ -188,8 +188,6 @@ case class LangTypesToCol[Pre <: Generation]() extends Rewriter[Pre] {
       globalDeclarations.declare(declaration.rewrite(specs = specs, declarator = decl))
     case cls: JavaClass[Pre] =>
       rewriteDefault(cls)
-//    case endpoint: PVLEndpoint[Pre] =>
-//      classDeclarations.succeed(endpoint, endpoint.rewrite(cls = succ(endpoint.cls.decl)))
     case other => rewriteDefault(other)
   }
 

--- a/src/rewrite/vct/rewrite/lang/LangTypesToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangTypesToCol.scala
@@ -27,7 +27,7 @@ case class LangTypesToCol[Pre <: Generation]() extends Rewriter[Pre] {
   override def porcelainRefSucc[RefDecl <: Declaration[Rewritten[Pre]]](ref: Ref[Pre, _])(implicit tag: ClassTag[RefDecl]): Option[Ref[Rewritten[Pre], RefDecl]] =
     ref match {
       // Retain unresolved references to be resolved by LangSpecificToCol
-      case unresolved: UnresolvedRef[_, _] => Some(new UnresolvedRef[Post, RefDecl](unresolved.name))
+      case unresolved: UnresolvedRef[_, _] if !unresolved.isResolved => Some(new UnresolvedRef[Post, RefDecl](unresolved.name))
       case _ => None
     }
 
@@ -188,6 +188,8 @@ case class LangTypesToCol[Pre <: Generation]() extends Rewriter[Pre] {
       globalDeclarations.declare(declaration.rewrite(specs = specs, declarator = decl))
     case cls: JavaClass[Pre] =>
       rewriteDefault(cls)
+//    case endpoint: PVLEndpoint[Pre] =>
+//      classDeclarations.succeed(endpoint, endpoint.rewrite(cls = succ(endpoint.cls.decl)))
     case other => rewriteDefault(other)
   }
 

--- a/src/rewrite/vct/rewrite/lang/LangVeyMontToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangVeyMontToCol.scala
@@ -10,12 +10,17 @@ import vct.col.rewrite.{Generation, Rewritten}
 import vct.col.rewrite.lang.LangSpecificToCol
 import vct.col.util.SuccessionMap
 import vct.result.VerificationError.UserError
-import vct.rewrite.lang.LangVeyMontToCol.{CommunicateNotSupported, NoRunBody, NoRunMethod}
+import vct.rewrite.lang.LangVeyMontToCol.{CommunicateNotSupported, EndpointUseNotSupported, NoRunBody, NoRunMethod}
 
 case object LangVeyMontToCol {
   case object CommunicateNotSupported extends UserError {
     override def code: String = "communicateNotSupported"
     override def text: String = "The `communicate` statement is not yet supported"
+  }
+
+  case object EndpointUseNotSupported extends UserError {
+    override def code: String = "endpointUseNotSupported"
+    override def text: String = "Referencing of endpoints is not yet supported"
   }
 
   case class NoRunMethod(prog: PVLSeqProg[_]) extends UserError {
@@ -84,8 +89,11 @@ case class LangVeyMontToCol[Pre <: Generation](rw: LangSpecificToCol[Pre]) exten
     case PVLFamilyRange(family, binder, start, end) => ???
   }
 
-  def rewriteEndpointUse(endpoint: RefPVLEndpoint[Pre], local: PVLLocal[Pre]): EndpointUse[Post] =
-    EndpointUse[Post](endpointSucc.ref(endpoint.decl))(local.o)
+  def rewriteEndpointUse(endpoint: RefPVLEndpoint[Pre], local: PVLLocal[Pre]): EndpointUse[Post] = {
+    throw EndpointUseNotSupported
+    // TODO: Enable when actual seq_program analysis is implemented
+//    EndpointUse[Post](endpointSucc.ref(endpoint.decl))(local.o)
+  }
 
   def rewriteRun(run: RunMethod[Pre]): SeqRun[Post] = run.body match {
     case Some(body) =>

--- a/src/rewrite/vct/rewrite/lang/LangVeyMontToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangVeyMontToCol.scala
@@ -72,4 +72,6 @@ case class LangVeyMontToCol[Pre <: Generation](rw: LangSpecificToCol[Pre]) exten
       )
     }
   }
+
+//  def rewriteEndpointName
 }

--- a/src/rewrite/vct/rewrite/lang/LangVeyMontToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangVeyMontToCol.scala
@@ -39,7 +39,7 @@ case class LangVeyMontToCol[Pre <: Generation](rw: LangSpecificToCol[Pre]) exten
   val seqProgSucc: SuccessionMap[PVLSeqProg[Pre], SeqProg[Post]] = SuccessionMap()
   val endpointSucc: SuccessionMap[PVLEndpoint[Pre], Endpoint[Post]] = SuccessionMap()
 
-  def rewriteCommunicate(comm: PVLCommunicate[Pre]): VeyMontCommExpression[Post] = {
+  def rewriteCommunicate(comm: PVLCommunicate[Pre]): Communicate[Post] = {
     throw CommunicateNotSupported
   }
 

--- a/src/rewrite/vct/rewrite/veymont/AddVeyMontAssignmentNodes.scala
+++ b/src/rewrite/vct/rewrite/veymont/AddVeyMontAssignmentNodes.scala
@@ -1,7 +1,7 @@
 package vct.col.rewrite.veymont
 
 import hre.util.ScopedStack
-import vct.col.ast.{Assign, Declaration, Deref, EndpointUse, Expr, MethodInvocation, Node, ProcedureInvocation, RunMethod, Statement, VeyMontAssignExpression, Communicate, SeqProg, Endpoint}
+import vct.col.ast.{Assign, Declaration, Deref, EndpointUse, Expr, MethodInvocation, Node, ProcedureInvocation, RunMethod, Statement, VeyMontAssignExpression, CommunicateX, SeqProg, Endpoint}
 import vct.col.ref.Ref
 import vct.col.rewrite.veymont.AddVeyMontAssignmentNodes.{AddVeyMontAssignmentError, getDerefsFromExpr, getThreadDeref}
 import vct.col.rewrite.{Generation, Rewriter, RewriterBuilder}
@@ -100,7 +100,7 @@ case class AddVeyMontAssignmentNodes[Pre <: Generation]() extends Rewriter[Pre] 
         new VeyMontAssignExpression[Post](succ(receiver),rewriteDefault(a))(a.o)
       else {
         val sender = getAssignmentSender(derefs.head)
-        new Communicate[Post](succ(receiver), succ(sender), dispatch(derefs.head.ref.decl.t), rewriteDefault(a))(a.o)
+        new CommunicateX[Post](succ(receiver), succ(sender), dispatch(derefs.head.ref.decl.t), rewriteDefault(a))(a.o)
       }
     } else throw AddVeyMontAssignmentError(a.value, "The value of this assignment is not allowed to refer to multiple threads!")
   }

--- a/src/rewrite/vct/rewrite/veymont/ChannelInfo.scala
+++ b/src/rewrite/vct/rewrite/veymont/ChannelInfo.scala
@@ -1,8 +1,8 @@
 package vct.rewrite.veymont
 
-import vct.col.ast.{Type, VeyMontCommExpression}
+import vct.col.ast.{Type, Communicate}
 import vct.col.rewrite.Generation
 
-class ChannelInfo[Pre <: Generation](val comExpr: VeyMontCommExpression[Pre], val channelType: Type[Pre], val channelName: String) {
+class ChannelInfo[Pre <: Generation](val comExpr: Communicate[Pre], val channelType: Type[Pre], val channelName: String) {
 
 }

--- a/src/rewrite/vct/rewrite/veymont/ChannelInfo.scala
+++ b/src/rewrite/vct/rewrite/veymont/ChannelInfo.scala
@@ -1,8 +1,8 @@
 package vct.rewrite.veymont
 
-import vct.col.ast.{Type, Communicate}
+import vct.col.ast.{Type, CommunicateX}
 import vct.col.rewrite.Generation
 
-class ChannelInfo[Pre <: Generation](val comExpr: Communicate[Pre], val channelType: Type[Pre], val channelName: String) {
+class ChannelInfo[Pre <: Generation](val comExpr: CommunicateX[Pre], val channelType: Type[Pre], val channelName: String) {
 
 }

--- a/src/rewrite/vct/rewrite/veymont/StructureCheck.scala
+++ b/src/rewrite/vct/rewrite/veymont/StructureCheck.scala
@@ -58,7 +58,7 @@ case class StructureCheck[Pre <: Generation]() extends Rewriter[Pre] {
   override def dispatch(st : Statement[Pre]) : Statement[Post] = {
     if(inSeqProg.nonEmpty)
       st match {
-        case Communicate(_,_,_,_) => rewriteDefault(st)
+        case CommunicateX(_,_,_,_) => rewriteDefault(st)
         case VeyMontAssignExpression(_,_) => rewriteDefault (st)
         case Assign(_,_) => rewriteDefault (st)
         case Branch(_) => rewriteDefault(st)

--- a/src/rewrite/vct/rewrite/veymont/StructureCheck.scala
+++ b/src/rewrite/vct/rewrite/veymont/StructureCheck.scala
@@ -58,7 +58,7 @@ case class StructureCheck[Pre <: Generation]() extends Rewriter[Pre] {
   override def dispatch(st : Statement[Pre]) : Statement[Post] = {
     if(inSeqProg.nonEmpty)
       st match {
-        case VeyMontCommExpression(_,_,_,_) => rewriteDefault(st)
+        case Communicate(_,_,_,_) => rewriteDefault(st)
         case VeyMontAssignExpression(_,_) => rewriteDefault (st)
         case Assign(_,_) => rewriteDefault (st)
         case Branch(_) => rewriteDefault(st)
@@ -79,7 +79,7 @@ case class StructureCheck[Pre <: Generation]() extends Rewriter[Pre] {
         case ThisSeqProg(_) =>
           if (args.isEmpty) rewriteDefault(st)
           else throw VeyMontStructCheckError(st, "Calls to methods in seq_program cannot have any arguments!")
-        case DerefEndpoint(thread) =>
+        case EndpointUse(thread) =>
           val argderefs = args.flatMap(getDerefsFromExpr)
           val argthreads = argderefs.map(d => getThreadDeref(d,
             VeyMontStructCheckError(st, "A method call on a thread object may only refer to a thread in its arguments!")))

--- a/src/rewrite/vct/rewrite/veymont/ThreadBuildingBlocks.scala
+++ b/src/rewrite/vct/rewrite/veymont/ThreadBuildingBlocks.scala
@@ -1,13 +1,13 @@
 package vct.rewrite.veymont
 
-import vct.col.ast.{ClassDeclaration, InstanceField, JavaClass, Type, VeyMontCommExpression, Endpoint}
+import vct.col.ast.{ClassDeclaration, InstanceField, JavaClass, Type, Communicate, Endpoint}
 import vct.col.origin.Origin
 import vct.col.rewrite.{Generation, Rewritten}
 
 class ThreadBuildingBlocks[Pre <: Generation](
                                                val runMethod: ClassDeclaration[Pre],
                                                val methods: Seq[ClassDeclaration[Pre]],
-                                               val channelFields: Map[(VeyMontCommExpression[Pre],Origin),InstanceField[Rewritten[Pre]]],
+                                               val channelFields: Map[(Communicate[Pre],Origin),InstanceField[Rewritten[Pre]]],
                                                val channelClasses: Map[Type[Pre],JavaClass[Rewritten[Pre]]],
                                                val thread: Endpoint[Pre],
                                                val threadField: InstanceField[Rewritten[Pre]]) {

--- a/src/rewrite/vct/rewrite/veymont/ThreadBuildingBlocks.scala
+++ b/src/rewrite/vct/rewrite/veymont/ThreadBuildingBlocks.scala
@@ -1,13 +1,13 @@
 package vct.rewrite.veymont
 
-import vct.col.ast.{ClassDeclaration, InstanceField, JavaClass, Type, Communicate, Endpoint}
+import vct.col.ast.{ClassDeclaration, CommunicateX, Endpoint, InstanceField, JavaClass, SeqRun, Type}
 import vct.col.origin.Origin
 import vct.col.rewrite.{Generation, Rewritten}
 
 class ThreadBuildingBlocks[Pre <: Generation](
-                                               val runMethod: ClassDeclaration[Pre],
+                                               val runMethod: SeqRun[Pre],
                                                val methods: Seq[ClassDeclaration[Pre]],
-                                               val channelFields: Map[(Communicate[Pre],Origin),InstanceField[Rewritten[Pre]]],
+                                               val channelFields: Map[(CommunicateX[Pre],Origin),InstanceField[Rewritten[Pre]]],
                                                val channelClasses: Map[Type[Pre],JavaClass[Rewritten[Pre]]],
                                                val thread: Endpoint[Pre],
                                                val threadField: InstanceField[Rewritten[Pre]]) {

--- a/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
+++ b/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
@@ -21,19 +21,19 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   """
 
   // TODO: Enable when plain field dereference works
-  // vercors should verify using silicon in "plain endpoint field dereference should be possible" pvl
-  // """
-  //    class Storage {
-  //       int x;
-  //    }
-  //    seq_program Example() {
-  //       endpoint alice = Storage();
+  vercors should verify using silicon in "plain endpoint field dereference should be possible" pvl
+  """
+     class Storage {
+        int x;
+     }
+     seq_program Example() {
+        endpoint alice = Storage();
 
-  //       run {
-  //         assert alice.x == 0;
-  //       }
-  //    }
-  // """
+        run {
+          assert alice.x == 0;
+        }
+     }
+  """
 
   vercors should error withCode "noSuchName" in "non-existent thread name in communicate fails" pvl
   """

--- a/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
+++ b/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
@@ -20,8 +20,7 @@ class TechnicalVeyMontSpec extends VercorsSpec {
      }
   """
 
-  // TODO: Enable when plain field dereference works
-  vercors should verify using silicon in "plain endpoint field dereference should be possible" pvl
+  vercors should error withCode "endpointUseNotSupported" in "plain endpoint field dereference should be possible" pvl
   """
      class Storage {
         int x;

--- a/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
+++ b/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
@@ -20,20 +20,20 @@ class TechnicalVeyMontSpec extends VercorsSpec {
      }
   """
 
-  // To be enabled when endpoint field dereference is implemented
-  // vercors should verify in "plain endpoint field dereference should be possible" pvl
-  """
-     class Storage {
-        int x;
-     }
-     seq_program Example() {
-        endpoint alice = Storage();
+  // TODO: Enable when plain field dereference works
+  // vercors should verify using silicon in "plain endpoint field dereference should be possible" pvl
+  // """
+  //    class Storage {
+  //       int x;
+  //    }
+  //    seq_program Example() {
+  //       endpoint alice = Storage();
 
-        run {
-          assert alice.x == 0;
-        }
-     }
-  """
+  //       run {
+  //         assert alice.x == 0;
+  //       }
+  //    }
+  // """
 
   vercors should error withCode "noSuchName" in "non-existent thread name in communicate fails" pvl
   """

--- a/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
+++ b/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
@@ -22,19 +22,18 @@ class TechnicalVeyMontSpec extends VercorsSpec {
 
   // To be enabled when endpoint field dereference is implemented
   // vercors should verify in "plain endpoint field dereference should be possible" pvl
-  // """
-  //    class Storage {
-  //       int x;
-  //    }
-  //    seq_program Example() {
-  //       endpoint alice = Storage();
-  //       endpoint bob = Storage();
+  """
+     class Storage {
+        int x;
+     }
+     seq_program Example() {
+        endpoint alice = Storage();
 
-  //       run {
-  //         assert alice.x == bob.x;
-  //       }
-  //    }
-  // """
+        run {
+          assert alice.x == 0;
+        }
+     }
+  """
 
   vercors should error withCode "noSuchName" in "non-existent thread name in communicate fails" pvl
   """
@@ -73,13 +72,10 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   seq_program Example() { }
   """
 
-  vercors should error withCode "forbiddenEndpointType" in "endpoints can only have class types" pvl
+  vercors should error withCode "parseError" in "endpoints can only have class types" pvl
   """
   seq_program Example() {
     endpoint alice = int();
-    run {
-
-    }
   }
   """
 }

--- a/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
+++ b/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
@@ -2,7 +2,7 @@ package vct.test.integration.examples
 
 import vct.test.integration.helper.VercorsSpec
 
-class TechnicalVeymontSpec extends VercorsSpec {
+class TechnicalVeyMontSpec extends VercorsSpec {
   vercors should error withCode "communicateNotSupported" in "example using communicate" pvl
   """
      class Storage {
@@ -45,17 +45,16 @@ class TechnicalVeymontSpec extends VercorsSpec {
   }
   """
 
-  // To be enabled when proper communiate support is implemented
-  // vercors should error withCode "noSuchName" in "non-existent field in communicate fails" pvl
-  // """
-  // class Storage { int x; }
-  // seq_program Example() {
-  //    endpoint charlie = Storage();
-  //    run {
-  //      communicate charlie.nonExistent <- charlie.nonExistent;
-  //    }
-  // }
-  // """
+  vercors should error withCode "noSuchName" in "non-existent field in communicate fails" pvl
+  """
+  class Storage { int x; }
+  seq_program Example() {
+     endpoint charlie = Storage();
+     run {
+       communicate charlie.nonExistent <- charlie.nonExistent;
+     }
+  }
+  """
 
   vercors should error withCode "parseError" in "parameterized sends not yet supported " pvl
   """
@@ -72,7 +71,7 @@ class TechnicalVeymontSpec extends VercorsSpec {
   vercors should error withCode "noRunMethod" in "run method should always be present" pvl
   """
   seq_program Example() { }
-  """.stripMargin
+  """
 
   vercors should error withCode "forbiddenEndpointType" in "endpoints can only have class types" pvl
   """
@@ -82,5 +81,5 @@ class TechnicalVeymontSpec extends VercorsSpec {
 
     }
   }
-  """.stripMargin
+  """
 }

--- a/test/main/vct/test/integration/meta/ExampleCoverage.scala
+++ b/test/main/vct/test/integration/meta/ExampleCoverage.scala
@@ -47,7 +47,7 @@ class ExampleCoverage extends AnyFlatSpec {
       new TechnicalJavaSpec(),
       new TechnicalSpec(),
       new TechnicalStaticSpec(),
-      new TechnicalVeymontSpec(),
+      new TechnicalVeyMontSpec(),
       new TerminationSpec(),
       new TypeValuesSpec(),
       new VerifyThisSpec(),


### PR DESCRIPTION
This PR adds resolution for communicate statements, endpoints, and endpoint field dereferences. It also factors the old VeyMont run method into a separate construct, the seq_run node.