### PR TITLE
VeyMont: auxiliary `seq_program` methods

### DIFF
--- a/src/col/vct/col/ast/declaration/global/SeqProgImpl.scala
+++ b/src/col/vct/col/ast/declaration/global/SeqProgImpl.scala
@@ -1,10 +1,22 @@
 package vct.col.ast.declaration.global
 
-import vct.col.ast.{Class, Declaration, SeqProg}
+import vct.col.ast.{Class, Declaration, Endpoint, EndpointGuard, EndpointName, Node, SeqAssign, SeqProg}
 import vct.col.ast.util.Declarator
 import vct.col.check.{CheckContext, CheckError}
 import vct.col.origin.Origin
 import vct.col.print._
+import vct.col.ref.Ref
+
+import scala.collection.immutable.ListSet
+
+object SeqProgImpl {
+  def participants[G](node: Node[G]): ListSet[Endpoint[G]] =
+    ListSet.from(node.collect {
+      case EndpointGuard(Ref(endpoint), _) => endpoint
+      case SeqAssign(Ref(endpoint), _, _) => endpoint
+      case EndpointName(Ref(endpoint)) => endpoint
+    })
+}
 
 trait SeqProgImpl[G] extends Declarator[G] { this: SeqProg[G] =>
   override def declarations: Seq[Declaration[G]] = args ++ endpoints ++ decls

--- a/src/main/vct/main/stages/Transformation.scala
+++ b/src/main/vct/main/stages/Transformation.scala
@@ -198,8 +198,8 @@ case class SilverTransformation
     SplitSeqGuards,
     EncodeUnpointedGuard,
     DeduplicateSeqGuards,
-    EncodeSeqBranchUnanimity,
     GenerateSeqProgPermissions.withArg(veymontGeneratePermissions),
+    EncodeSeqBranchUnanimity,
     EncodeSeqProg,
 
     EncodeString, // Encode spec string as seq<int>

--- a/src/main/vct/main/stages/Transformation.scala
+++ b/src/main/vct/main/stages/Transformation.scala
@@ -195,11 +195,11 @@ case class SilverTransformation
     EncodeRangedFor,
 
     // VeyMont sequential program encoding
-    GenerateSeqProgPermissions.withArg(veymontGeneratePermissions),
     SplitSeqGuards,
     EncodeUnpointedGuard,
     DeduplicateSeqGuards,
     EncodeSeqBranchUnanimity,
+    GenerateSeqProgPermissions.withArg(veymontGeneratePermissions),
     EncodeSeqProg,
 
     EncodeString, // Encode spec string as seq<int>

--- a/src/rewrite/vct/rewrite/veymont/GenerateSeqProgPermissions.scala
+++ b/src/rewrite/vct/rewrite/veymont/GenerateSeqProgPermissions.scala
@@ -5,10 +5,10 @@ import hre.util.ScopedStack
 import vct.col.ast.RewriteHelpers._
 import vct.col.util.AstBuildHelpers._
 import vct.col.ast.{Applicable, ApplicableContract, ArraySubscript, BooleanValue, Class, ContractApplicable, Declaration, Deref, Endpoint, EndpointGuard, EndpointName, SeqLoop, EndpointUse, EnumUse, Expr, FieldLocation, Function, InstanceField, InstanceFunction, InstanceMethod, IterationContract, Length, Local, LoopContract, LoopInvariant, Node, Null, Perm, Procedure, Result, SeqAssign, SeqProg, SeqRun, SplitAccountedPredicate, Statement, TArray, TClass, TInt, ThisObject, Type, UnitAccountedPredicate, Variable, WritePerm}
+import vct.col.ast.declaration.global.SeqProgImpl.participants
 import vct.col.origin.{Origin, PanicBlame}
 import vct.col.ref.Ref
 import vct.col.rewrite.{Generation, Rewriter, RewriterBuilderArg}
-
 import scala.collection.immutable.ListSet
 
 object GenerateSeqProgPermissions extends RewriterBuilderArg[Boolean] {
@@ -187,11 +187,4 @@ case class GenerateSeqProgPermissions[Pre <: Generation](enabled: Boolean = fals
     fieldPerm[Post](`this`, succ(f), WritePerm()) &*
       transitivePerm(Deref[Post](`this`, succ(f))(PanicBlame("Permission for this field is already established")), f.t)
   }
-
-  def participants(node: Node[Pre]): ListSet[Endpoint[Pre]] =
-    ListSet.from(node.collect {
-      case EndpointGuard(Ref(endpoint), _) => endpoint
-      case SeqAssign(Ref(endpoint), _, _) => endpoint
-      case EndpointName(Ref(endpoint)) => endpoint
-    })
 }

--- a/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
+++ b/test/main/vct/test/integration/examples/TechnicalVeyMontSpec.scala
@@ -668,4 +668,30 @@ class TechnicalVeyMontSpec extends VercorsSpec {
       }
     }
     """)
+
+  (vercors
+    should verify
+    using silicon
+    flag "--veymont-generate-permissions"
+    in "Permission generation should only generate permissions that are strictly necessary"
+    pvl
+    """
+    class Storage {
+      int x;
+    }
+
+    seq_program Example() {
+      endpoint alice = Storage();
+      endpoint bob = Storage();
+      seq_run {
+        alice.x := 0;
+        bob.x := 3;
+        loop_invariant 0 <= alice.x && alice.x <= 10;
+        while(alice.x < 10) {
+          alice.x := alice.x + 1;
+        }
+        assert bob.x == 3;
+      }
+    }
+    """)
 }


### PR DESCRIPTION
This PR implements the following:

- support for auxiliary `seq_program` methods
-  Stricter permission generation; only permissions for participants participating in a piece of seq_prog code have permissions generated. This makes it easier to frame knowledge across pieces of code in which endpoints do not participate.

Depends on #1110.