### PR TITLE
VeyMont: seq_prog initialization & permission generation

### DIFF
--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -56,7 +56,9 @@ import vct.col.ast.family.location._
 import vct.col.ast.family.loopcontract._
 import vct.col.ast.family.parregion._
 import vct.col.ast.family.pvlcommunicate.{PVLCommunicateAccessImpl, PVLCommunicateImpl, PVLCommunicateSubjectImpl, PVLEndpointNameImpl, PVLFamilyRangeImpl, PVLIndexedFamilyNameImpl}
+import vct.col.ast.family.seqrun.SeqRunImpl
 import vct.col.ast.family.signals._
+import vct.col.ast.family.subject.EndpointNameImpl
 import vct.col.ast.lang._
 import vct.col.ast.lang.smt._
 import vct.col.ast.node._
@@ -1260,16 +1262,16 @@ case class PVLCommunicateAccess[G](subject: PVLCommunicateSubject[G], field: Str
   var ref: Option[RefField[G]] = None
 }
 case class PVLCommunicate[G](sender: PVLCommunicateAccess[G], receiver: PVLCommunicateAccess[G])(implicit val o: Origin) extends Statement[G] with PVLCommunicateImpl[G]
-final case class PVLSeqAssign[G](receiver: Ref[G, PVLEndpoint[G]], field: Ref[G, InstanceField[G]], value: Expr[G])(implicit val o: Origin) extends Statement[G]
+final case class PVLSeqAssign[G](receiver: Ref[G, PVLEndpoint[G]], field: Ref[G, InstanceField[G]], value: Expr[G])(implicit val o: Origin) extends Statement[G] with PVLSeqAssignImpl[G]
 
 final class Endpoint[G](val cls: Ref[G, Class[G]], val constructor: Ref[G, Procedure[G]], val args: Seq[Expr[G]])(implicit val o: Origin) extends Declaration[G] with EndpointImpl[G]
 final class SeqProg[G](val contract: ApplicableContract[G], val args : Seq[Variable[G]], val endpoints: Seq[Endpoint[G]], val run: SeqRun[G], val decls: Seq[ClassDeclaration[G]])(implicit val o: Origin) extends GlobalDeclaration[G] with SeqProgImpl[G]
-final case class SeqRun[G](body: Statement[G], contract: ApplicableContract[G])(val blame: Blame[CallableFailure])(implicit val o: Origin) extends NodeFamily[G]
+final case class SeqRun[G](body: Statement[G], contract: ApplicableContract[G])(val blame: Blame[CallableFailure])(implicit val o: Origin) extends NodeFamily[G] with SeqRunImpl[G]
 sealed trait Subject[G] extends NodeFamily[G]
-final case class EndpointName[G](ref: Ref[G, Endpoint[G]])(implicit val o: Origin) extends Subject[G]
+final case class EndpointName[G](ref: Ref[G, Endpoint[G]])(implicit val o: Origin) extends Subject[G] with EndpointNameImpl[G]
 case class Access[G](subject: Subject[G], field: Ref[G, InstanceField[G]])(implicit val o: Origin) extends NodeFamily[G] with AccessImpl[G]
-final case class Communicate[G](receiver: Access[G], sender: Access[G])(implicit val o: Origin) extends Statement[G]
-final case class SeqAssign[G](receiver: Ref[G, Endpoint[G]], field: Ref[G, InstanceField[G]], value: Expr[G])(implicit val o: Origin) extends Statement[G]
+final case class Communicate[G](receiver: Access[G], sender: Access[G])(implicit val o: Origin) extends Statement[G] with CommunicateImpl[G]
+final case class SeqAssign[G](receiver: Ref[G, Endpoint[G]], field: Ref[G, InstanceField[G]], value: Expr[G])(implicit val o: Origin) extends Statement[G] with SeqAssignImpl[G]
 final case class EndpointUse[G](ref: Ref[G, Endpoint[G]])(implicit val o: Origin) extends Expr[G] with EndpointUseImpl[G]
 
 final case class VeyMontAssignExpression[G](endpoint: Ref[G, Endpoint[G]], assign: Statement[G])(implicit val o: Origin) extends Statement[G] with VeyMontAssignExpressionImpl[G]

--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -224,7 +224,7 @@ final class HeapVariable[G](val t: Type[G])(implicit val o: Origin) extends Glob
 final class SimplificationRule[G](val axiom: Expr[G])(implicit val o: Origin) extends GlobalDeclaration[G] with SimplificationRuleImpl[G]
 final class AxiomaticDataType[G](val decls: Seq[ADTDeclaration[G]], val typeArgs: Seq[Variable[G]])(implicit val o: Origin) extends GlobalDeclaration[G] with AxiomaticDataTypeImpl[G]
 final class Class[G](val declarations: Seq[ClassDeclaration[G]], val supports: Seq[Ref[G, Class[G]]], val intrinsicLockInvariant: Expr[G])(implicit val o: Origin) extends GlobalDeclaration[G] with ClassImpl[G]
