### PR TITLE
VeyMont: full permission generation & auxiliary methods

### DIFF
--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -1255,8 +1255,8 @@ final case class TEndpoint[G](cls: Ref[G, Endpoint[G]])(implicit val o: Origin =
 final class PVLEndpoint[G](val name: String, val cls: Ref[G, Class[G]], val args: Seq[Expr[G]])(implicit val o: Origin) extends ClassDeclaration[G] {
   var ref: Option[PVLConstructorTarget[G]] = None
 }
-final class PVLSeqProg[G](val name: String, val declarations: Seq[ClassDeclaration[G]], val contract: ApplicableContract[G], val args: Seq[Variable[G]])(implicit val o: Origin) extends GlobalDeclaration[G] with PVLSeqProgImpl[G] with Declarator[G]
-final case class PVLSeqRun[G](body: Statement[G], contract: ApplicableContract[G])(val blame: Blame[CallableFailure])(implicit val o: Origin) extends ClassDeclaration[G]
+final class PVLSeqProg[G](val name: String, val declarations: Seq[ClassDeclaration[G]], val contract: ApplicableContract[G], val args: Seq[Variable[G]])(val blame: Blame[PVLSeqProgFailure])(implicit val o: Origin) extends GlobalDeclaration[G] with PVLSeqProgImpl[G] with Declarator[G]
+final case class PVLSeqRun[G](body: Statement[G], contract: ApplicableContract[G])(val blame: Blame[PVLSeqRunFailure])(implicit val o: Origin) extends ClassDeclaration[G]
 
 sealed trait PVLSubject[G] extends NodeFamily[G] with PVLSubjectImpl[G]
 case class PVLEndpointName[G](name: String)(implicit val o: Origin) extends PVLSubject[G] with PVLEndpointNameImpl[G] {
@@ -1275,8 +1275,8 @@ case class PVLCommunicate[G](sender: PVLAccess[G], receiver: PVLAccess[G])(impli
 final case class PVLSeqAssign[G](receiver: Ref[G, PVLEndpoint[G]], field: Ref[G, InstanceField[G]], value: Expr[G])(val blame: Blame[PVLSeqAssignFailure])(implicit val o: Origin) extends Statement[G] with PVLSeqAssignImpl[G]
 
 final class Endpoint[G](val cls: Ref[G, Class[G]], val constructor: Ref[G, Procedure[G]], val args: Seq[Expr[G]])(implicit val o: Origin) extends Declaration[G] with EndpointImpl[G]
-final class SeqProg[G](val contract: ApplicableContract[G], val args : Seq[Variable[G]], val endpoints: Seq[Endpoint[G]], val run: SeqRun[G], val decls: Seq[ClassDeclaration[G]])(implicit val o: Origin) extends GlobalDeclaration[G] with SeqProgImpl[G]
-final case class SeqRun[G](body: Statement[G], contract: ApplicableContract[G])(val blame: Blame[CallableFailure])(implicit val o: Origin) extends NodeFamily[G] with SeqRunImpl[G]
+final class SeqProg[G](val contract: ApplicableContract[G], val args : Seq[Variable[G]], val endpoints: Seq[Endpoint[G]], val run: SeqRun[G], val decls: Seq[ClassDeclaration[G]])(val blame: Blame[SeqProgFailure])(implicit val o: Origin) extends GlobalDeclaration[G] with SeqProgImpl[G]
+final case class SeqRun[G](body: Statement[G], contract: ApplicableContract[G])(val blame: Blame[SeqRunFailure])(implicit val o: Origin) extends NodeFamily[G] with SeqRunImpl[G]
 sealed trait Subject[G] extends NodeFamily[G]
 final case class EndpointName[G](ref: Ref[G, Endpoint[G]])(implicit val o: Origin) extends Subject[G] with EndpointNameImpl[G]
 case class Access[G](subject: Subject[G], field: Ref[G, InstanceField[G]])(val blame: Blame[AccessFailure])(implicit val o: Origin) extends NodeFamily[G] with AccessImpl[G]

--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -55,7 +55,7 @@ import vct.col.ast.family.javavar.JavaVariableDeclarationImpl
 import vct.col.ast.family.location._
 import vct.col.ast.family.loopcontract._
 import vct.col.ast.family.parregion._
-import vct.col.ast.family.pvlcommunicate.{PVLCommunicateAccessImpl, PVLCommunicateImpl, PVLCommunicateSubjectImpl, PVLEndpointNameImpl, PVLFamilyRangeImpl, PVLIndexedFamilyNameImpl}
+import vct.col.ast.family.pvlcommunicate.{PVLAccessImpl, PVLCommunicateImpl, PVLSubjectImpl, PVLEndpointNameImpl, PVLFamilyRangeImpl, PVLIndexedFamilyNameImpl}
 import vct.col.ast.family.seqguard._
 import vct.col.ast.family.seqrun.SeqRunImpl
 import vct.col.ast.family.signals._
@@ -1258,7 +1258,7 @@ final class PVLEndpoint[G](val name: String, val cls: Ref[G, Class[G]], val args
 final class PVLSeqProg[G](val name: String, val declarations: Seq[ClassDeclaration[G]], val contract: ApplicableContract[G], val args: Seq[Variable[G]])(implicit val o: Origin) extends GlobalDeclaration[G] with PVLSeqProgImpl[G] with Declarator[G]
 final case class PVLSeqRun[G](body: Statement[G], contract: ApplicableContract[G])(val blame: Blame[CallableFailure])(implicit val o: Origin) extends ClassDeclaration[G]
 
-sealed trait PVLSubject[G] extends NodeFamily[G] with PVLCommunicateSubjectImpl[G]
+sealed trait PVLSubject[G] extends NodeFamily[G] with PVLSubjectImpl[G]
 case class PVLEndpointName[G](name: String)(implicit val o: Origin) extends PVLSubject[G] with PVLEndpointNameImpl[G] {
   var ref: Option[RefPVLEndpoint[G]] = None
 }
@@ -1268,7 +1268,7 @@ case class PVLIndexedFamilyName[G](family: String, index: Expr[G])(implicit val 
 case class PVLFamilyRange[G](family: String, binder: String, start: Expr[G], end: Expr[G])(implicit val o: Origin) extends PVLSubject[G] with PVLFamilyRangeImpl[G] {
   var ref: Option[RefPVLEndpoint[G]] = None
 }
-case class PVLAccess[G](subject: PVLSubject[G], field: String)(implicit val o: Origin) extends NodeFamily[G] with PVLCommunicateAccessImpl[G] {
+case class PVLAccess[G](subject: PVLSubject[G], field: String)(implicit val o: Origin) extends NodeFamily[G] with PVLAccessImpl[G] {
   var ref: Option[RefField[G]] = None
 }
 case class PVLCommunicate[G](sender: PVLAccess[G], receiver: PVLAccess[G])(val blame: Blame[PVLCommunicateFailure])(implicit val o: Origin) extends Statement[G] with PVLCommunicateImpl[G]

--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -1268,10 +1268,10 @@ case class PVLIndexedFamilyName[G](family: String, index: Expr[G])(implicit val 
 case class PVLFamilyRange[G](family: String, binder: String, start: Expr[G], end: Expr[G])(implicit val o: Origin) extends PVLSubject[G] with PVLFamilyRangeImpl[G] {
   var ref: Option[RefPVLEndpoint[G]] = None
 }
-case class PVLAccess[G](subject: PVLSubject[G], field: String)(implicit val o: Origin) extends NodeFamily[G] with PVLAccessImpl[G] {
+case class PVLAccess[G](subject: PVLSubject[G], field: String)(val blame: Blame[PVLAccessFailure])(implicit val o: Origin) extends NodeFamily[G] with PVLAccessImpl[G] {
   var ref: Option[RefField[G]] = None
 }
-case class PVLCommunicate[G](sender: PVLAccess[G], receiver: PVLAccess[G])(val blame: Blame[PVLCommunicateFailure])(implicit val o: Origin) extends Statement[G] with PVLCommunicateImpl[G]
+case class PVLCommunicate[G](sender: PVLAccess[G], receiver: PVLAccess[G])(implicit val o: Origin) extends Statement[G] with PVLCommunicateImpl[G]
 final case class PVLSeqAssign[G](receiver: Ref[G, PVLEndpoint[G]], field: Ref[G, InstanceField[G]], value: Expr[G])(val blame: Blame[PVLSeqAssignFailure])(implicit val o: Origin) extends Statement[G] with PVLSeqAssignImpl[G]
 
 final class Endpoint[G](val cls: Ref[G, Class[G]], val constructor: Ref[G, Procedure[G]], val args: Seq[Expr[G]])(implicit val o: Origin) extends Declaration[G] with EndpointImpl[G]
@@ -1279,8 +1279,8 @@ final class SeqProg[G](val contract: ApplicableContract[G], val args : Seq[Varia
 final case class SeqRun[G](body: Statement[G], contract: ApplicableContract[G])(val blame: Blame[CallableFailure])(implicit val o: Origin) extends NodeFamily[G] with SeqRunImpl[G]
 sealed trait Subject[G] extends NodeFamily[G]
 final case class EndpointName[G](ref: Ref[G, Endpoint[G]])(implicit val o: Origin) extends Subject[G] with EndpointNameImpl[G]
-case class Access[G](subject: Subject[G], field: Ref[G, InstanceField[G]])(implicit val o: Origin) extends NodeFamily[G] with AccessImpl[G]
-final case class Communicate[G](receiver: Access[G], sender: Access[G])(val blame: Blame[CommunicateFailure])(implicit val o: Origin) extends Statement[G] with CommunicateImpl[G]
+case class Access[G](subject: Subject[G], field: Ref[G, InstanceField[G]])(val blame: Blame[AccessFailure])(implicit val o: Origin) extends NodeFamily[G] with AccessImpl[G]
+final case class Communicate[G](receiver: Access[G], sender: Access[G])(implicit val o: Origin) extends Statement[G] with CommunicateImpl[G]
 final case class SeqAssign[G](receiver: Ref[G, Endpoint[G]], field: Ref[G, InstanceField[G]], value: Expr[G])(val blame: Blame[SeqAssignFailure])(implicit val o: Origin) extends Statement[G] with SeqAssignImpl[G]
 final case class EndpointUse[G](ref: Ref[G, Endpoint[G]])(implicit val o: Origin) extends Expr[G] with EndpointUseImpl[G]
 

--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -1271,8 +1271,8 @@ case class PVLFamilyRange[G](family: String, binder: String, start: Expr[G], end
 case class PVLCommunicateAccess[G](subject: PVLCommunicateSubject[G], field: String)(implicit val o: Origin) extends NodeFamily[G] with PVLCommunicateAccessImpl[G] {
   var ref: Option[RefField[G]] = None
 }
-case class PVLCommunicate[G](sender: PVLCommunicateAccess[G], receiver: PVLCommunicateAccess[G])(implicit val o: Origin) extends Statement[G] with PVLCommunicateImpl[G]
-final case class PVLSeqAssign[G](receiver: Ref[G, PVLEndpoint[G]], field: Ref[G, InstanceField[G]], value: Expr[G])(implicit val o: Origin) extends Statement[G] with PVLSeqAssignImpl[G]
+case class PVLCommunicate[G](sender: PVLCommunicateAccess[G], receiver: PVLCommunicateAccess[G])(val blame: Blame[PVLCommunicateFailure])(implicit val o: Origin) extends Statement[G] with PVLCommunicateImpl[G]
+final case class PVLSeqAssign[G](receiver: Ref[G, PVLEndpoint[G]], field: Ref[G, InstanceField[G]], value: Expr[G])(val blame: Blame[PVLSeqAssignFailure])(implicit val o: Origin) extends Statement[G] with PVLSeqAssignImpl[G]
 
 final class Endpoint[G](val cls: Ref[G, Class[G]], val constructor: Ref[G, Procedure[G]], val args: Seq[Expr[G]])(implicit val o: Origin) extends Declaration[G] with EndpointImpl[G]
 final class SeqProg[G](val contract: ApplicableContract[G], val args : Seq[Variable[G]], val endpoints: Seq[Endpoint[G]], val run: SeqRun[G], val decls: Seq[ClassDeclaration[G]])(implicit val o: Origin) extends GlobalDeclaration[G] with SeqProgImpl[G]
@@ -1280,8 +1280,8 @@ final case class SeqRun[G](body: Statement[G], contract: ApplicableContract[G])(
 sealed trait Subject[G] extends NodeFamily[G]
 final case class EndpointName[G](ref: Ref[G, Endpoint[G]])(implicit val o: Origin) extends Subject[G] with EndpointNameImpl[G]
 case class Access[G](subject: Subject[G], field: Ref[G, InstanceField[G]])(implicit val o: Origin) extends NodeFamily[G] with AccessImpl[G]
-final case class Communicate[G](receiver: Access[G], sender: Access[G])(implicit val o: Origin) extends Statement[G] with CommunicateImpl[G]
-final case class SeqAssign[G](receiver: Ref[G, Endpoint[G]], field: Ref[G, InstanceField[G]], value: Expr[G])(implicit val o: Origin) extends Statement[G] with SeqAssignImpl[G]
+final case class Communicate[G](receiver: Access[G], sender: Access[G])(val blame: Blame[CommunicateFailure])(implicit val o: Origin) extends Statement[G] with CommunicateImpl[G]
+final case class SeqAssign[G](receiver: Ref[G, Endpoint[G]], field: Ref[G, InstanceField[G]], value: Expr[G])(val blame: Blame[SeqAssignFailure])(implicit val o: Origin) extends Statement[G] with SeqAssignImpl[G]
 final case class EndpointUse[G](ref: Ref[G, Endpoint[G]])(implicit val o: Origin) extends Expr[G] with EndpointUseImpl[G]
 
 final case class UnresolvedSeqBranch[G](branches: Seq[(Expr[G], Statement[G])])(val blame: Blame[SeqBranchFailure])(implicit val o: Origin) extends Statement[G]

--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -1255,8 +1255,8 @@ final case class TEndpoint[G](cls: Ref[G, Endpoint[G]])(implicit val o: Origin =
 final class PVLEndpoint[G](val name: String, val cls: Ref[G, Class[G]], val args: Seq[Expr[G]])(implicit val o: Origin) extends ClassDeclaration[G] {
   var ref: Option[PVLConstructorTarget[G]] = None
 }
-final class PVLSeqProg[G](val name: String, val declarations: Seq[ClassDeclaration[G]], val contract: ApplicableContract[G], val args: Seq[Variable[G]])(val blame: Blame[PVLSeqProgFailure])(implicit val o: Origin) extends GlobalDeclaration[G] with PVLSeqProgImpl[G] with Declarator[G]
-final case class PVLSeqRun[G](body: Statement[G], contract: ApplicableContract[G])(val blame: Blame[PVLSeqRunFailure])(implicit val o: Origin) extends ClassDeclaration[G]
+final class PVLSeqProg[G](val name: String, val declarations: Seq[ClassDeclaration[G]], val contract: ApplicableContract[G], val args: Seq[Variable[G]])(val blame: Blame[SeqCallableFailure])(implicit val o: Origin) extends GlobalDeclaration[G] with PVLSeqProgImpl[G] with Declarator[G]
+final case class PVLSeqRun[G](body: Statement[G], contract: ApplicableContract[G])(val blame: Blame[SeqCallableFailure])(implicit val o: Origin) extends ClassDeclaration[G]
 
 sealed trait PVLSubject[G] extends NodeFamily[G] with PVLSubjectImpl[G]
 case class PVLEndpointName[G](name: String)(implicit val o: Origin) extends PVLSubject[G] with PVLEndpointNameImpl[G] {
@@ -1275,8 +1275,8 @@ case class PVLCommunicate[G](sender: PVLAccess[G], receiver: PVLAccess[G])(impli
 final case class PVLSeqAssign[G](receiver: Ref[G, PVLEndpoint[G]], field: Ref[G, InstanceField[G]], value: Expr[G])(val blame: Blame[PVLSeqAssignFailure])(implicit val o: Origin) extends Statement[G] with PVLSeqAssignImpl[G]
 
 final class Endpoint[G](val cls: Ref[G, Class[G]], val constructor: Ref[G, Procedure[G]], val args: Seq[Expr[G]])(implicit val o: Origin) extends Declaration[G] with EndpointImpl[G]
-final class SeqProg[G](val contract: ApplicableContract[G], val args : Seq[Variable[G]], val endpoints: Seq[Endpoint[G]], val run: SeqRun[G], val decls: Seq[ClassDeclaration[G]])(val blame: Blame[SeqProgFailure])(implicit val o: Origin) extends GlobalDeclaration[G] with SeqProgImpl[G]
-final case class SeqRun[G](body: Statement[G], contract: ApplicableContract[G])(val blame: Blame[SeqRunFailure])(implicit val o: Origin) extends NodeFamily[G] with SeqRunImpl[G]
+final class SeqProg[G](val contract: ApplicableContract[G], val args : Seq[Variable[G]], val endpoints: Seq[Endpoint[G]], val run: SeqRun[G], val decls: Seq[ClassDeclaration[G]])(val blame: Blame[SeqCallableFailure])(implicit val o: Origin) extends GlobalDeclaration[G] with SeqProgImpl[G]
+final case class SeqRun[G](body: Statement[G], contract: ApplicableContract[G])(val blame: Blame[SeqCallableFailure])(implicit val o: Origin) extends NodeFamily[G] with SeqRunImpl[G]
 sealed trait Subject[G] extends NodeFamily[G]
 final case class EndpointName[G](ref: Ref[G, Endpoint[G]])(implicit val o: Origin) extends Subject[G] with EndpointNameImpl[G]
 case class Access[G](subject: Subject[G], field: Ref[G, InstanceField[G]])(val blame: Blame[AccessFailure])(implicit val o: Origin) extends NodeFamily[G] with AccessImpl[G]

--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -1258,20 +1258,20 @@ final class PVLEndpoint[G](val name: String, val cls: Ref[G, Class[G]], val args
 final class PVLSeqProg[G](val name: String, val declarations: Seq[ClassDeclaration[G]], val contract: ApplicableContract[G], val args: Seq[Variable[G]])(implicit val o: Origin) extends GlobalDeclaration[G] with PVLSeqProgImpl[G] with Declarator[G]
 final case class PVLSeqRun[G](body: Statement[G], contract: ApplicableContract[G])(val blame: Blame[CallableFailure])(implicit val o: Origin) extends ClassDeclaration[G]
 
-sealed trait PVLCommunicateSubject[G] extends NodeFamily[G] with PVLCommunicateSubjectImpl[G]
-case class PVLEndpointName[G](name: String)(implicit val o: Origin) extends PVLCommunicateSubject[G] with PVLEndpointNameImpl[G] {
+sealed trait PVLSubject[G] extends NodeFamily[G] with PVLCommunicateSubjectImpl[G]
+case class PVLEndpointName[G](name: String)(implicit val o: Origin) extends PVLSubject[G] with PVLEndpointNameImpl[G] {
   var ref: Option[RefPVLEndpoint[G]] = None
 }
-case class PVLIndexedFamilyName[G](family: String, index: Expr[G])(implicit val o: Origin) extends PVLCommunicateSubject[G] with PVLIndexedFamilyNameImpl[G] {
+case class PVLIndexedFamilyName[G](family: String, index: Expr[G])(implicit val o: Origin) extends PVLSubject[G] with PVLIndexedFamilyNameImpl[G] {
   var ref: Option[RefPVLEndpoint[G]] = None
 }
-case class PVLFamilyRange[G](family: String, binder: String, start: Expr[G], end: Expr[G])(implicit val o: Origin) extends PVLCommunicateSubject[G] with PVLFamilyRangeImpl[G] {
+case class PVLFamilyRange[G](family: String, binder: String, start: Expr[G], end: Expr[G])(implicit val o: Origin) extends PVLSubject[G] with PVLFamilyRangeImpl[G] {
   var ref: Option[RefPVLEndpoint[G]] = None
 }
-case class PVLCommunicateAccess[G](subject: PVLCommunicateSubject[G], field: String)(implicit val o: Origin) extends NodeFamily[G] with PVLCommunicateAccessImpl[G] {
+case class PVLAccess[G](subject: PVLSubject[G], field: String)(implicit val o: Origin) extends NodeFamily[G] with PVLCommunicateAccessImpl[G] {
   var ref: Option[RefField[G]] = None
 }
-case class PVLCommunicate[G](sender: PVLCommunicateAccess[G], receiver: PVLCommunicateAccess[G])(val blame: Blame[PVLCommunicateFailure])(implicit val o: Origin) extends Statement[G] with PVLCommunicateImpl[G]
+case class PVLCommunicate[G](sender: PVLAccess[G], receiver: PVLAccess[G])(val blame: Blame[PVLCommunicateFailure])(implicit val o: Origin) extends Statement[G] with PVLCommunicateImpl[G]
 final case class PVLSeqAssign[G](receiver: Ref[G, PVLEndpoint[G]], field: Ref[G, InstanceField[G]], value: Expr[G])(val blame: Blame[PVLSeqAssignFailure])(implicit val o: Origin) extends Statement[G] with PVLSeqAssignImpl[G]
 
 final class Endpoint[G](val cls: Ref[G, Class[G]], val constructor: Ref[G, Procedure[G]], val args: Seq[Expr[G]])(implicit val o: Origin) extends Declaration[G] with EndpointImpl[G]

--- a/src/col/vct/col/ast/declaration/global/SeqProgImpl.scala
+++ b/src/col/vct/col/ast/declaration/global/SeqProgImpl.scala
@@ -1,10 +1,22 @@
 package vct.col.ast.declaration.global
 
-import vct.col.ast.{Class, Declaration, SeqProg}
+import vct.col.ast.{Class, Declaration, Endpoint, EndpointGuard, EndpointName, Node, SeqAssign, SeqProg}
 import vct.col.ast.util.Declarator
 import vct.col.check.{CheckContext, CheckError}
 import vct.col.origin.Origin
 import vct.col.print._
+import vct.col.ref.Ref
+
+import scala.collection.immutable.ListSet
+
+object SeqProgImpl {
+  def participants[G](node: Node[G]): ListSet[Endpoint[G]] =
+    ListSet.from(node.collect {
+      case EndpointGuard(Ref(endpoint), _) => endpoint
+      case SeqAssign(Ref(endpoint), _, _) => endpoint
+      case EndpointName(Ref(endpoint)) => endpoint
+    })
+}
 
 trait SeqProgImpl[G] extends Declarator[G] { this: SeqProg[G] =>
   override def declarations: Seq[Declaration[G]] = args ++ endpoints ++ decls

--- a/src/col/vct/col/ast/family/pvlcommunicate/PVLAccessImpl.scala
+++ b/src/col/vct/col/ast/family/pvlcommunicate/PVLAccessImpl.scala
@@ -2,6 +2,6 @@ package vct.col.ast.family.pvlcommunicate
 
 import vct.col.ast.{PVLAccess, Type}
 
-trait PVLCommunicateAccessImpl[G] { this: PVLAccess[G] =>
+trait PVLAccessImpl[G] { this: PVLAccess[G] =>
   def fieldType: Type[G] = ref.get.decl.t
 }

--- a/src/col/vct/col/ast/family/pvlcommunicate/PVLCommunicateAccessImpl.scala
+++ b/src/col/vct/col/ast/family/pvlcommunicate/PVLCommunicateAccessImpl.scala
@@ -1,7 +1,7 @@
 package vct.col.ast.family.pvlcommunicate
 
-import vct.col.ast.{PVLCommunicateAccess, Type}
+import vct.col.ast.{PVLAccess, Type}
 
-trait PVLCommunicateAccessImpl[G] { this: PVLCommunicateAccess[G] =>
+trait PVLCommunicateAccessImpl[G] { this: PVLAccess[G] =>
   def fieldType: Type[G] = ref.get.decl.t
 }

--- a/src/col/vct/col/ast/family/pvlcommunicate/PVLCommunicateSubjectImpl.scala
+++ b/src/col/vct/col/ast/family/pvlcommunicate/PVLCommunicateSubjectImpl.scala
@@ -1,9 +1,9 @@
 package vct.col.ast.family.pvlcommunicate
 
-import vct.col.ast.{PVLCommunicateSubject, TClass, Class, Type}
+import vct.col.ast.{PVLSubject, TClass, Class, Type}
 import vct.col.resolve.ctx.RefPVLEndpoint
 
-trait PVLCommunicateSubjectImpl[G] { this: PVLCommunicateSubject[G] =>
+trait PVLCommunicateSubjectImpl[G] { this: PVLSubject[G] =>
   def cls: Class[G] = ref.get.decl.cls.decl
   def ref: Option[RefPVLEndpoint[G]]
 }

--- a/src/col/vct/col/ast/family/pvlcommunicate/PVLSubjectImpl.scala
+++ b/src/col/vct/col/ast/family/pvlcommunicate/PVLSubjectImpl.scala
@@ -3,7 +3,7 @@ package vct.col.ast.family.pvlcommunicate
 import vct.col.ast.{PVLSubject, TClass, Class, Type}
 import vct.col.resolve.ctx.RefPVLEndpoint
 
-trait PVLCommunicateSubjectImpl[G] { this: PVLSubject[G] =>
+trait PVLSubjectImpl[G] { this: PVLSubject[G] =>
   def cls: Class[G] = ref.get.decl.cls.decl
   def ref: Option[RefPVLEndpoint[G]]
 }

--- a/src/col/vct/col/origin/Blame.scala
+++ b/src/col/vct/col/origin/Blame.scala
@@ -365,6 +365,12 @@ case class SeqAssignInsufficientPermission(node: SeqAssign[_]) extends SeqAssign
   override def inlineDescWithSource(source: String): String = s"There may be insufficient permission to access `$source`."
 }
 
+sealed trait PVLSeqProgFailure extends VerificationFailure
+sealed trait SeqProgFailure extends PVLSeqProgFailure
+
+sealed trait PVLSeqRunFailure extends VerificationFailure
+sealed trait SeqRunFailure extends PVLSeqRunFailure
+
 sealed trait DerefInsufficientPermission extends FrontendDerefError
 case class InsufficientPermission(node: HeapDeref[_]) extends DerefInsufficientPermission with NodeVerificationFailure {
   override def code: String = "perm"

--- a/src/col/vct/col/origin/Blame.scala
+++ b/src/col/vct/col/origin/Blame.scala
@@ -217,12 +217,13 @@ case class SYCLItemMethodPreconditionFailed(node: InvokingNode[_]) extends NodeV
 
 sealed trait CallableFailure extends ConstructorFailure with JavaConstructorFailure
 sealed trait ContractedFailure extends CallableFailure
-case class PostconditionFailed(path: Seq[AccountedDirection], failure: ContractFailure, node: ContractApplicable[_]) extends ContractedFailure with WithContractFailure {
+sealed trait SeqCallableFailure extends CallableFailure
+case class PostconditionFailed(path: Seq[AccountedDirection], failure: ContractFailure, node: ContractApplicable[_]) extends ContractedFailure with SeqCallableFailure with WithContractFailure {
   override def baseCode: String = "postFailed"
   override def descInContext: String = "Postcondition may not hold, since"
   override def inlineDescWithSource(node: String, failure: String): String = s"Postcondition of `$node` may not hold, since $failure."
 }
-case class TerminationMeasureFailed(applicable: ContractApplicable[_], apply: Invocation[_], measure: DecreasesClause[_]) extends ContractedFailure with VerificationFailure {
+case class TerminationMeasureFailed(applicable: ContractApplicable[_], apply: Invocation[_], measure: DecreasesClause[_]) extends ContractedFailure with SeqCallableFailure with VerificationFailure {
   override def code: String = "decreasesFailed"
   override def position: String = measure.o.shortPositionText
   override def desc: String = Message.messagesInContext(
@@ -233,7 +234,7 @@ case class TerminationMeasureFailed(applicable: ContractApplicable[_], apply: In
   override def inlineDesc: String =
     s"${apply.o.inlineContextText} may not terminate, since `${measure.o.inlineContextText}` is not decreased or not bounded"
 }
-case class ContextEverywhereFailedInPost(failure: ContractFailure, node: ContractApplicable[_]) extends ContractedFailure with WithContractFailure {
+case class ContextEverywhereFailedInPost(failure: ContractFailure, node: ContractApplicable[_]) extends ContractedFailure with SeqCallableFailure with WithContractFailure {
   override def baseCode: String = "contextPostFailed"
   override def descInContext: String = "Context may not hold in postcondition, since"
   override def inlineDescWithSource(node: String, failure: String): String = s"Context of `$node` may not hold in the postcondition, since $failure."
@@ -364,12 +365,6 @@ case class SeqAssignInsufficientPermission(node: SeqAssign[_]) extends SeqAssign
   override def descInContext: String = "There may be insufficient permission to access this field on this endpoint."
   override def inlineDescWithSource(source: String): String = s"There may be insufficient permission to access `$source`."
 }
-
-sealed trait PVLSeqProgFailure extends VerificationFailure
-sealed trait SeqProgFailure extends PVLSeqProgFailure
-
-sealed trait PVLSeqRunFailure extends VerificationFailure
-sealed trait SeqRunFailure extends PVLSeqRunFailure
 
 sealed trait DerefInsufficientPermission extends FrontendDerefError
 case class InsufficientPermission(node: HeapDeref[_]) extends DerefInsufficientPermission with NodeVerificationFailure {

--- a/src/col/vct/col/origin/Blame.scala
+++ b/src/col/vct/col/origin/Blame.scala
@@ -347,17 +347,23 @@ case class LoopUnanimityNotMaintained(guard1: Node[_], guard2: Node[_]) extends 
   override def inlineDesc: String = "The agreement of two conditions in this branch could not be maintained for an arbitrary loop iteration."
 }
 
-sealed trait PVLCommunicateFailure extends VerificationFailure
-sealed trait CommunicateFailure extends PVLCommunicateFailure
+sealed trait PVLAccessFailure extends VerificationFailure
+sealed trait AccessFailure extends PVLAccessFailure
 
-case class CommunicateTargetPermission(node: Access[_]) extends CommunicateFailure with NodeVerificationFailure {
-  override def code: String = "communicateTargetPermission"
-  override def descInContext: String = "There may be insufficient permission to access this field."
+case class AccessInsufficientPermission(node: Access[_]) extends AccessFailure with NodeVerificationFailure {
+  override def code: String = "accessPerm"
+  override def descInContext: String = "There may be insufficient permission to access this field on this endpoint."
   override def inlineDescWithSource(source: String): String = s"There may be insufficient permission to access `$source`."
 }
 
 sealed trait PVLSeqAssignFailure extends VerificationFailure
 sealed trait SeqAssignFailure extends PVLSeqAssignFailure
+
+case class SeqAssignInsufficientPermission(node: SeqAssign[_]) extends SeqAssignFailure with NodeVerificationFailure {
+  override def code: String = "seqAssignPerm"
+  override def descInContext: String = "There may be insufficient permission to access this field on this endpoint."
+  override def inlineDescWithSource(source: String): String = s"There may be insufficient permission to access `$source`."
+}
 
 sealed trait DerefInsufficientPermission extends FrontendDerefError
 case class InsufficientPermission(node: HeapDeref[_]) extends DerefInsufficientPermission with NodeVerificationFailure {

--- a/src/col/vct/col/origin/Blame.scala
+++ b/src/col/vct/col/origin/Blame.scala
@@ -347,6 +347,12 @@ case class LoopUnanimityNotMaintained(guard1: Node[_], guard2: Node[_]) extends 
   override def inlineDesc: String = "The agreement of two conditions in this branch could not be maintained for an arbitrary loop iteration."
 }
 
+sealed trait PVLCommunicateFailure extends VerificationFailure
+sealed trait CommunicateFailure extends PVLCommunicateFailure
+
+sealed trait PVLSeqAssignFailure extends VerificationFailure
+sealed trait SeqAssignFailure extends PVLSeqAssignFailure
+
 sealed trait DerefInsufficientPermission extends FrontendDerefError
 case class InsufficientPermission(node: HeapDeref[_]) extends DerefInsufficientPermission with NodeVerificationFailure {
   override def code: String = "perm"

--- a/src/col/vct/col/origin/Blame.scala
+++ b/src/col/vct/col/origin/Blame.scala
@@ -350,6 +350,12 @@ case class LoopUnanimityNotMaintained(guard1: Node[_], guard2: Node[_]) extends 
 sealed trait PVLCommunicateFailure extends VerificationFailure
 sealed trait CommunicateFailure extends PVLCommunicateFailure
 
+case class CommunicateTargetPermission(node: Access[_]) extends CommunicateFailure with NodeVerificationFailure {
+  override def code: String = "communicateTargetPermission"
+  override def descInContext: String = "There may be insufficient permission to access this field."
+  override def inlineDescWithSource(source: String): String = s"There may be insufficient permission to access `$source`."
+}
+
 sealed trait PVLSeqAssignFailure extends VerificationFailure
 sealed trait SeqAssignFailure extends PVLSeqAssignFailure
 

--- a/src/col/vct/col/origin/Name.scala
+++ b/src/col/vct/col/origin/Name.scala
@@ -18,7 +18,7 @@ object Name {
   case class Preferred(parts: Seq[String]) extends Name {
     override def snake: String = parts.map(_.toLowerCase).mkString("_")
     override def usnake: String = parts.map(_.toUpperCase).mkString("_")
-    override def camel: String = (parts.head.toLowerCase +: parts.map(_.toLowerCase.capitalize)).mkString("")
+    override def camel: String = (parts.head.toLowerCase +: parts.tail.map(_.toLowerCase.capitalize)).mkString("")
     override def ucamel: String = camel.capitalize
   }
 }

--- a/src/col/vct/col/resolve/Resolve.scala
+++ b/src/col/vct/col/resolve/Resolve.scala
@@ -404,7 +404,7 @@ case object ResolveReferences extends LazyLogging {
       case Some(_) => throw ForbiddenEndpointNameType(local)
       case None => throw NoSuchNameError("endpoint", name, local)
     }
-    case access@PVLCommunicateAccess(subject, field) =>
+    case access@PVLAccess(subject, field) =>
         access.ref = Some(PVL.findDerefOfClass(subject.cls, field).getOrElse(throw NoSuchNameError("field", field, access)))
     case endpoint: PVLEndpoint[G] =>
       endpoint.ref = Some(PVL.findConstructor(TClass(endpoint.cls.decl.ref[Class[G]]), endpoint.args).getOrElse(throw ConstructorNotFound(endpoint)))

--- a/src/col/vct/col/resolve/lang/Java.scala
+++ b/src/col/vct/col/resolve/lang/Java.scala
@@ -241,6 +241,10 @@ case object Java extends LazyLogging {
           case JavaClassPathEntry.Path(root) => Some(root)
         }
 
+        println(s"Resolution: $name")
+        println(s"maybeBasePath: $maybeBasePath")
+        println(s"classPath: ${ctx.javaClassPath}")
+
         for {
           basePath <- maybeBasePath
           ns <- loader.load[G](basePath, name)

--- a/src/col/vct/col/resolve/lang/Java.scala
+++ b/src/col/vct/col/resolve/lang/Java.scala
@@ -241,10 +241,6 @@ case object Java extends LazyLogging {
           case JavaClassPathEntry.Path(root) => Some(root)
         }
 
-        println(s"Resolution: $name")
-        println(s"maybeBasePath: $maybeBasePath")
-        println(s"classPath: ${ctx.javaClassPath}")
-
         for {
           basePath <- maybeBasePath
           ns <- loader.load[G](basePath, name)

--- a/src/col/vct/col/rewrite/NonLatchingRewriter.scala
+++ b/src/col/vct/col/rewrite/NonLatchingRewriter.scala
@@ -66,8 +66,8 @@ class NonLatchingRewriter[Pre, Post]() extends AbstractRewriter[Pre, Post] {
   override def dispatch(node: LlvmFunctionContract[Pre]): LlvmFunctionContract[Post] = rewriteDefault(node)
   override def dispatch(node: LlvmLoopContract[Pre]): LlvmLoopContract[Post] = rewriteDefault(node)
 
-  override def dispatch(node: PVLCommunicateAccess[Pre]): PVLCommunicateAccess[Post] = rewriteDefault(node)
-  override def dispatch(node: PVLCommunicateSubject[Pre]): PVLCommunicateSubject[Post] = rewriteDefault(node)
+  override def dispatch(node: PVLAccess[Pre]): PVLAccess[Post] = rewriteDefault(node)
+  override def dispatch(node: PVLSubject[Pre]): PVLSubject[Post] = rewriteDefault(node)
   override def dispatch(node: SeqRun[Pre]): SeqRun[Post] = rewriteDefault(node)
   override def dispatch(node: Access[Pre]): Access[Post] = rewriteDefault(node)
   override def dispatch(node: Subject[Pre]): Subject[Post] = rewriteDefault(node)

--- a/src/col/vct/col/typerules/CoercingRewriter.scala
+++ b/src/col/vct/col/typerules/CoercingRewriter.scala
@@ -1683,18 +1683,18 @@ abstract class CoercingRewriter[Pre <: Generation]() extends AbstractRewriter[Pr
       case w @ WandPackage(expr, stat) => WandPackage(res(expr), stat)(w.blame)
       case VeyMontAssignExpression(t,a) => VeyMontAssignExpression(t,a)
       case CommunicateX(r,s,t,a) => CommunicateX(r,s,t,a)
-      case PVLCommunicate(s, r) if r.fieldType == s.fieldType => PVLCommunicate(s, r)
+      case c @ PVLCommunicate(s, r) if r.fieldType == s.fieldType => PVLCommunicate(s, r)(c.blame)
       case comm@PVLCommunicate(s, r) => throw IncoercibleExplanation(comm, s"The receiver should have type ${s.fieldType}, but actually has type ${r.fieldType}.")
-      case Communicate(r, s) if r.field.decl.t == s.field.decl.t => Communicate(r, s)
+      case c @ Communicate(r, s) if r.field.decl.t == s.field.decl.t => Communicate(r, s)(c.blame)
       case comm@Communicate(r, s) => throw IncoercibleExplanation(comm, s"The receiver should have type ${s.field.decl.t}, but actually has type ${r.field.decl.t}.")
-      case PVLSeqAssign(r, f, v) =>
-        try { PVLSeqAssign(r, f, coerce(v, f.decl.t)) } catch {
+      case a @ PVLSeqAssign(r, f, v) =>
+        try { PVLSeqAssign(r, f, coerce(v, f.decl.t))(a.blame) } catch {
           case err: Incoercible =>
             println(err.text)
             throw err
         }
-      case SeqAssign(r, f, v) =>
-        try { SeqAssign(r, f, coerce(v, f.decl.t)) } catch {
+      case a @ SeqAssign(r, f, v) =>
+        try { SeqAssign(r, f, coerce(v, f.decl.t))(a.blame) } catch {
           case err: Incoercible =>
             println(err.text)
             throw err

--- a/src/col/vct/col/typerules/CoercingRewriter.scala
+++ b/src/col/vct/col/typerules/CoercingRewriter.scala
@@ -1683,9 +1683,9 @@ abstract class CoercingRewriter[Pre <: Generation]() extends AbstractRewriter[Pr
       case w @ WandPackage(expr, stat) => WandPackage(res(expr), stat)(w.blame)
       case VeyMontAssignExpression(t,a) => VeyMontAssignExpression(t,a)
       case CommunicateX(r,s,t,a) => CommunicateX(r,s,t,a)
-      case c @ PVLCommunicate(s, r) if r.fieldType == s.fieldType => PVLCommunicate(s, r)(c.blame)
+      case c @ PVLCommunicate(s, r) if r.fieldType == s.fieldType => PVLCommunicate(s, r)
       case comm@PVLCommunicate(s, r) => throw IncoercibleExplanation(comm, s"The receiver should have type ${s.fieldType}, but actually has type ${r.fieldType}.")
-      case c @ Communicate(r, s) if r.field.decl.t == s.field.decl.t => Communicate(r, s)(c.blame)
+      case c @ Communicate(r, s) if r.field.decl.t == s.field.decl.t => Communicate(r, s)
       case comm@Communicate(r, s) => throw IncoercibleExplanation(comm, s"The receiver should have type ${s.field.decl.t}, but actually has type ${r.field.decl.t}.")
       case a @ PVLSeqAssign(r, f, v) =>
         try { PVLSeqAssign(r, f, coerce(v, f.decl.t))(a.blame) } catch {

--- a/src/col/vct/col/typerules/CoercingRewriter.scala
+++ b/src/col/vct/col/typerules/CoercingRewriter.scala
@@ -254,8 +254,8 @@ abstract class CoercingRewriter[Pre <: Generation]() extends AbstractRewriter[Pr
     case node: LlvmLoopContract[Pre] => node
     case node: ProverLanguage[Pre] => node
     case node: SmtlibFunctionSymbol[Pre] => node
-    case node: PVLCommunicateAccess[Pre] => node
-    case node: PVLCommunicateSubject[Pre] => node
+    case node: PVLAccess[Pre] => node
+    case node: PVLSubject[Pre] => node
     case node: SeqRun[Pre] => node
     case node: Access[Pre] => node
     case node: Subject[Pre] => node
@@ -462,13 +462,13 @@ abstract class CoercingRewriter[Pre <: Generation]() extends AbstractRewriter[Pr
   def postCoerce(node: SmtlibFunctionSymbol[Pre]): SmtlibFunctionSymbol[Post] = rewriteDefault(node)
   override final def dispatch(node: SmtlibFunctionSymbol[Pre]): SmtlibFunctionSymbol[Post] = postCoerce(coerce(preCoerce(node)))
 
-  def preCoerce(node: PVLCommunicateAccess[Pre]): PVLCommunicateAccess[Pre] = node
-  def postCoerce(node: PVLCommunicateAccess[Pre]): PVLCommunicateAccess[Post] = rewriteDefault(node)
-  override final def dispatch(node: PVLCommunicateAccess[Pre]): PVLCommunicateAccess[Post] = postCoerce(coerce(preCoerce(node)))
+  def preCoerce(node: PVLAccess[Pre]): PVLAccess[Pre] = node
+  def postCoerce(node: PVLAccess[Pre]): PVLAccess[Post] = rewriteDefault(node)
+  override final def dispatch(node: PVLAccess[Pre]): PVLAccess[Post] = postCoerce(coerce(preCoerce(node)))
 
-  def preCoerce(node: PVLCommunicateSubject[Pre]): PVLCommunicateSubject[Pre] = node
-  def postCoerce(node: PVLCommunicateSubject[Pre]): PVLCommunicateSubject[Post] = rewriteDefault(node)
-  override final def dispatch(node: PVLCommunicateSubject[Pre]): PVLCommunicateSubject[Post] = postCoerce(coerce(preCoerce(node)))
+  def preCoerce(node: PVLSubject[Pre]): PVLSubject[Pre] = node
+  def postCoerce(node: PVLSubject[Pre]): PVLSubject[Post] = rewriteDefault(node)
+  override final def dispatch(node: PVLSubject[Pre]): PVLSubject[Post] = postCoerce(coerce(preCoerce(node)))
 
   def preCoerce(node: Access[Pre]): Access[Pre] = node
   def postCoerce(node: Access[Pre]): Access[Post] = rewriteDefault(node)
@@ -2186,8 +2186,8 @@ abstract class CoercingRewriter[Pre <: Generation]() extends AbstractRewriter[Pr
   def coerce(node: ProverLanguage[Pre]): ProverLanguage[Pre] = node
   def coerce(node: SmtlibFunctionSymbol[Pre]): SmtlibFunctionSymbol[Pre] = node
 
-  def coerce(node: PVLCommunicateAccess[Pre]): PVLCommunicateAccess[Pre] = node
-  def coerce(node: PVLCommunicateSubject[Pre]): PVLCommunicateSubject[Pre] = node
+  def coerce(node: PVLAccess[Pre]): PVLAccess[Pre] = node
+  def coerce(node: PVLSubject[Pre]): PVLSubject[Pre] = node
   def coerce(node: SeqRun[Pre]): SeqRun[Pre] = node
   def coerce(node: Access[Pre]): Access[Pre] = node
   def coerce(node: Subject[Pre]): Subject[Pre] = node

--- a/src/main/vct/main/stages/Resolution.scala
+++ b/src/main/vct/main/stages/Resolution.scala
@@ -36,6 +36,7 @@ case object Resolution {
         case ClassPathEntry.SourcePackageRoot => ResolveTypes.JavaClassPathEntry.SourcePackageRoot
         case ClassPathEntry.SourcePath(root) => ResolveTypes.JavaClassPathEntry.Path(root)
       },
+      options.veymontGeneratePermissions
     )
 }
 
@@ -98,6 +99,7 @@ case class Resolution[G <: Generation]
     ResolveTypes.JavaClassPathEntry.Path(Resources.getJrePath),
     ResolveTypes.JavaClassPathEntry.SourcePackageRoot
   ),
+  veymontGeneratePermissions: Boolean = false,
 ) extends Stage[ParseResult[G], Verification[_ <: Generation]] with LazyLogging {
   override def friendlyName: String = "Name Resolution"
 
@@ -115,7 +117,7 @@ case class Resolution[G <: Generation]
       case Nil => // ok
       case some => throw InputResolutionError(some)
     }
-    val resolvedProgram = LangSpecificToCol().dispatch(typedProgram)
+    val resolvedProgram = LangSpecificToCol(veymontGeneratePermissions).dispatch(typedProgram)
     resolvedProgram.check match {
       case Nil => // ok
       // PB: This explicitly allows LangSpecificToCol to generate invalid ASTs, and will blame the input for them. The

--- a/src/main/vct/main/stages/Transformation.scala
+++ b/src/main/vct/main/stages/Transformation.scala
@@ -67,6 +67,7 @@ object Transformation {
           inferHeapContextIntoFrame = options.inferHeapContextIntoFrame,
           bipResults = bipResults,
           splitVerificationByProcedure = options.devSplitVerificationByProcedure,
+          veymontGeneratePermissions = options.veymontGeneratePermissions,
         )
     }
 
@@ -172,6 +173,7 @@ case class SilverTransformation
   bipResults: BIP.VerificationResults,
   checkSat: Boolean = true,
   splitVerificationByProcedure: Boolean = false,
+  veymontGeneratePermissions: Boolean = false,
 ) extends Transformation(onBeforePassKey, onAfterPassKey, Seq(
     // Replace leftover SYCL types
     ReplaceSYCLTypes,
@@ -193,7 +195,7 @@ case class SilverTransformation
     EncodeRangedFor,
 
     // VeyMont sequential program encoding
-    GenerateSeqProgPermissions,
+    GenerateSeqProgPermissions.withArg(veymontGeneratePermissions),
     SplitSeqGuards,
     EncodeUnpointedGuard,
     DeduplicateSeqGuards,

--- a/src/main/vct/main/stages/Transformation.scala
+++ b/src/main/vct/main/stages/Transformation.scala
@@ -198,8 +198,8 @@ case class SilverTransformation
     SplitSeqGuards,
     EncodeUnpointedGuard,
     DeduplicateSeqGuards,
-    EncodeSeqBranchUnanimity,
     GenerateSeqProgPermissions.withArg(veymontGeneratePermissions),
+    EncodeSeqBranchUnanimity,
     EncodeSeqProg,
 
     EncodeString, // Encode spec string as seq<int>

--- a/src/main/vct/main/stages/Transformation.scala
+++ b/src/main/vct/main/stages/Transformation.scala
@@ -195,11 +195,11 @@ case class SilverTransformation
     EncodeRangedFor,
 
     // VeyMont sequential program encoding
-    GenerateSeqProgPermissions.withArg(veymontGeneratePermissions),
     SplitSeqGuards,
     EncodeUnpointedGuard,
     DeduplicateSeqGuards,
     EncodeSeqBranchUnanimity,
+    GenerateSeqProgPermissions.withArg(veymontGeneratePermissions),
     EncodeSeqProg,
 
     EncodeString, // Encode spec string as seq<int>

--- a/src/main/vct/options/Options.scala
+++ b/src/main/vct/options/Options.scala
@@ -240,6 +240,10 @@ case object Options {
         .action((path, c) => c.copy(cPreprocessorPath = path))
         .text("Set the location of the C preprocessor binary"),
 
+      opt[Unit]("veymont-generate-permissions")
+        .action((_, c) => c.copy(veymontGeneratePermissions = true))
+        .text("Generate permissions for the entire sequential program in the style of VeyMont 1.4"),
+
       note(""),
       note("VeyMont Mode"),
       opt[Unit]("veymont")
@@ -389,6 +393,7 @@ case class Options
   // VeyMont options
   veymontOutput: Path = null, // required
   veymontChannel: PathOrStd = PathOrStd.Path(getVeymontChannel),
+  veymontGeneratePermissions: Boolean = false,
 
   // VeSUV options
   vesuvOutput: Path = null,

--- a/src/parsers/antlr4/LangPVLParser.g4
+++ b/src/parsers/antlr4/LangPVLParser.g4
@@ -188,7 +188,7 @@ statement
  | 'label' identifier ';' # pvlLabel
  | allowedForStatement ';' # pvlForStatement
  | 'communicate' access direction access ';' # pvlCommunicateStatement
- | identifier '.' identifier ':' '=' expr ';' # pvlParAssign
+ | identifier '.' identifier ':' '=' expr ';' # pvlSeqAssign
  ;
 
 direction

--- a/src/parsers/vct/parsers/transform/PVLToCol.scala
+++ b/src/parsers/vct/parsers/transform/PVLToCol.scala
@@ -357,9 +357,9 @@ case class PVLToCol[G](override val baseOrigin: Origin,
     case PvlLabel(_, label, _) => Label(new LabelDecl()(origin(stat).sourceName(convert(label))), Block(Nil))
     case PvlForStatement(inner, _) => convert(inner)
     case PvlCommunicateStatement(_, receiver, Direction0("<-"), sender, _) =>
-      PVLCommunicate(convert(sender), convert(receiver))(blame(stat))
+      PVLCommunicate(convert(sender), convert(receiver))
     case PvlCommunicateStatement(_, sender, Direction1("->"), receiver, _) =>
-      PVLCommunicate(convert(sender), convert(receiver))(blame(stat))
+      PVLCommunicate(convert(sender), convert(receiver))
     case PvlSeqAssign(endpoint, _, field, _, _, expr, _) =>
       PVLSeqAssign(
         new UnresolvedRef[G, PVLEndpoint[G]](convert(endpoint)),
@@ -389,7 +389,7 @@ case class PVLToCol[G](override val baseOrigin: Origin,
   }
 
   def convert(implicit acc: AccessContext): PVLAccess[G] = acc match {
-    case Access0(subject, _, field) => PVLAccess(convert(subject), convert(field))
+    case Access0(subject, _, field) => PVLAccess(convert(subject), convert(field))(blame(acc))
   }
 
   def convert(implicit subject: SubjectContext): PVLSubject[G] = subject match {

--- a/src/parsers/vct/parsers/transform/PVLToCol.scala
+++ b/src/parsers/vct/parsers/transform/PVLToCol.scala
@@ -30,7 +30,7 @@ case class PVLToCol[G](override val baseOrigin: Origin,
     case ProgramDecl1(cls) => Seq(convert(cls))
     case ProgramDecl2(enum) => Seq(convert(enum))
     case ProgramDecl3(method) => Seq(convertProcedure(method))
-    case ProgramDecl4(seqProg) => Seq(convertVeyMontProg(seqProg))
+    case ProgramDecl4(seqProg) => Seq(convertSeqProg(seqProg))
   }
 
   def convert(implicit enum: EnumDeclContext): Enum[G] = enum match {
@@ -50,7 +50,7 @@ case class PVLToCol[G](override val baseOrigin: Origin,
         PVLSeqRun(
           convert(body),
           contract.consumeApplicableContract(blame(decl))
-        )(blame(decl)))
+        )(blame(decl))(origin(decl).where(name = "run")))
     case PvlEndpoint(_, name, _, ClassType0(endpointType, None), _, args, _, _) =>
       new PVLEndpoint(
         convert(name),
@@ -60,15 +60,15 @@ case class PVLToCol[G](override val baseOrigin: Origin,
     case PvlEndpoint(_, name, _, t@ClassType0(_, Some(_)), _, args, _, _) => ??(t)
   }
 
-  def convertVeyMontProg(implicit cls: DeclVeyMontSeqProgContext): PVLSeqProg[G] = cls match {
+  def convertSeqProg(implicit decl: DeclVeyMontSeqProgContext): PVLSeqProg[G] = decl match {
     case DeclVeyMontSeqProg0(contract, _, name, _, args, _, _, decls, _) =>
       withContract(contract, contract => {
         new PVLSeqProg(
           convert(name),
           decls.map(convert(_)),
-          contract.consumeApplicableContract(blame(cls)),
+          contract.consumeApplicableContract(blame(decl)),
           args.map(convert(_)).getOrElse(Seq())
-        )(origin(cls).sourceName(convert(name)))
+        )(blame(decl))(origin(decl).sourceName(convert(name)))
       })
   }
 

--- a/src/parsers/vct/parsers/transform/PVLToCol.scala
+++ b/src/parsers/vct/parsers/transform/PVLToCol.scala
@@ -388,11 +388,11 @@ case class PVLToCol[G](override val baseOrigin: Origin,
     case PvlAssign(target, _, value) => Assign(convert(target), convert(value))(blame(stat))
   }
 
-  def convert(implicit acc: AccessContext): PVLCommunicateAccess[G] = acc match {
-    case Access0(subject, _, field) => PVLCommunicateAccess(convert(subject), convert(field))
+  def convert(implicit acc: AccessContext): PVLAccess[G] = acc match {
+    case Access0(subject, _, field) => PVLAccess(convert(subject), convert(field))
   }
 
-  def convert(implicit subject: SubjectContext): PVLCommunicateSubject[G] = subject match {
+  def convert(implicit subject: SubjectContext): PVLSubject[G] = subject match {
     case Subject0(name) => PVLEndpointName(convert(name))(origin(subject).sourceName(convert(name)))
     case Subject1(family, _, expr, _) => ??(subject)
     case Subject2(family, _, binder, _, start, _, end, _) => ??(subject)

--- a/src/parsers/vct/parsers/transform/PVLToCol.scala
+++ b/src/parsers/vct/parsers/transform/PVLToCol.scala
@@ -357,14 +357,14 @@ case class PVLToCol[G](override val baseOrigin: Origin,
     case PvlLabel(_, label, _) => Label(new LabelDecl()(origin(stat).sourceName(convert(label))), Block(Nil))
     case PvlForStatement(inner, _) => convert(inner)
     case PvlCommunicateStatement(_, receiver, Direction0("<-"), sender, _) =>
-      PVLCommunicate(convert(sender), convert(receiver))
+      PVLCommunicate(convert(sender), convert(receiver))(blame(stat))
     case PvlCommunicateStatement(_, sender, Direction1("->"), receiver, _) =>
-      PVLCommunicate(convert(sender), convert(receiver))
-    case PvlParAssign(endpoint, _, field, _, _, expr, _) =>
+      PVLCommunicate(convert(sender), convert(receiver))(blame(stat))
+    case PvlSeqAssign(endpoint, _, field, _, _, expr, _) =>
       PVLSeqAssign(
         new UnresolvedRef[G, PVLEndpoint[G]](convert(endpoint)),
         new UnresolvedRef[G, InstanceField[G]](convert(field)),
-        convert(expr))
+        convert(expr))(blame(stat))
   }
 
   def convert(implicit stat: ForStatementListContext): Statement[G] =

--- a/src/rewrite/vct/rewrite/lang/LangPVLToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangPVLToCol.scala
@@ -20,7 +20,7 @@ case object LangPVLToCol {
   }
 }
 
-case class LangPVLToCol[Pre <: Generation](rw: LangSpecificToCol[Pre]) extends LazyLogging {
+case class LangPVLToCol[Pre <: Generation](rw: LangSpecificToCol[Pre], veymontGeneratePermissions: Boolean) extends LazyLogging {
   type Post = Rewritten[Pre]
   implicit val implicitRewriter: AbstractRewriter[Pre, Post] = rw
 
@@ -78,7 +78,7 @@ case class LangPVLToCol[Pre <: Generation](rw: LangSpecificToCol[Pre]) extends L
         ApplicableContract(
           UnitAccountedPredicate(tt),
           UnitAccountedPredicate(AstBuildHelpers.foldStar(cls.declarations.collect {
-            case field: InstanceField[Pre] if field.flags.collectFirst { case _: Final[Pre] => () }.isEmpty =>
+            case field: InstanceField[Pre] if field.flags.collectFirst { case _: Final[Pre] => () }.isEmpty && !veymontGeneratePermissions =>
               fieldPerm[Post](result, rw.succ(field), WritePerm())
           }) &* (if (checkRunnable) IdleToken(result) else tt)), tt, Nil, Nil, Nil, None,
         )(TrueSatisfiable)

--- a/src/rewrite/vct/rewrite/lang/LangSpecificToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangSpecificToCol.scala
@@ -10,11 +10,11 @@ import vct.col.ref.Ref
 import vct.col.resolve.ctx._
 import vct.col.resolve.lang.Java
 import vct.rewrite.lang.LangSpecificToCol.NotAValue
-import vct.col.rewrite.{Generation, Rewriter, RewriterBuilder}
+import vct.col.rewrite.{Generation, Rewriter, RewriterBuilder, RewriterBuilderArg}
 import vct.result.VerificationError.UserError
 import vct.rewrite.lang.LangVeyMontToCol
 
-case object LangSpecificToCol extends RewriterBuilder {
+case object LangSpecificToCol extends RewriterBuilderArg[Boolean] {
   override def key: String = "langSpecific"
   override def desc: String = "Translate language-specific constructs to a common subset of nodes."
 
@@ -31,12 +31,12 @@ case object LangSpecificToCol extends RewriterBuilder {
   }
 }
 
-case class LangSpecificToCol[Pre <: Generation]() extends Rewriter[Pre] with LazyLogging {
+case class LangSpecificToCol[Pre <: Generation](veymontGeneratePermissions: Boolean = false) extends Rewriter[Pre] with LazyLogging {
   val java: LangJavaToCol[Pre] = LangJavaToCol(this)
   val bip: LangBipToCol[Pre] = LangBipToCol(this)
   val c: LangCToCol[Pre] = LangCToCol(this)
   val cpp: LangCPPToCol[Pre] = LangCPPToCol(this)
-  val pvl: LangPVLToCol[Pre] = LangPVLToCol(this)
+  val pvl: LangPVLToCol[Pre] = LangPVLToCol(this, veymontGeneratePermissions)
   val veymont: LangVeyMontToCol[Pre] = LangVeyMontToCol(this)
   val silver: LangSilverToCol[Pre] = LangSilverToCol(this)
   val llvm: LangLLVMToCol[Pre] = LangLLVMToCol(this)

--- a/src/rewrite/vct/rewrite/lang/LangSpecificToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangSpecificToCol.scala
@@ -172,7 +172,7 @@ case class LangSpecificToCol[Pre <: Generation](veymontGeneratePermissions: Bool
     case eval@Eval(CPPInvocation(_, _, _, _)) => cpp.invocationStatement(eval)
 
     case communicate: PVLCommunicate[Pre] => veymont.rewriteCommunicate(communicate)
-    case assign: PVLSeqAssign[Pre] => veymont.rewriteParAssign(assign)
+    case assign: PVLSeqAssign[Pre] => veymont.rewriteSeqAssign(assign)
 
     case other => rewriteDefault(other)
   }

--- a/src/rewrite/vct/rewrite/lang/LangVeyMontToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangVeyMontToCol.scala
@@ -3,16 +3,12 @@ package vct.rewrite.lang
 import com.typesafe.scalalogging.LazyLogging
 import hre.util.ScopedStack
 import vct.col.ast._
-import vct.col.ast.RewriteHelpers._
-import vct.col.origin.{DiagnosticOrigin, Origin}
-import vct.col.ref.Ref
+import vct.col.origin.Origin
 import vct.col.resolve.ctx.RefPVLEndpoint
 import vct.col.rewrite.{Generation, Rewritten}
-import vct.rewrite.lang.LangSpecificToCol
 import vct.col.util.SuccessionMap
 import vct.result.VerificationError.UserError
-import vct.rewrite.lang.LangVeyMontToCol.{EndpointUseNotSupported, NoRunMethod}
-import vct.rewrite.veymont.EncodeSeqProg.CommunicateNotSupported
+import vct.rewrite.lang.LangVeyMontToCol.NoRunMethod
 
 case object LangVeyMontToCol {
   case object EndpointUseNotSupported extends UserError {

--- a/src/rewrite/vct/rewrite/lang/LangVeyMontToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangVeyMontToCol.scala
@@ -76,7 +76,7 @@ case class LangVeyMontToCol[Pre <: Generation](rw: LangSpecificToCol[Pre]) exten
                 case decl => rw.dispatch(decl)
               }
             )._1
-          )(prog.o)
+          )(prog.blame)(prog.o)
         )
       }
     }

--- a/src/rewrite/vct/rewrite/lang/LangVeyMontToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangVeyMontToCol.scala
@@ -40,10 +40,10 @@ case class LangVeyMontToCol[Pre <: Generation](rw: LangSpecificToCol[Pre]) exten
   def rewriteCommunicate(comm: PVLCommunicate[Pre]): Communicate[Post] =
     Communicate(rewriteAccess(comm.receiver), rewriteAccess(comm.sender))(comm.blame)(comm.o)
 
-  def rewriteAccess(access: PVLCommunicateAccess[Pre]): Access[Post] =
+  def rewriteAccess(access: PVLAccess[Pre]): Access[Post] =
     Access[Post](rewriteSubject(access.subject), rw.succ(access.ref.get.decl))(access.o)
 
-  def rewriteSubject(subject: PVLCommunicateSubject[Pre]): Subject[Post] = subject match {
+  def rewriteSubject(subject: PVLSubject[Pre]): Subject[Post] = subject match {
     case subject@PVLEndpointName(name) => EndpointName[Post](endpointSucc.ref(subject.ref.get.decl))(subject.o)
     case PVLIndexedFamilyName(family, index) => ???
     case PVLFamilyRange(family, binder, start, end) => ???

--- a/src/rewrite/vct/rewrite/lang/LangVeyMontToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangVeyMontToCol.scala
@@ -38,10 +38,10 @@ case class LangVeyMontToCol[Pre <: Generation](rw: LangSpecificToCol[Pre]) exten
   val currentProg: ScopedStack[PVLSeqProg[Pre]] = ScopedStack()
 
   def rewriteCommunicate(comm: PVLCommunicate[Pre]): Communicate[Post] =
-    Communicate(rewriteAccess(comm.receiver), rewriteAccess(comm.sender))(comm.blame)(comm.o)
+    Communicate(rewriteAccess(comm.receiver), rewriteAccess(comm.sender))(comm.o)
 
   def rewriteAccess(access: PVLAccess[Pre]): Access[Post] =
-    Access[Post](rewriteSubject(access.subject), rw.succ(access.ref.get.decl))(access.o)
+    Access[Post](rewriteSubject(access.subject), rw.succ(access.ref.get.decl))(access.blame)(access.o)
 
   def rewriteSubject(subject: PVLSubject[Pre]): Subject[Post] = subject match {
     case subject@PVLEndpointName(name) => EndpointName[Post](endpointSucc.ref(subject.ref.get.decl))(subject.o)

--- a/src/rewrite/vct/rewrite/lang/LangVeyMontToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangVeyMontToCol.scala
@@ -38,7 +38,7 @@ case class LangVeyMontToCol[Pre <: Generation](rw: LangSpecificToCol[Pre]) exten
   val currentProg: ScopedStack[PVLSeqProg[Pre]] = ScopedStack()
 
   def rewriteCommunicate(comm: PVLCommunicate[Pre]): Communicate[Post] =
-    Communicate(rewriteAccess(comm.receiver), rewriteAccess(comm.sender))(comm.o)
+    Communicate(rewriteAccess(comm.receiver), rewriteAccess(comm.sender))(comm.blame)(comm.o)
 
   def rewriteAccess(access: PVLCommunicateAccess[Pre]): Access[Post] =
     Access[Post](rewriteSubject(access.subject), rw.succ(access.ref.get.decl))(access.o)
@@ -94,8 +94,8 @@ case class LangVeyMontToCol[Pre <: Generation](rw: LangSpecificToCol[Pre]) exten
       SeqRun(rw.dispatch(run.body), rw.dispatch(run.contract))(run.blame)(run.o)
   }
 
-  def rewriteParAssign(assign: PVLSeqAssign[Pre]): SeqAssign[Post] =
-    SeqAssign[Post](endpointSucc.ref(assign.receiver.decl), rw.succ(assign.field.decl), rw.dispatch(assign.value))(assign.o)
+  def rewriteSeqAssign(assign: PVLSeqAssign[Pre]): SeqAssign[Post] =
+    SeqAssign[Post](endpointSucc.ref(assign.receiver.decl), rw.succ(assign.field.decl), rw.dispatch(assign.value))(assign.blame)(assign.o)
 
   def rewriteBranch(branch: PVLBranch[Pre]): UnresolvedSeqBranch[Post] =
     UnresolvedSeqBranch(branch.branches.map { case (e, s) => (rw.dispatch(e), rw.dispatch(s)) })(branch.blame)(branch.o)

--- a/src/rewrite/vct/rewrite/veymont/EncodeSeqProg.scala
+++ b/src/rewrite/vct/rewrite/veymont/EncodeSeqProg.scala
@@ -126,7 +126,7 @@ case class EncodeSeqProg[Pre <: Generation]() extends Rewriter[Pre] with LazyLog
 
     currentRun.having(run) {
       for (endpoint <- currentProg.top.endpoints) {
-        endpointSucc((mode, endpoint)) = new Variable(TClass(succ[Class[Post]](endpoint.cls.decl)))
+        endpointSucc((mode, endpoint)) = new Variable(TClass(succ[Class[Post]](endpoint.cls.decl)))(endpoint.o)
       }
 
       for (arg <- currentProg.top.args) {

--- a/src/rewrite/vct/rewrite/veymont/GenerateSeqProgPermissions.scala
+++ b/src/rewrite/vct/rewrite/veymont/GenerateSeqProgPermissions.scala
@@ -17,7 +17,6 @@ object GenerateSeqProgPermissions extends RewriterBuilderArg[Boolean] {
 }
 
 case class GenerateSeqProgPermissions[Pre <: Generation](enabled: Boolean = false) extends Rewriter[Pre] with LazyLogging {
-  println(s"Enabled: $enabled")
 
   val currentPerm: ScopedStack[Expr[Post]] = ScopedStack()
 

--- a/src/rewrite/vct/rewrite/veymont/GenerateSeqProgPermissions.scala
+++ b/src/rewrite/vct/rewrite/veymont/GenerateSeqProgPermissions.scala
@@ -5,10 +5,10 @@ import hre.util.ScopedStack
 import vct.col.ast.RewriteHelpers._
 import vct.col.util.AstBuildHelpers._
 import vct.col.ast.{Applicable, ApplicableContract, ArraySubscript, BooleanValue, Class, ContractApplicable, Declaration, Deref, Endpoint, EndpointGuard, EndpointName, SeqLoop, EndpointUse, EnumUse, Expr, FieldLocation, Function, InstanceField, InstanceFunction, InstanceMethod, IterationContract, Length, Local, LoopContract, LoopInvariant, Node, Null, Perm, Procedure, Result, SeqAssign, SeqProg, SeqRun, SplitAccountedPredicate, Statement, TArray, TClass, TInt, ThisObject, Type, UnitAccountedPredicate, Variable, WritePerm}
+import vct.col.ast.declaration.global.SeqProgImpl.participants
 import vct.col.origin.{Origin, PanicBlame}
 import vct.col.ref.Ref
 import vct.col.rewrite.{Generation, Rewriter, RewriterBuilderArg}
-
 import scala.collection.immutable.ListSet
 
 object GenerateSeqProgPermissions extends RewriterBuilderArg[Boolean] {
@@ -187,11 +187,4 @@ case class GenerateSeqProgPermissions[Pre <: Generation](enabled: Boolean = fals
     fieldPerm[Post](`this`, succ(f), WritePerm()) &*
       transitivePerm(Deref[Post](`this`, succ(f))(PanicBlame("Permission for this field is already established")), f.t)
   }
-
-  def participants(node: Node[Pre]): ListSet[Endpoint[Pre]] =
-    ListSet.from(node.collect {
-      case EndpointGuard(Ref(endpoint), _) => endpoint
-      case SeqAssign(Ref(endpoint), _, _) => endpoint
-      case EndpointName(Ref(endpoint)) => endpoint
-    })
 }

--- a/src/rewrite/vct/rewrite/veymont/ParalleliseVeyMontThreads.scala
+++ b/src/rewrite/vct/rewrite/veymont/ParalleliseVeyMontThreads.scala
@@ -2,8 +2,8 @@ package vct.rewrite.veymont
 
 import hre.util.ScopedStack
 import vct.col.ast.RewriteHelpers.{RewriteApplicableContract, RewriteClass, RewriteDeref, RewriteJavaClass, RewriteJavaConstructor, RewriteMethodInvocation}
-import vct.col.ast.{AbstractRewriter, ApplicableContract, Assert, Assign, Block, BooleanValue, Branch, Class, ClassDeclaration, CommunicateX, Declaration, Deref, Endpoint, EndpointUse, Eval, Expr, InstanceField, InstanceMethod, JavaClass, JavaConstructor, JavaInvocation, JavaLocal, JavaMethod, JavaNamedType, JavaParam, JavaPublic, JavaTClass, Local, Loop, MethodInvocation, NewObject, Node, Procedure, Program, RunMethod, Scope, SeqProg, SeqRun, Statement, TClass, TVeyMontChannel, TVoid, ThisObject, ThisSeqProg, Type, UnitAccountedPredicate, Variable, VeyMontAssignExpression, SeqGuard}
-import vct.col.origin.Origin
+import vct.col.ast.{AbstractRewriter, ApplicableContract, Assert, Assign, Block, BooleanValue, Branch, Class, ClassDeclaration, CommunicateX, Declaration, Deref, Endpoint, EndpointUse, Eval, Expr, InstanceField, InstanceMethod, JavaClass, JavaConstructor, JavaInvocation, JavaLocal, JavaMethod, JavaNamedType, JavaParam, JavaPublic, JavaTClass, Local, Loop, MethodInvocation, NewObject, Node, Procedure, Program, RunMethod, Scope, SeqGuard, SeqProg, SeqRun, Statement, TClass, TVeyMontChannel, TVoid, ThisObject, ThisSeqProg, Type, UnitAccountedPredicate, Variable, VeyMontAssignExpression}
+import vct.col.origin.{Origin, PanicBlame}
 import vct.col.resolve.ctx.RefJavaMethod
 import vct.col.rewrite.{Generation, Rewriter, RewriterBuilder, RewriterBuilderArg, Rewritten}
 import vct.col.util.SuccessionMap
@@ -284,7 +284,7 @@ case class ParalleliseEndpoints[Pre <: Generation](channelClass: JavaClass[_]) e
       TVoid[Post](),
       Seq.empty,Seq.empty,Seq.empty,
       Some(dispatch(run.body)),
-      dispatch(run.contract))(run.blame)(RunMethodOrigin(run))
+      dispatch(run.contract))(PanicBlame("TODO: Convert InstanceMethod blame to SeqRun blame")/* run.blame */)(RunMethodOrigin(run))
   }
 
   override def dispatch(node: Expr[Pre]): Expr[Post] = {

--- a/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
+++ b/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
@@ -7,36 +7,47 @@ import vct.options.types.Verbosity
 import vct.test.integration.helper.VercorsSpec
 
 class TechnicalVeyMontSpec extends VercorsSpec {
-  vercors should verify using silicon in "example using communicate" pvl
-  """
-     class Storage {
-        int x;
-     }
-     seq_program Example() {
-        endpoint alice = Storage();
-        endpoint bob = Storage();
+  (vercors
+    should verify
+    using silicon
+    flag "--veymont-generate-permissions"
+    in "example using communicate"
+    pvl
+    """
+       class Storage {
+          int x;
+       }
+       seq_program Example() {
+          endpoint alice = Storage();
+          endpoint bob = Storage();
 
-        seq_run {
-          communicate alice.x <- bob.x;
-          communicate bob.x -> alice.x;
-          assert alice.x == bob.x;
-        }
-     }
-  """
+          seq_run {
+            communicate alice.x <- bob.x;
+            communicate bob.x -> alice.x;
+            assert alice.x == bob.x;
+          }
+       }
+    """)
 
-  vercors should fail withCode "assertFailed:false" using silicon in "plain endpoint field dereference should be possible" pvl
-  """
-     class Storage {
-        int x;
-     }
-     seq_program Example() {
-        endpoint alice = Storage();
+  (vercors
+    should fail
+    withCode "assertFailed:false"
+    using silicon
+    flag "--veymont-generate-permissions"
+    in "plain endpoint field dereference should be possible"
+    pvl
+    """
+       class Storage {
+          int x;
+       }
+       seq_program Example() {
+          endpoint alice = Storage();
 
-        seq_run {
-          assert alice.x == 0;
-        }
-     }
-  """
+          seq_run {
+            assert alice.x == 0;
+          }
+       }
+    """)
 
   vercors should error withCode "noSuchName" in "non-existent thread name in communicate fails" pvl
   """
@@ -82,17 +93,22 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   }
   """
 
-  vercors should verify using silicon in "Endpoint fields should be assignable" pvl
-  """
-  class Storage { int x; int y; }
-  seq_program Example() {
-    endpoint alice = Storage();
+  (vercors
+    should verify
+    using silicon
+    flag "--veymont-generate-permissions"
+    in "Endpoint fields should be assignable"
+    pvl
+    """
+    class Storage { int x; int y; }
+    seq_program Example() {
+      endpoint alice = Storage();
 
-    seq_run {
-      alice.x := alice.y;
+      seq_run {
+        alice.x := alice.y;
+      }
     }
-  }
-  """
+    """)
 
   vercors should error withCode "resolutionError:seqProgInstanceMethodArgs" in "instance method in seq_program cannot have arguments" pvl
   """
@@ -187,51 +203,59 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   }
   """
 
-  /* TODO: In the new veymont, this test will probably be replaced by one that manually manages the
-           permissions for alice.x
-  */
-  vercors should verify using silicon in "assignment should work" pvl
-  """
-  class Storage {
-    int x;
+  (vercors
+    should verify
+    using silicon
+    flag "--veymont-generate-permissions"
+    in "assignment should work"
+    pvl
+    """
+    class Storage {
+      int x;
 
-    ensures Perm(x, 1) ** x == 0;
-    constructor() {
-      x = 0;
+      ensures x == 0;
+      constructor() {
+        x = 0;
+      }
     }
-  }
-  seq_program Example() {
-     endpoint alice = Storage();
+    seq_program Example() {
+       endpoint alice = Storage();
 
-     requires alice.x == 0;
-     ensures alice.x == 0;
-     seq_run {
-       assert alice.x == 0;
-     }
-  }
-  """
+       requires alice.x == 0;
+       ensures alice.x == 0;
+       seq_run {
+         assert alice.x == 0;
+       }
+    }
+    """)
 
   // TODO: Eventually should be postconditionFailed if the assignment statement works succesfully
-  vercors should error withCode "callableFailureNotSupported" in "assigning should change state" pvl
-  """
-  class Storage {
-     int x;
+  (vercors
+    should fail
+    withCode "postconditionFailed?"
+    using silicon
+    flag "--veymont-generate-permissions"
+    in "assigning should change state"
+    pvl
+    """
+    class Storage {
+       int x;
 
-     ensures Perm(x, write) ** x == v;
-     constructor(int v) {
-       x = v;
-     }
-  }
-  seq_program Example() {
-     endpoint alice = Storage(0);
+       ensures x == v;
+       constructor(int v) {
+         x = v;
+       }
+    }
+    seq_program Example() {
+       endpoint alice = Storage(0);
 
-     requires alice.x == 0;
-     ensures alice.x == 0;
-     seq_run {
-       alice.x := 1;
-     }
-  }
-  """
+       requires alice.x == 0;
+       ensures alice.x == 0;
+       seq_run {
+         alice.x := 1;
+       }
+    }
+    """)
 
   vercors should error withCode "resolutionError:seqProgReceivingEndpoint" in "Assignment statement only allows one endpoint in the assigned expression" pvl
   """
@@ -248,61 +272,78 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   }
   """
 
-  vercors should fail withCode "branchNotUnanimous" using silicon in "Parts of condition in branch have to agree inside seqprog" pvl
-  """
-  class Storage {
-     int x;
-  }
-  seq_program Example() {
-     endpoint alice = Storage();
-     endpoint bob = Storage();
+  (vercors
+    should fail
+    withCode "branchNotUnanimous"
+    using silicon
+    flag "--veymont-generate-permissions"
+    in "Parts of condition in branch have to agree inside seqprog"
+    pvl
+    """
+    class Storage {
+       int x;
+    }
+    seq_program Example() {
+       endpoint alice = Storage();
+       endpoint bob = Storage();
 
-     seq_run {
-        if (alice.x == 0 && bob.x == 0) {
-          // Alice might go here, bob might not: error
-        }
-     }
-  }
-  """
+       seq_run {
+          if (alice.x == 0 && bob.x == 0) {
+            // Alice might go here, bob might not: error
+          }
+       }
+    }
+    """)
 
-  vercors should fail withCode "branchNotUnanimous" using silicon in "Parts of condition in branch have to agree inside seqprog, including conditions for all endpoints" pvl
-  """
-  class Storage {
-     int x;
-  }
+  (vercors
+    should fail
+    withCode "branchNotUnanimous"
+    using silicon
+    flag "--veymont-generate-permissions"
+    in "Parts of condition in branch have to agree inside seqprog, including conditions for all endpoints"
+    pvl
+    """
+    class Storage {
+       int x;
+    }
 
-  pure int f() = 3;
+    pure int f() = 3;
 
-  seq_program Example() {
-     endpoint alice = Storage();
-     endpoint bob = Storage();
+    seq_program Example() {
+       endpoint alice = Storage();
+       endpoint bob = Storage();
 
-     seq_run {
-        if (alice.x == 0 && f() == 3) {
-          // Alice might go here, bob will definitely, because of the second expression: error
-        }
-     }
-  }
-  """
+       seq_run {
+          if (alice.x == 0 && f() == 3) {
+            // Alice might go here, bob will definitely, because of the second expression: error
+          }
+       }
+    }
+    """)
 
-  vercors should verify using silicon in "If there is only one endpoint, the conditions don't have to agree, as there is only one endpoint" pvl
-  """
-  class Storage {
-     int x;
-  }
+  (vercors
+    should verify
+    using silicon
+    flag "--veymont-generate-permissions"
+    in "If there is only one endpoint, the conditions don't have to agree, as there is only one endpoint"
+    pvl
+    """
+    class Storage {
+       int x;
+    }
 
-  pure int f() = 3;
+    pure int f() = 3;
 
-  seq_program Example() {
-     endpoint alice = Storage();
+    seq_program Example() {
+       endpoint alice = Storage();
 
-     seq_run {
-        if (alice.x == 0 && f() == 3) {
-          // Alice might go here, bob will definitely, because of the second expression: error
-        }
-     }
-  }
-  """
+       seq_run {
+          if (alice.x == 0 && f() == 3) {
+            // Alice might go here, bob will definitely, because of the second expression: error
+          }
+       }
+    }
+    """)
 
   vercors should error withCode "seqProgParticipantErrors" in "`if` cannot depend on bob, inside an `if` depending on alice" pvl
   """
@@ -357,61 +398,78 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   }
   """
 
-  vercors should verify using silicon in "Programs where branch conditions agree should verify" pvl
-  """
-  class Storage {
-     bool x;
-  }
-  seq_program Example() {
-     endpoint alice = Storage();
-     endpoint bob = Storage();
+  (vercors
+    should verify
+    using silicon
+    flag "--veymont-generate-permissions"
+    in "Programs where branch conditions agree should verify"
+    pvl
+    """
+    class Storage {
+       bool x;
+    }
+    seq_program Example() {
+       endpoint alice = Storage();
+       endpoint bob = Storage();
 
-     seq_run {
-       alice.x := true;
-       bob.x := true;
-       while (alice.x && bob.x) {
-         bob.x := false;
-         communicate alice.x <- bob.x;
+       seq_run {
+         alice.x := true;
+         bob.x := true;
+         while (alice.x && bob.x) {
+           bob.x := false;
+           communicate alice.x <- bob.x;
+         }
        }
-     }
-  }
-  """
+    }
+    """)
 
-  vercors should fail withCode "loopUnanimityNotEstablished" using silicon in "Programs where branch condition unanimity cannot be established should fail" pvl
-  """
-  class Storage {
-     bool x;
-  }
-  seq_program Example() {
-     endpoint alice = Storage();
-     endpoint bob = Storage();
+  (vercors
+    should fail
+    withCode "loopUnanimityNotEstablished"
+    using silicon
+    flag "--veymont-generate-permissions"
+    in "Programs where branch condition unanimity cannot be established should fail"
+    pvl
+    """
+    class Storage {
+       bool x;
+    }
+    seq_program Example() {
+       endpoint alice = Storage();
+       endpoint bob = Storage();
 
-     seq_run {
-       while (alice.x && bob.x) {
+       seq_run {
+         while (alice.x && bob.x) {
 
+         }
        }
-     }
-  }
-  """
+    }
+    """)
 
-  vercors should fail withCode "loopUnanimityNotMaintained" using silicon in "Programs where branch condition unanimity cannot be maintained should fail" pvl
-  """
-  class Storage {
-     bool x;
-  }
-  seq_program Example() {
-     endpoint alice = Storage();
-     endpoint bob = Storage();
+  (vercors
+    should fail
+    withCode "loopUnanimityNotMaintained"
+    using silicon
+    flag "--veymont-generate-permissions"
+    in "Programs where branch condition unanimity cannot be maintained should fail"
+    pvl
+    """
+    class Storage {
+       bool x;
+    }
+    seq_program Example() {
+       endpoint alice = Storage();
+       endpoint bob = Storage();
 
-     seq_run {
-       alice.x := true;
-       bob.x := true;
-       while (alice.x && bob.x) {
-         alice.x := false;
+       seq_run {
+         alice.x := true;
+         bob.x := true;
+         while (alice.x && bob.x) {
+           alice.x := false;
+         }
        }
-     }
-  }
-  """
+    }
+    """)
 
   vercors should error withCode "seqProgParticipantErrors" in "Loops should also limit the number of participants" pvl
   """
@@ -434,28 +492,33 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   }
   """
 
-  vercors should verify using silicon in "Loops should also limit the number of participants when combined with branches" pvl
-  """
-  class Storage {
-     bool x;
-  }
-  seq_program Example() {
-     endpoint alice = Storage();
-     endpoint bob = Storage();
-     endpoint charlie = Storage();
+  (vercors
+    should verify
+    using silicon
+    flag "--veymont-generate-permissions"
+    in "Loops should also limit the number of participants when combined with branches"
+    pvl
+    """
+    class Storage {
+       bool x;
+    }
+    seq_program Example() {
+       endpoint alice = Storage();
+       endpoint bob = Storage();
+       endpoint charlie = Storage();
 
-     seq_run {
-       alice.x := true;
-       bob.x := true;
-       while (alice.x && bob.x) {
-         alice.x := false;
-         if (bob.x == true) {
-          bob.x := false;
+       seq_run {
+         alice.x := true;
+         bob.x := true;
+         while (alice.x && bob.x) {
+           alice.x := false;
+           if (bob.x == true) {
+            bob.x := false;
+           }
          }
        }
-     }
-  }
-  """
+    }
+    """)
 
   vercors should error withCode "seqProgParticipantErrors" in "Loops should also limit the number of participants when combined with branches" pvl
   """
@@ -483,12 +546,13 @@ class TechnicalVeyMontSpec extends VercorsSpec {
 
   (vercors should verify
     using silicon
-    flags Seq("--veymont-generate-permissions")
+    flag "--veymont-generate-permissions"
     in "Permission should be generated for constructors as well" pvl
     """
     class Storage {
       int x;
 
+      ensures x == 2;
       int m() {
         x = 2;
       }
@@ -502,28 +566,13 @@ class TechnicalVeyMontSpec extends VercorsSpec {
       }
     }
     """)
-}
 
-class TechnicalVeyMontSpec2 extends VercorsSpec {
-  (vercors should verify
+  (vercors
+    should fail
+    withCode "accessPerm"
     using silicon
-    in "Permission should be generated for constructors as well" pvl
-    """
-    class Storage {
-      int x;
-    }
-
-    seq_program Example() {
-      endpoint alice = Storage();
-      seq_run {
-        alice.x := 2;
-      }
-    }
-    """)
-
-  (vercors should verify
-    using silicon
-    in "Permission should be generated for constructors all" pvl
+    in "When no permission is generated, a failure should occur on endpoint field access"
+    pvl
     """
     class Storage {
       int x;
@@ -534,6 +583,25 @@ class TechnicalVeyMontSpec2 extends VercorsSpec {
       endpoint bob = Storage();
       seq_run {
         communicate alice.x <- bob.x;
+      }
+    }
+    """)
+
+  (vercors
+    should fail
+    withCode "seqAssignPerm"
+    using silicon
+    in "When no permission is generated, a failure should occur on seq assign field access"
+    pvl
+    """
+    class Storage {
+      int x;
+    }
+
+    seq_program Example() {
+      endpoint alice = Storage();
+      seq_run {
+        alice.x := 3;
       }
     }
     """)

--- a/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
+++ b/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
@@ -503,3 +503,38 @@ class TechnicalVeyMontSpec extends VercorsSpec {
     }
     """)
 }
+
+class TechnicalVeyMontSpec2 extends VercorsSpec {
+  (vercors should verify
+    using silicon
+    in "Permission should be generated for constructors as well" pvl
+    """
+    class Storage {
+      int x;
+    }
+
+    seq_program Example() {
+      endpoint alice = Storage();
+      seq_run {
+        alice.x := 2;
+      }
+    }
+    """)
+
+  (vercors should verify
+    using silicon
+    in "Permission should be generated for constructors all" pvl
+    """
+    class Storage {
+      int x;
+    }
+
+    seq_program Example() {
+      endpoint alice = Storage();
+      endpoint bob = Storage();
+      seq_run {
+        communicate alice.x <- bob.x;
+      }
+    }
+    """)
+}

--- a/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
+++ b/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
@@ -1,5 +1,9 @@
 package vct.test.integration.examples
 
+import hre.io.LiteralReadable
+import vct.main.modes.Verify
+import vct.options.Options
+import vct.options.types.Verbosity
 import vct.test.integration.helper.VercorsSpec
 
 class TechnicalVeyMontSpec extends VercorsSpec {
@@ -477,4 +481,28 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   }
   """
 
+}
+
+class TechnicalVeyMontSpec2 extends VercorsSpec {
+  (vercors should verify
+    using silicon
+    flags Seq("--veymont-generate-permissions")
+    in "Loops should also limit the number of participants when combined with branches" pvl
+  """
+  class Storage {
+    int x;
+
+    int m() {
+      x = 2;
+    }
+  }
+
+  seq_program Example() {
+    endpoint alice = Storage();
+    seq_run {
+      alice.m();
+      assert alice.x == 2;
+    }
+  }
+  """)
 }

--- a/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
+++ b/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
@@ -668,4 +668,30 @@ class TechnicalVeyMontSpec extends VercorsSpec {
       }
     }
     """)
+
+  (vercors
+    should verify
+    using silicon
+    flag "--veymont-generate-permissions"
+    in "Permission generation should only generate permissions that are strictly necessary"
+    pvl
+    """
+    class Storage {
+      int x;
+    }
+
+    seq_program Example() {
+      endpoint alice = Storage();
+      endpoint bob = Storage();
+      seq_run {
+        alice.x := 0;
+        bob.x := 3;
+        loop_invariant 0 <= alice.x && alice.x <= 10;
+        while(alice.x < 10) {
+          alice.x := alice.x + 1;
+        }
+        assert bob.x == 3;
+      }
+    }
+    """)
 }

--- a/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
+++ b/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
@@ -618,19 +618,41 @@ class TechnicalVeyMontSpec extends VercorsSpec {
       }
     }
     """)
-}
 
-class TechnicalVeyMontSpec2 extends VercorsSpec {
   (vercors
     should verify
     using silicon
     flag "--veymont-generate-permissions"
-    in "Permissions are generated for loop invariants"
+    in "Permissions are generated for loop invariants, procedures, functions, instance methods, instance functions"
     pvl
     """
     class Storage {
       int x;
+
+      ensures x == \old(x);
+      ensures \result == x;
+      int imx() {
+        return x;
+      }
+
+      pure int ifx() = x;
+
+      ensures x == \old(x);
+      void all() {
+        assert imx() == ifx();
+        assert ifx() == px(this);
+        assert px(this) == fx(this);
+      }
     }
+
+    ensures s.x == \old(s.x);
+    ensures \result == s.x;
+    int px(Storage s) {
+      return s.x;
+    }
+
+    ensures \result == s.x;
+    pure int fx(Storage s) = s.x;
 
     seq_program Example(int N) {
       endpoint alice = Storage();
@@ -641,6 +663,8 @@ class TechnicalVeyMontSpec2 extends VercorsSpec {
         while(alice.x < 10) {
           alice.x := alice.x + 1;
         }
+
+        alice.all();
       }
     }
     """)

--- a/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
+++ b/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
@@ -481,28 +481,25 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   }
   """
 
-}
-
-class TechnicalVeyMontSpec2 extends VercorsSpec {
   (vercors should verify
     using silicon
     flags Seq("--veymont-generate-permissions")
-    in "Loops should also limit the number of participants when combined with branches" pvl
-  """
-  class Storage {
-    int x;
+    in "Permission should be generated for constructors as well" pvl
+    """
+    class Storage {
+      int x;
 
-    int m() {
-      x = 2;
+      int m() {
+        x = 2;
+      }
     }
-  }
 
-  seq_program Example() {
-    endpoint alice = Storage();
-    seq_run {
-      alice.m();
-      assert alice.x == 2;
+    seq_program Example() {
+      endpoint alice = Storage();
+      seq_run {
+        alice.m();
+        assert alice.x == 2;
+      }
     }
-  }
-  """)
+    """)
 }

--- a/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
+++ b/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
@@ -229,30 +229,43 @@ class TechnicalVeyMontSpec extends VercorsSpec {
     }
     """)
 
-  // TODO: Eventually should be postconditionFailed if the assignment statement works succesfully
   (vercors
     should fail
-    withCode "postconditionFailed?"
+    withCode "postFailed:false"
     using silicon
     flag "--veymont-generate-permissions"
-    in "assigning should change state"
+    in "Postcondition of seq_run can fail"
     pvl
     """
     class Storage {
        int x;
-
-       ensures x == v;
-       constructor(int v) {
-         x = v;
-       }
     }
     seq_program Example() {
-       endpoint alice = Storage(0);
+       endpoint alice = Storage();
 
-       requires alice.x == 0;
        ensures alice.x == 0;
        seq_run {
-         alice.x := 1;
+       }
+    }
+    """)
+
+  (vercors
+    should fail
+    withCode "postFailed:false"
+    using silicon
+    flag "--veymont-generate-permissions"
+    in "Postcondition of seq_program can fail"
+    pvl
+    """
+    class Storage {
+       int x;
+    }
+
+    ensures 1 == 0;
+    seq_program Example() {
+       endpoint alice = Storage();
+
+       seq_run {
        }
     }
     """)

--- a/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
+++ b/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
@@ -50,7 +50,7 @@ class TechnicalVeyMontSpec extends VercorsSpec {
     """)
 
   vercors should error withCode "noSuchName" in "non-existent thread name in communicate fails" pvl
-  """
+    """
   seq_program Example() {
      seq_run {
        communicate charlie.x <- charlie.x;
@@ -59,7 +59,7 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   """
 
   vercors should error withCode "noSuchName" in "non-existent field in communicate fails" pvl
-  """
+    """
   class Storage { int x; }
   seq_program Example() {
      endpoint charlie = Storage();
@@ -70,7 +70,7 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   """
 
   vercors should error withCode "parseError" in "parameterized sends not yet supported " pvl
-  """
+    """
     class Storage { int x; }
     seq_program Example() {
       endpoint alice[10] = Storage();
@@ -82,12 +82,12 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   """
 
   vercors should error withCode "noRunMethod" in "run method should always be present" pvl
-  """
+    """
   seq_program Example() { }
   """
 
   vercors should error withCode "parseError" in "endpoints can only have class types" pvl
-  """
+    """
   seq_program Example() {
     endpoint alice = int();
   }
@@ -111,7 +111,7 @@ class TechnicalVeyMontSpec extends VercorsSpec {
     """)
 
   vercors should error withCode "resolutionError:seqProgInstanceMethodArgs" in "instance method in seq_program cannot have arguments" pvl
-  """
+    """
   seq_program Example() {
     void m(int x) { }
 
@@ -120,7 +120,7 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   """
 
   vercors should error withCode "resolutionError:seqProgInstanceMethodBody" in "instance method in seq_program must have a body" pvl
-  """
+    """
   seq_program Example() {
     void m();
 
@@ -129,7 +129,7 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   """
 
   vercors should error withCode "resolutionError:seqProgInstanceMethodNonVoid" in "instance method in seq_program must have void return type" pvl
-  """
+    """
   seq_program Example() {
     int m() { }
 
@@ -138,7 +138,7 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   """
 
   vercors should error withCode "resolutionError:seqProgStatement" in "seq_prog excludes certain statements" pvl
-  """
+    """
   class C { }
   seq_program Example(C c) {
     seq_run {
@@ -148,7 +148,7 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   """
 
   vercors should error withCode "resolutionError:seqProgReceivingEndpoint" in "Dereferencing anything other than the receiving endpoint in the arguments of a endpoint method invocation is not supported yet" pvl
-  """
+    """
   class C { C d; void foo(int x); int x; }
   seq_program Example(C c) {
     endpoint c = C();
@@ -160,7 +160,7 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   """
 
   vercors should error withCode "resolutionError:seqProgInvocation" in "Only method calls on endpoints or seq_program are allowed within seq_program" pvl
-  """
+    """
   class C { C d; void foo(); }
   seq_program Example(C c) {
     endpoint c = C();
@@ -171,7 +171,7 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   """
 
   vercors should verify using silicon in "Empty seq_program must verify" pvl
-  """
+    """
   seq_program C() {
     seq_run {
 
@@ -180,7 +180,7 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   """
 
   vercors should error withCode "resolutionError:type" in "Assign must be well-typed" pvl
-  """
+    """
   class C { int x; }
   seq_program C() {
     endpoint charlie = C();
@@ -191,7 +191,7 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   """
 
   vercors should error withCode "resolutionError:type" in "Communicating parties must agree on the type" pvl
-  """
+    """
   class C { int c; }
   class A { bool a; }
   seq_program C() {
@@ -271,7 +271,7 @@ class TechnicalVeyMontSpec extends VercorsSpec {
     """)
 
   vercors should error withCode "resolutionError:seqProgReceivingEndpoint" in "Assignment statement only allows one endpoint in the assigned expression" pvl
-  """
+    """
   class Storage {
      int x;
   }
@@ -359,7 +359,7 @@ class TechnicalVeyMontSpec extends VercorsSpec {
     """)
 
   vercors should error withCode "seqProgParticipantErrors" in "`if` cannot depend on bob, inside an `if` depending on alice" pvl
-  """
+    """
   class Storage {
     int x;
   }
@@ -378,7 +378,7 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   """
 
   vercors should error withCode "seqProgParticipantErrors" in "If alice branches, bob cannot communicate" pvl
-  """
+    """
   class Storage {
     int x;
   }
@@ -395,7 +395,7 @@ class TechnicalVeyMontSpec extends VercorsSpec {
   """
 
   vercors should error withCode "seqProgParticipantErrors" in "If alice branches, bob cannot assign" pvl
-  """
+    """
   class Storage {
     int x;
   }
@@ -485,7 +485,7 @@ class TechnicalVeyMontSpec extends VercorsSpec {
     """)
 
   vercors should error withCode "seqProgParticipantErrors" in "Loops should also limit the number of participants" pvl
-  """
+    """
   class Storage {
      bool x;
   }
@@ -534,7 +534,7 @@ class TechnicalVeyMontSpec extends VercorsSpec {
     """)
 
   vercors should error withCode "seqProgParticipantErrors" in "Loops should also limit the number of participants when combined with branches" pvl
-  """
+    """
   class Storage {
      bool x;
   }
@@ -615,6 +615,32 @@ class TechnicalVeyMontSpec extends VercorsSpec {
       endpoint alice = Storage();
       seq_run {
         alice.x := 3;
+      }
+    }
+    """)
+}
+
+class TechnicalVeyMontSpec2 extends VercorsSpec {
+  (vercors
+    should verify
+    using silicon
+    flag "--veymont-generate-permissions"
+    in "Permissions are generated for loop invariants"
+    pvl
+    """
+    class Storage {
+      int x;
+    }
+
+    seq_program Example(int N) {
+      endpoint alice = Storage();
+      ensures alice.x == 10;
+      seq_run {
+        alice.x := 0;
+        loop_invariant 0 <= alice.x && alice.x <= 10;
+        while(alice.x < 10) {
+          alice.x := alice.x + 1;
+        }
       }
     }
     """)

--- a/test/main/vct/test/integration/helper/VercorsSpec.scala
+++ b/test/main/vct/test/integration/helper/VercorsSpec.scala
@@ -8,11 +8,12 @@ import org.scalatest.concurrent.TimeLimits.failAfter
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.time._
 import org.slf4j.LoggerFactory
+import scopt.OParser
 import vct.col.origin.{BlameUnreachable, VerificationFailure}
 import vct.col.rewrite.bip.BIP.Standalone.VerificationReport
 import vct.main.Main.TemporarilyUnsupported
 import vct.main.modes.Verify
-import vct.options.types
+import vct.options.{Options, types}
 import vct.options.types.{Backend, PathOrStd}
 import vct.parsers.ParseError
 import vct.result.VerificationError
@@ -71,7 +72,7 @@ abstract class VercorsSpec extends AnyFlatSpec {
     }
   }
 
-  private def registerTest(verdict: Verdict, desc: String, tags: Seq[Tag], backend: Backend, inputs: Seq[Readable])(implicit pos: source.Position): Unit = {
+  private def registerTest(verdict: Verdict, desc: String, tags: Seq[Tag], backend: Backend, inputs: Seq[Readable], flags: Seq[String])(implicit pos: source.Position): Unit = {
     val fullDesc: String = s"${desc.capitalize} produces verdict $verdict with $backend".replaceAll("should", "shld")
     // PB: note that object typically do not have a deterministic hashCode, but Strings do.
     val matrixId = Math.floorMod(fullDesc.hashCode, MATRIX_COUNT)
@@ -83,8 +84,16 @@ abstract class VercorsSpec extends AnyFlatSpec {
 
       failAfter(Span(300, Seconds)) {
         matchVerdict(verdict, backend match {
-          case types.Backend.Silicon => Verify.verifyWithSilicon(inputs)
+          case types.Backend.Silicon =>
+            Verify.verifyWithOptions(
+              Options.parse((Seq("--backend", "silicon") ++ flags).toArray).get,
+              inputs
+            )
           case types.Backend.Carbon => Verify.verifyWithCarbon(inputs)
+            Verify.verifyWithOptions(
+              Options.parse((Seq("--backend", "carbon") ++ flags).toArray).get,
+              inputs
+            )
         })
       }
     }
@@ -167,14 +176,14 @@ abstract class VercorsSpec extends AnyFlatSpec {
   }
 
   class ErrorVerdictPhrase() {
-    def withCode(code: String): BackendPhrase = new BackendPhrase(Error(code), None, silicon)
+    def withCode(code: String): BackendPhrase = new BackendPhrase(Error(code), None, silicon, Nil)
   }
 
   class VerdictPhrase(val verdict: Verdict, val reportPath: Option[Path]) {
-    def using(backend: Seq[Backend]): BackendPhrase = new BackendPhrase(verdict, reportPath, backend)
+    def using(backend: Seq[Backend]): BackendPhrase = new BackendPhrase(verdict, reportPath, backend, Nil)
   }
 
-  class BackendPhrase(val verdict: Verdict, val reportPath: Option[Path], val backends: Seq[Backend]) {
+  class BackendPhrase(val verdict: Verdict, val reportPath: Option[Path], val backends: Seq[Backend], val _flags: Seq[String]) {
     def example(path: String)(implicit pos: source.Position): Unit = examples(path)
 
     def examples(examples: String*)(implicit pos: source.Position): Unit = {
@@ -183,32 +192,34 @@ abstract class VercorsSpec extends AnyFlatSpec {
       val inputs = paths.map(PathOrStd.Path)
 
       for(backend <- backends) {
-        registerTest(verdict, s"Examples ${paths.mkString(", ")}", Seq(new Tag("exampleCase")), backend, inputs)
+        registerTest(verdict, s"Examples ${paths.mkString(", ")}", Seq(new Tag("exampleCase")), backend, inputs, _flags)
       }
     }
 
-    def in(desc: String): DescPhrase = new DescPhrase(verdict, backends, desc)
+    def in(desc: String): DescPhrase = new DescPhrase(verdict, backends, desc, _flags)
+
+    def flags(args: Seq[String]): BackendPhrase = new BackendPhrase(verdict, reportPath, backends, args)
   }
 
-  class DescPhrase(val verdict: Verdict, val backends: Seq[Backend], val desc: String) {
+  class DescPhrase(val verdict: Verdict, val backends: Seq[Backend], val desc: String, val flags: Seq[String]) {
     def pvl(data: String)(implicit pos: source.Position): Unit = {
       val inputs = Seq(LiteralReadable("test.pvl", data))
       for(backend <- backends) {
-        registerTest(verdict, desc, Seq(new Tag("literalCase")), backend, inputs)
+        registerTest(verdict, desc, Seq(new Tag("literalCase")), backend, inputs, flags)
       }
     }
 
     def java(data: String)(implicit pos: source.Position): Unit = {
       val inputs = Seq(LiteralReadable("test.java", data))
       for(backend <- backends) {
-        registerTest(verdict, desc, Seq(new Tag("literalCase")), backend, inputs)
+        registerTest(verdict, desc, Seq(new Tag("literalCase")), backend, inputs, flags)
       }
     }
 
     def c(data: String)(implicit pos: source.Position): Unit = {
       val inputs = Seq(LiteralReadable("test.c", data))
       for(backend <- backends) {
-        registerTest(verdict, desc, Seq(new Tag("literalCase")), backend, inputs)
+        registerTest(verdict, desc, Seq(new Tag("literalCase")), backend, inputs, flags)
       }
     }
   }

--- a/test/main/vct/test/integration/helper/VercorsSpec.scala
+++ b/test/main/vct/test/integration/helper/VercorsSpec.scala
@@ -199,6 +199,7 @@ abstract class VercorsSpec extends AnyFlatSpec {
     def in(desc: String): DescPhrase = new DescPhrase(verdict, backends, desc, _flags)
 
     def flags(args: Seq[String]): BackendPhrase = new BackendPhrase(verdict, reportPath, backends, args)
+    def flag(arg: String): BackendPhrase = new BackendPhrase(verdict, reportPath, backends, Seq(arg))
   }
 
   class DescPhrase(val verdict: Verdict, val backends: Seq[Backend], val desc: String, val flags: Seq[String]) {


### PR DESCRIPTION
Implements:

- Opt-in permission generation, also outside VeyMont AST nodes, plus tests
- Capability to pass flags in the test suite
- Proper blames for communicate, :=, seq_run, seq_program, plus tests.
- Support for auxiliary seq_program methods
- Stricter permission generation; only permissions for participants participating in a piece of seq_prog code have permissions generated.

Depends on #1106