-final class SeqProg[G](val contract: ApplicableContract[G], val args : Seq[Variable[G]], val threads: Seq[Endpoint[G]], val run: SeqRun[G], val decls: Seq[ClassDeclaration[G]])(implicit val o: Origin) extends GlobalDeclaration[G] with SeqProgImpl[G]
+final class SeqProg[G](val contract: ApplicableContract[G], val args : Seq[Variable[G]], val endpoints: Seq[Endpoint[G]], val run: SeqRun[G], val decls: Seq[ClassDeclaration[G]])(implicit val o: Origin) extends GlobalDeclaration[G] with SeqProgImpl[G]
 final class Endpoint[G](val cls: Ref[G, Class[G]], val constructor: Ref[G, Procedure[G]], val args: Seq[Expr[G]])(implicit val o: Origin) extends Declaration[G] with EndpointImpl[G]
 final class Model[G](val declarations: Seq[ModelDeclaration[G]])(implicit val o: Origin) extends GlobalDeclaration[G] with Declarator[G] with ModelImpl[G]
 final class Function[G](val returnType: Type[G], val args: Seq[Variable[G]], val typeArgs: Seq[Variable[G]],
@@ -1270,7 +1270,7 @@ final case class Communicate[G](receiver: Access[G], sender: Access[G])(implicit
 final case class PVLSeqAssign[G](receiver: Ref[G, PVLEndpoint[G]], field: Ref[G, InstanceField[G]], value: Expr[G])(implicit val o: Origin) extends Statement[G]
 final case class SeqAssign[G](receiver: Ref[G, Endpoint[G]], field: Ref[G, InstanceField[G]], value: Expr[G])(implicit val o: Origin) extends Statement[G]
 
-final case class VeyMontAssignExpression[G](thread: Ref[G, Endpoint[G]], assign: Statement[G])(implicit val o: Origin) extends Statement[G] with VeyMontAssignExpressionImpl[G]
+final case class VeyMontAssignExpression[G](endpoint: Ref[G, Endpoint[G]], assign: Statement[G])(implicit val o: Origin) extends Statement[G] with VeyMontAssignExpressionImpl[G]
 
 final case class CommunicateX[G](receiver: Ref[G, Endpoint[G]], sender: Ref[G, Endpoint[G]], chanType: Type[G], assign: Statement[G])(implicit val o: Origin) extends Statement[G] with CommunicateXImpl[G]
 

--- a/src/col/vct/col/ast/declaration/global/SeqProgImpl.scala
+++ b/src/col/vct/col/ast/declaration/global/SeqProgImpl.scala
@@ -7,13 +7,13 @@ import vct.col.origin.Origin
 import vct.col.print._
 
 trait SeqProgImpl[G] extends Declarator[G] { this: SeqProg[G] =>
-  override def declarations: Seq[Declaration[G]] = args ++ threads ++ decls
+  override def declarations: Seq[Declaration[G]] = args ++ endpoints ++ decls
 
   override def layout(implicit ctx: Ctx): Doc =
     Doc.stack(Seq(
       contract,
       Group(Text("seq_program") <+> ctx.name(this) <> "(" <> Doc.args(args) <> ")") <+> "{" <>>
-        Doc.stack(threads ++ decls :+ run) <+/>
+        Doc.stack(endpoints ++ decls :+ run) <+/>
       "}"
     ))
 

--- a/src/col/vct/col/ast/expr/heap/read/DerefImpl.scala
+++ b/src/col/vct/col/ast/expr/heap/read/DerefImpl.scala
@@ -2,7 +2,7 @@ package vct.col.ast.expr.heap.read
 
 import vct.col.ast.expr.ExprImpl
 import vct.col.ast.{Deref, EndpointUse, Expr, TClass, Type}
-import vct.col.check.{Check, CheckContext, CheckError, SeqProgInvocationReceiver}
+import vct.col.check.{Check, CheckContext, CheckError, SeqProgReceivingEndpoint}
 import vct.col.print.{Ctx, Doc, Group, Precedence}
 import vct.col.ref.Ref
 
@@ -28,7 +28,7 @@ trait DerefImpl[G] extends ExprImpl[G] { this: Deref[G] =>
     (context.currentSeqProg, context.currentReceiverEndpoint) match {
     case (Some(_), Some(currentReceiver)) => root() match {
       case EndpointUse(Ref(receiver)) if currentReceiver != receiver =>
-        Seq(SeqProgInvocationReceiver(this))
+        Seq(SeqProgReceivingEndpoint(this))
       case _ => Seq()
     }
     case _ => Seq()

--- a/src/col/vct/col/ast/family/access/AccessImpl.scala
+++ b/src/col/vct/col/ast/family/access/AccessImpl.scala
@@ -1,6 +1,10 @@
 package vct.col.ast.family.access
 
 import vct.col.ast.{Access, Type}
+import vct.col.print.{Ctx, Doc, Text}
 
 trait AccessImpl[G] { this: Access[G] =>
+  override def layout(implicit ctx: Ctx): Doc = {
+    subject.show <> "." <> field.decl.o.getPreferredNameOrElse()
+  }
 }

--- a/src/col/vct/col/ast/family/seqrun/SeqRunImpl.scala
+++ b/src/col/vct/col/ast/family/seqrun/SeqRunImpl.scala
@@ -1,0 +1,10 @@
+package vct.col.ast.family.seqrun
+
+import vct.col.ast.SeqRun
+import vct.col.print.{Ctx, Doc, Text}
+
+trait SeqRunImpl[G] { this: SeqRun[G] =>
+  override def layout(implicit ctx: Ctx): Doc = {
+    contract.show </> Text("seq_run") <+> this.body.show
+  }
+}

--- a/src/col/vct/col/ast/family/subject/EndpointNameImpl.scala
+++ b/src/col/vct/col/ast/family/subject/EndpointNameImpl.scala
@@ -1,0 +1,9 @@
+package vct.col.ast.family.subject
+
+import vct.col.ast.EndpointName
+import vct.col.print.{Ctx, Doc, Text}
+
+trait EndpointNameImpl[G] { this: EndpointName[G] =>
+  override def layout(implicit ctx: Ctx): Doc =
+    Text(ref.decl.o.getPreferredNameOrElse())
+}

--- a/src/col/vct/col/ast/statement/exceptional/EvalImpl.scala
+++ b/src/col/vct/col/ast/statement/exceptional/EvalImpl.scala
@@ -9,7 +9,7 @@ trait EvalImpl[G] extends StatementImpl[G] { this: Eval[G] =>
   override def layout(implicit ctx: Ctx): Doc = expr.show <> ";"
 
   override def enterCheckContext(context: CheckContext[G]): CheckContext[G] = this match {
-    case Eval(MethodInvocation(EndpointUse(endpoint), _, _, _, _, _, _)) =>
+    case Eval(MethodInvocation(EndpointUse(endpoint), _, _, _, _, _, _)) if context.currentSeqProg.isDefined =>
       context.withReceiverEndpoint(endpoint.decl)
     case _ => context
   }

--- a/src/col/vct/col/ast/statement/veymont/CommunicateImpl.scala
+++ b/src/col/vct/col/ast/statement/veymont/CommunicateImpl.scala
@@ -1,0 +1,9 @@
+package vct.col.ast.statement.veymont
+
+import vct.col.ast.Communicate
+import vct.col.print.{Ctx, Doc, Text}
+
+trait CommunicateImpl[G] { this: Communicate[G] =>
+  override def layout(implicit ctx: Ctx): Doc =
+    Text("communicate") <+> receiver.show <+> "<-" <+> sender.show <> ";"
+}

--- a/src/col/vct/col/ast/statement/veymont/PVLSeqAssignImpl.scala
+++ b/src/col/vct/col/ast/statement/veymont/PVLSeqAssignImpl.scala
@@ -1,0 +1,9 @@
+package vct.col.ast.statement.veymont
+
+import vct.col.ast.PVLSeqAssign
+import vct.col.print.{Ctx, Doc, Group, Text}
+
+trait  PVLSeqAssignImpl[G] { this: PVLSeqAssign[G] =>
+  override def layout(implicit ctx: Ctx): Doc =
+    Group(Text(receiver.decl.name) <> "." <> field.decl.o.getPreferredNameOrElse() <+> ":=" <+> value.show)
+}

--- a/src/col/vct/col/ast/statement/veymont/SeqAssignImpl.scala
+++ b/src/col/vct/col/ast/statement/veymont/SeqAssignImpl.scala
@@ -1,0 +1,16 @@
+package vct.col.ast.statement.veymont
+
+import vct.col.ast.SeqAssign
+import vct.col.ast.statement.StatementImpl
+import vct.col.check.{CheckContext, CheckError}
+import vct.col.print.{Ctx, Doc, Group, Text}
+
+trait SeqAssignImpl[G] extends StatementImpl[G] { this: SeqAssign[G] =>
+
+  override def enterCheckContext(context: CheckContext[G]): CheckContext[G] =
+      context.withReceiverEndpoint(receiver.decl)
+
+  override def layout(implicit ctx: Ctx): Doc =
+    Group(Text(receiver.decl.o.getPreferredNameOrElse()) <> "." <> field.decl.o.getPreferredNameOrElse() <+> ":=" <+> value.show)
+
+}

--- a/src/col/vct/col/check/Check.scala
+++ b/src/col/vct/col/check/Check.scala
@@ -61,7 +61,7 @@ sealed trait CheckError {
     case SeqProgInstanceMethodBody(m) => Seq(context(m, "An instance method in a `seq_prog` must have a body."))
     case SeqProgInstanceMethodNonVoid(m) => Seq(context(m, "An instance method in a `seq_prog` must have return type `void`."))
     case SeqProgInvocation(s) => Seq(context(s, "Only invocations on `this` and endpoints are allowed."))
-    case SeqProgInvocationReceiver(e) => Seq(context(e, "Referring to other endpoints within an invocation on a specific endpoint is not yet supported."))
+    case SeqProgReceivingEndpoint(e) => Seq(context(e, s"Can only refer to the receiving endpoint of this statement"))
   }).mkString(Origin.BOLD_HR, Origin.HR, Origin.BOLD_HR)
 
   def subcode: String
@@ -121,8 +121,8 @@ case class SeqProgStatement(s: Statement[_]) extends CheckError {
 case class SeqProgInvocation(s: Statement[_]) extends CheckError {
   val subcode = "seqProgInvocation"
 }
-case class SeqProgInvocationReceiver(e: Expr[_]) extends CheckError {
-  val subcode = "seqProgInvocationReceiver"
+case class SeqProgReceivingEndpoint(e: Expr[_]) extends CheckError {
+  val subcode = "seqProgReceivingEndpoint"
 }
 
 case object CheckContext {

--- a/src/col/vct/col/resolve/Resolve.scala
+++ b/src/col/vct/col/resolve/Resolve.scala
@@ -286,7 +286,7 @@ case object ResolveReferences extends LazyLogging {
     case seqProg: SeqProg[G] => ctx
       .copy(currentThis = Some(RefSeqProg(seqProg)))
       .declare(seqProg.decls)
-      .declare(seqProg.threads)
+      .declare(seqProg.endpoints)
       .declare(seqProg.args)
     case seqProg: PVLSeqProg[G] => ctx
       .copy(currentThis = Some(RefPVLSeqProg(seqProg)))

--- a/src/col/vct/col/util/AstBuildHelpers.scala
+++ b/src/col/vct/col/util/AstBuildHelpers.scala
@@ -329,6 +329,16 @@ object AstBuildHelpers {
                        yields: Seq[(Expr[G], Ref[G, Variable[G]])] = Nil)(implicit o: Origin): MethodInvocation[G] =
     MethodInvocation(obj, ref, args, outArgs, typeArgs, givenMap, yields)(blame)
 
+  def procedureInvocation[G]
+                         (blame: Blame[InvocationFailure],
+                          ref: Ref[G, Procedure[G]],
+                          args: Seq[Expr[G]] = Nil,
+                          outArgs: Seq[Expr[G]] = Nil,
+                          typeArgs: Seq[Type[G]] = Nil,
+                          givenMap: Seq[(Ref[G, Variable[G]], Expr[G])] = Nil,
+                          yields: Seq[(Expr[G], Ref[G, Variable[G]])] = Nil)(implicit o: Origin): ProcedureInvocation[G] =
+    ProcedureInvocation(ref, args, outArgs, typeArgs, givenMap, yields)(blame)
+
   private def GeneratedQuantifier: Origin = Origin(
     Seq(
       PreferredName("i"),

--- a/src/main/vct/main/stages/Transformation.scala
+++ b/src/main/vct/main/stages/Transformation.scala
@@ -24,7 +24,7 @@ import vct.resources.Resources
 import vct.result.VerificationError.SystemError
 import vct.rewrite.{EncodeResourceValues, ExplicitResourceValues, HeapVariableToRef}
 import vct.rewrite.lang.ReplaceSYCLTypes
-import vct.rewrite.veymont.EncodeSeqProg
+import vct.rewrite.veymont.{EncodeSeqProg, GenerateSeqProgPermissions}
 
 object Transformation {
   case class TransformationCheckError(pass: RewriterBuilder, errors: Seq[(Program[_], CheckError)]) extends SystemError {
@@ -193,6 +193,7 @@ case class SilverTransformation
     EncodeRangedFor,
 
     // VeyMont sequential program encoding
+    GenerateSeqProgPermissions,
     EncodeSeqProg,
 
     EncodeString, // Encode spec string as seq<int>

--- a/src/main/vct/main/stages/Transformation.scala
+++ b/src/main/vct/main/stages/Transformation.scala
@@ -176,8 +176,6 @@ case class SilverTransformation
     // Replace leftover SYCL types
     ReplaceSYCLTypes,
 
-    EncodeSeqProg,
-
     ComputeBipGlue,
     InstantiateBipSynchronizations,
     EncodeBipPermissions,
@@ -193,6 +191,9 @@ case class SilverTransformation
     Disambiguate, // Resolve overloaded operators (+, subscript, etc.)
     DisambiguateLocation, // Resolve location type
     EncodeRangedFor,
+
+    // VeyMont sequential program encoding
+    EncodeSeqProg,
 
     EncodeString, // Encode spec string as seq<int>
     EncodeChar,

--- a/src/rewrite/vct/rewrite/veymont/AddVeyMontConditionNodes.scala
+++ b/src/rewrite/vct/rewrite/veymont/AddVeyMontConditionNodes.scala
@@ -30,7 +30,7 @@ case class AddVeyMontConditionNodes[Pre <: Generation]() extends Rewriter[Pre] {
   override def dispatch(decl: Declaration[Pre]): Unit =
     decl match {
       case dcl: SeqProg[Pre] =>
-        inSeqProg.push(dcl.threads.size)
+        inSeqProg.push(dcl.endpoints.size)
         try {
           rewriteDefault(dcl)
         } finally {

--- a/src/rewrite/vct/rewrite/veymont/EncodeSeqProg.scala
+++ b/src/rewrite/vct/rewrite/veymont/EncodeSeqProg.scala
@@ -2,7 +2,7 @@ package vct.rewrite.veymont
 
 import com.typesafe.scalalogging.LazyLogging
 import hre.util.ScopedStack
-import vct.col.ast.{AbstractRewriter, Class, Communicate, Declaration, Endpoint, EndpointUse, Expr, Local, Procedure, SeqAssign, SeqProg, SeqRun, Statement, TClass, TVoid, Variable}
+import vct.col.ast.{Assign, Block, Class, Communicate, Declaration, Endpoint, EndpointUse, Eval, Expr, Local, LocalDecl, Procedure, SeqAssign, SeqProg, SeqRun, Statement, TClass, TVoid, Variable}
 import vct.col.origin.{DiagnosticOrigin, Origin, PanicBlame}
 import vct.col.rewrite.{Generation, Rewriter, RewriterBuilder}
 import vct.col.util.AstBuildHelpers._
@@ -32,14 +32,72 @@ case class EncodeSeqProg[Pre <: Generation]() extends Rewriter[Pre] with LazyLog
   val currentProg: ScopedStack[SeqProg[Pre]] = ScopedStack()
   val currentRun: ScopedStack[SeqRun[Pre]] = ScopedStack()
 
-  val endpointToRunVar: mut.Map[Endpoint[Pre], Variable[Post]] = mut.LinkedHashMap()
+  sealed trait Mode
+  case object Top extends Mode
+  case class InProg(prog: SeqProg[Pre]) extends Mode
+  case class InRun(prog: SeqProg[Pre], run: SeqRun[Pre]) extends Mode
+
+  def mode: Mode = (currentProg.topOption, currentRun.topOption) match {
+    case (None, None) => Top
+    case (Some(prog), None) => InProg(prog)
+    case (Some(prog), Some(run)) => InRun(prog, run)
+    case (None, Some(_)) => throw new RuntimeException()
+  }
+
+  val runToProc: mut.Map[SeqRun[Pre], Procedure[Post]] = mut.LinkedHashMap()
+
+  val seqProgSucc: SuccessionMap[SeqProg[Pre], Procedure[Post]] = SuccessionMap()
+  val endpointSucc: SuccessionMap[(Mode, Endpoint[Pre]), Variable[Post]] = SuccessionMap()
+  val variableSucc: SuccessionMap[(Mode, Variable[Pre]), Variable[Post]] = SuccessionMap()
 
   override def dispatch(decl: Declaration[Pre]): Unit = decl match {
     case prog: SeqProg[Pre] => currentProg.having(prog) {
       // First generate a procedure that implements the run method
       rewriteRun(prog.run)
+
       // Then generate a procedure that initializes all the endpoints and calls the run procedure
-      generateSeqProgMain(prog)
+      // First set up the succesor variables that will be encoding the seq_program argument and endpoints
+      implicit val o = DiagnosticOrigin
+      prog.endpoints.foreach(_.drop())
+      for (endpoint <- currentProg.top.endpoints) {
+        endpointSucc((mode, endpoint)) = new Variable(TClass(succ[Class[Post]](endpoint.cls.decl)))(endpoint.o)
+      }
+
+      // Maintain successor for seq_prog argument variables manually, as two contexts are maintained
+      // The main procedure context and run procedure contex
+      prog.args.foreach(_.drop())
+      for(arg <- prog.args) {
+        variableSucc((mode, arg)) = new Variable(dispatch(arg.t))(arg.o)
+      }
+
+      seqProgSucc(prog) = globalDeclarations.declare(new Procedure(
+        returnType = TVoid(), outArgs = Seq(), typeArgs = Seq(),
+        args = prog.args.map(arg => variableSucc((mode, arg))),
+        contract = dispatch(prog.contract),
+        body = Some(Block(
+          prog.endpoints.flatMap { endpoint =>
+            val v = endpointSucc((mode, endpoint))
+            Seq(
+              LocalDecl(v),
+              Assign(
+                Local[Post](v.ref),
+                procedureInvocation[Post](
+                  ref = succ(endpoint.constructor.decl),
+                  args = endpoint.args.map(dispatch),
+                  blame = PanicBlame("TODO: endpoint constructor failure blame")
+                )
+              )(PanicBlame("TODO: Constructor assign failure blame"))
+            )
+          }
+          :+
+          Eval(procedureInvocation[Post](
+            ref = runToProc(prog.run).ref,
+            args = prog.args.map(arg => Local[Post](variableSucc((mode, arg)).ref)) ++
+              prog.endpoints.map(endpoint => Local[Post](endpointSucc((mode, endpoint)).ref)),
+            blame = PanicBlame("TODO: run invocation failure blame")
+          ))
+        ))
+      )(PanicBlame("TODO: callable failure blame")))
     }
     case _ => rewriteDefault(decl)
   }
@@ -47,24 +105,24 @@ case class EncodeSeqProg[Pre <: Generation]() extends Rewriter[Pre] with LazyLog
   def rewriteRun(run: SeqRun[Pre]): Unit = {
     implicit val o: Origin = DiagnosticOrigin
 
-    for(endpoint <- currentProg.top.threads) {
-      endpointToRunVar(endpoint) = new Variable(TClass(succ[Class[Post]](endpoint.cls.decl)))
-    }
-
     currentRun.having(run) {
-      globalDeclarations.declare(new Procedure(
-        args = currentProg.top.threads.map(endpoint => endpointToRunVar(endpoint)),
+      for (endpoint <- currentProg.top.endpoints) {
+        endpointSucc((mode, endpoint)) = new Variable(TClass(succ[Class[Post]](endpoint.cls.decl)))
+      }
+
+      for (arg <- currentProg.top.args) {
+        variableSucc((mode, arg)) = new Variable(dispatch(arg.t))(arg.o)
+      }
+
+      runToProc(run) = globalDeclarations.declare(new Procedure(
+        args = currentProg.top.args.map(arg => variableSucc((mode, arg))) ++
+          currentProg.top.endpoints.map(endpoint => endpointSucc((mode, endpoint))),
         contract = dispatch(run.contract),
         body = Some(dispatch(run.body)),
         outArgs = Seq(), typeArgs = Seq(),
         returnType = TVoid(),
-      )(PanicBlame("TODO: inner run blame"))) // CallableFailure
+      )(PanicBlame("TODO: inner run blame")))
     }
-  }
-
-  def generateSeqProgMain(prog: SeqProg[Pre]): Unit = {
-    prog.drop()
-    logger.warn("SeqProg main generation not yet supported")
   }
 
   override def dispatch(stat: Statement[Pre]): Statement[Post] = stat match {
@@ -73,8 +131,12 @@ case class EncodeSeqProg[Pre <: Generation]() extends Rewriter[Pre] with LazyLog
     case stat => rewriteDefault(stat)
   }
 
-  override def dispatch(expr: Expr[Pre]): Expr[Post] = expr match {
-    case EndpointUse(Ref(endpoint)) => Local[Post](endpointToRunVar(endpoint).ref)(expr.o)
-    case expr => rewriteDefault(expr)
+  override def dispatch(expr: Expr[Pre]): Expr[Post] = (mode, expr) match {
+    case (Top, EndpointUse(Ref(endpoint))) => throw new RuntimeException()
+    case (mode, EndpointUse(Ref(endpoint))) =>
+      Local[Post](endpointSucc((mode, endpoint)).ref)(expr.o)
+    case (mode, Local(Ref(v))) if mode != Top && currentProg.top.args.contains(v) =>
+      Local[Post](variableSucc((mode, v)).ref)(expr.o)
+    case (_, expr) => rewriteDefault(expr)
   }
 }

--- a/src/rewrite/vct/rewrite/veymont/GenerateSeqProgPermissions.scala
+++ b/src/rewrite/vct/rewrite/veymont/GenerateSeqProgPermissions.scala
@@ -1,0 +1,103 @@
+package vct.rewrite.veymont
+
+import com.typesafe.scalalogging.LazyLogging
+import hre.util.ScopedStack
+import vct.col.ast.RewriteHelpers._
+import vct.col.util.AstBuildHelpers._
+import vct.col.ast.{ApplicableContract, ArraySubscript, Declaration, Deref, Endpoint, EndpointUse, EnumUse, Expr, FieldLocation, InstanceField, IterationContract, Length, Local, LoopContract, LoopInvariant, Null, Perm, SeqProg, SeqRun, SplitAccountedPredicate, TArray, TClass, TInt, Type, UnitAccountedPredicate, WritePerm}
+import vct.col.origin.{Origin, PanicBlame}
+import vct.col.ref.Ref
+import vct.col.rewrite.{Generation, Rewriter, RewriterBuilder}
+
+object GenerateSeqProgPermissions extends RewriterBuilder {
+  override def key: String = "generateSeqProgPermissions"
+  override def desc: String = "Generates permissions for fields of some types (int, bool, and arrays of simple datatypes) for constructs used inside seq_program."
+}
+
+case class GenerateSeqProgPermissions[Pre <: Generation]() extends Rewriter[Pre] with LazyLogging {
+
+  val currentProg: ScopedStack[SeqProg[Pre]] = ScopedStack()
+  val currentRun: ScopedStack[SeqRun[Pre]] = ScopedStack()
+
+  override def dispatch(decl: Declaration[Pre]): Unit = decl match {
+    case prog: SeqProg[Pre] => currentProg.having(prog) { rewriteDefault(prog) }
+    case decl => rewriteDefault(decl)
+  }
+
+  override def dispatch(run: SeqRun[Pre]): SeqRun[Post] = currentRun.having(run) { rewriteDefault(run) }
+
+  override def dispatch(contract: ApplicableContract[Pre]): ApplicableContract[Post] =
+    (currentProg.topOption, currentRun.topOption) match {
+      case (Some(prog), Some(_)) =>
+        implicit val o = contract.o
+        contract.rewrite(
+          requires =
+            SplitAccountedPredicate[Post](
+              UnitAccountedPredicate(foldStar[Post](prog.endpoints.map(endpointPerm))),
+              dispatch(contract.requires)
+            ),
+          ensures =
+           SplitAccountedPredicate[Post](
+             UnitAccountedPredicate(foldStar[Post](prog.endpoints.map(endpointPerm))),
+             dispatch(contract.ensures)
+           )
+        )
+      case _ => rewriteDefault(contract)
+    }
+
+  override def dispatch(loopContract: LoopContract[Pre]): LoopContract[Post] = (currentProg.topOption, currentRun.topOption, loopContract) match {
+    case (Some(prog), Some(_), invariant: LoopInvariant[pre]) =>
+      implicit val o = loopContract.o
+      invariant.rewrite(
+        invariant = foldStar[Post](prog.endpoints.map(endpointPerm) :+ dispatch(invariant.invariant))
+      )
+    case (Some(prog), Some(_), iteration: IterationContract[pre]) =>
+      implicit val o = loopContract.o
+      iteration.rewrite(
+        requires = foldStar[Post](prog.endpoints.map(endpointPerm) :+ dispatch(iteration.requires)),
+        ensures = foldStar[Post](prog.endpoints.map(endpointPerm) :+ dispatch(iteration.ensures))
+      )
+    case _ => rewriteDefault(loopContract)
+  }
+
+  def endpointPerm(endpoint: Endpoint[Pre])(implicit o: Origin): Expr[Post] =
+    transitivePerm(EndpointUse[Post](succ(endpoint)), TClass(endpoint.cls))
+
+  /*
+
+  int x;
+  => perm(x, 1);
+
+  int[] x;
+  => perm(x, 1) ** x != null ** (\forall int i = 0 .. x.length; perm(x[i], 1))
+
+  cell x;
+  => perm(x, 1) ** perm(x.v, 1)
+
+  cell[] x;
+  => perm(x, 1) ** x != null ** (\forall int i = 0 .. x.length; perm(x[i], 1) ** perm(x[i].v, 1))
+
+   */
+
+  def transitivePerm(e: Expr[Post], t: Type[Pre])(implicit o: Origin): Expr[Post] = t match {
+    case TArray(u) =>
+      (e !== Null()) &*
+      starall[Post](
+        /* Only with --assumeinjectivityoninhale. However, this will be deleted in later versions of veymont,
+                 so it's fine if its incomplete */
+        PanicBlame("Quantifying over an array should be injective."),
+        TInt(),
+        (i: Local[Post]) => ((const[Post](0) <= i) && (i < Length(e)(PanicBlame("Array is guaranteed non-null")))) ==>
+          (arrayPerm(e, i, WritePerm(), PanicBlame("Encoding guarantees well-formedness")) &*
+            transitivePerm(ArraySubscript(e, i)(PanicBlame("Encoding guarantees well-formedness")), u))
+      )
+    case TClass(Ref(cls)) => foldStar(cls.collect { case f: InstanceField[Pre] => fieldTransitivePerm(e, f) })
+    case _ => tt
+  }
+
+  def fieldTransitivePerm(`this`: Expr[Post], f: InstanceField[Pre])(implicit o: Origin): Expr[Post] = {
+    fieldPerm[Post](`this`, succ(f), WritePerm()) &*
+      transitivePerm(Deref[Post](`this`, succ(f))(PanicBlame("Permission for this field is already established")), f.t)
+  }
+
+}

--- a/src/rewrite/vct/rewrite/veymont/ParalleliseVeyMontThreads.scala
+++ b/src/rewrite/vct/rewrite/veymont/ParalleliseVeyMontThreads.scala
@@ -74,7 +74,7 @@ case class ParalleliseEndpoints[Pre <: Generation](channelClass: JavaClass[_]) e
     channelClasses.foreach{ case (t,c) =>
       globalDeclarations.declare(c)
     }
-    seqProg.threads.foreach(thread => {
+    seqProg.endpoints.foreach(thread => {
       val threadField = new InstanceField[Post](TClass(givenClassSucc.ref(thread.t)), Set.empty)(thread.o)
       val channelFields = getChannelFields(thread, indexedChannelInfo, channelClasses)
       threadBuildingBlocks.having(new ThreadBuildingBlocks(seqProg.run, seqProg.decls, channelFields, channelClasses, thread, threadField)) {

--- a/src/rewrite/vct/rewrite/veymont/StructureCheck.scala
+++ b/src/rewrite/vct/rewrite/veymont/StructureCheck.scala
@@ -46,7 +46,7 @@ case class StructureCheck[Pre <: Generation]() extends Rewriter[Pre] {
   override def dispatch(prog : Program[Pre]) : Program[Post] = {
     if(!prog.declarations.exists {
       case dcl: SeqProg[Pre] =>
-        if(dcl.threads.isEmpty)
+        if(dcl.endpoints.isEmpty)
           throw VeyMontStructCheckError(dcl,"A seq_program needs to have at least 1 thread, but none was found!")
         else true
       case _ => false

--- a/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
+++ b/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
@@ -3,7 +3,8 @@ package vct.test.integration.examples
 import vct.test.integration.helper.VercorsSpec
 
 class TechnicalVeyMontSpec extends VercorsSpec {
-  vercors should error withCode "communicateNotSupported" in "example using communicate" pvl
+  // TODO: Should eventually become pass
+  vercors should error withCode "generatedPermMissing" in "example using communicate" pvl
   """
      class Storage {
         int x;

--- a/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
+++ b/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
@@ -4,7 +4,7 @@ import vct.test.integration.helper.VercorsSpec
 
 class TechnicalVeyMontSpec extends VercorsSpec {
   // TODO: Should eventually become pass
-  vercors should error withCode "generatedPermMissing" in "example using communicate" pvl
+  vercors should verify using silicon in "example using communicate" pvl
   """
      class Storage {
         int x;
@@ -21,7 +21,7 @@ class TechnicalVeyMontSpec extends VercorsSpec {
      }
   """
 
-  vercors should fail withCode "perm" using silicon in "plain endpoint field dereference should be possible" pvl
+  vercors should fail withCode "assertFailed:false" using silicon in "plain endpoint field dereference should be possible" pvl
   """
      class Storage {
         int x;
@@ -79,7 +79,7 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   }
   """
 
-  vercors should fail withCode "perm" using silicon in "Endpoint fields should be assignable" pvl
+  vercors should verify using silicon in "Endpoint fields should be assignable" pvl
   """
   class Storage { int x; int y; }
   seq_program Example() {
@@ -128,7 +128,7 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   }
   """
 
-  vercors should error withCode "resolutionError:seqProgInvocationReceiver" in "Dereferencing anything other than the receiving endpoint in the arguments of a endpoint method invocation is not supported yet" pvl
+  vercors should error withCode "resolutionError:seqProgReceivingEndpoint" in "Dereferencing anything other than the receiving endpoint in the arguments of a endpoint method invocation is not supported yet" pvl
   """
   class C { C d; void foo(int x); int x; }
   seq_program Example(C c) {
@@ -184,24 +184,32 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   }
   """
 
-  vercors should fail withCode "perm" using silicon in "assignment should work" pvl
+  /* TODO: In the new veymont, this test will probably be replaced by one that manually manages the
+           permissions for alice.x
+  */
+  vercors should verify using silicon in "assignment should work" pvl
   """
   class Storage {
-     int x;
+    int x;
+
+    ensures Perm(x, 1) ** x == 0;
+    constructor() {
+      x = 0;
+    }
   }
   seq_program Example() {
      endpoint alice = Storage();
 
+     requires alice.x == 0;
      ensures alice.x == 0;
      seq_run {
-
        assert alice.x == 0;
      }
   }
   """
 
   // TODO: Eventually should be postconditionFailed if the assignment statement works succesfully
-  vercors should fail withCode "perm" using silicon in "assigning should change state" pvl
+  vercors should error withCode "callableFailureNotSupported" in "assigning should change state" pvl
   """
   class Storage {
      int x;
@@ -218,6 +226,21 @@ class TechnicalVeyMontSpec extends VercorsSpec {
      ensures alice.x == 0;
      seq_run {
        alice.x := 1;
+     }
+  }
+  """
+
+  vercors should error withCode "resolutionError:seqProgReceivingEndpoint" in "Assignment statement only allows one endpoint in the assigned expression" pvl
+  """
+  class Storage {
+     int x;
+  }
+  seq_program Example() {
+     endpoint alice = Storage();
+     endpoint bob = Storage();
+
+     seq_run {
+       alice.x := bob.x;
      }
   }
   """

--- a/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
+++ b/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
@@ -78,7 +78,7 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   }
   """
 
-  vercors should error withCode "seqAssignNotSupported" in "Endpoint fields should be assignable" pvl
+  vercors should fail withCode "perm" using silicon in "Endpoint fields should be assignable" pvl
   """
   class Storage { int x; int y; }
   seq_program Example() {
@@ -180,6 +180,44 @@ class TechnicalVeyMontSpec extends VercorsSpec {
     seq_run {
       communicate charlie.c <- alice.a;
     }
+  }
+  """
+
+  vercors should fail withCode "perm" using silicon in "assignment should work" pvl
+  """
+  class Storage {
+     int x;
+  }
+  seq_program Example() {
+     endpoint alice = Storage();
+
+     ensures alice.x == 0;
+     seq_run {
+
+       assert alice.x == 0;
+     }
+  }
+  """
+
+  // TODO: Eventually should be postconditionFailed if the assignment statement works succesfully
+  vercors should fail withCode "perm" using silicon in "assigning should change state" pvl
+  """
+  class Storage {
+     int x;
+
+     ensures Perm(x, write) ** x == v;
+     constructor(int v) {
+       x = v;
+     }
+  }
+  seq_program Example() {
+     endpoint alice = Storage(0);
+
+     requires alice.x == 0;
+     ensures alice.x == 0;
+     seq_run {
+       alice.x := 1;
+     }
   }
   """
 }

--- a/test/main/vct/test/integration/helper/VercorsSpec.scala
+++ b/test/main/vct/test/integration/helper/VercorsSpec.scala
@@ -118,10 +118,10 @@ abstract class VercorsSpec extends AnyFlatSpec {
       case AnyFail => value match {
         case Left(err: UserError) =>
           println(err)
-          fail(s"Expected the test to pass, but it returned an error with code ${err.code} instead.")
+          fail(s"Expected the test to fail, but it returned an error with code ${err.code} instead.")
         case Left(err: SystemError) =>
           println(err)
-          fail(s"Expected the test to pass, but it crashed with the above error instead.")
+          fail(s"Expected the test to fail, but it crashed with the above error instead.")
         case Right((Nil, _)) =>
           fail("Expected the test to fail, but it passed instead.")
         case Right((_, _)) => // success
@@ -129,12 +129,12 @@ abstract class VercorsSpec extends AnyFlatSpec {
       case Fail(code) => value match {
         case Left(err: UserError) =>
           println(err)
-          fail(s"Expected the test to pass, but it returned an error with code ${err.code} instead.")
+          fail(s"Expected the test to fail with code $code, but it returned an error with code ${err.code} instead.")
         case Left(err: SystemError) =>
           println(err)
-          fail(s"Expected the test to pass, but it crashed with the above error instead.")
+          fail(s"Expected the test to fail with code $code, but it crashed with the above error instead.")
         case Right((Nil, _)) =>
-          fail("Expected the test to fail, but it passed instead.")
+          fail("Expected the test to fail with code $code, but it passed instead.")
         case Right((fails, _)) => fails.filterNot(_.code == code) match {
           case Nil => // success
           case fails =>


### PR DESCRIPTION
- Endpoint receiver logic and checks for the seqassign statement
- Initialization code for sequential program analysis
- Encoding for seqassign and communicate
- Pretty printing for a few new internal VeyMont nodes