### PR TITLE
Actually skip backend

### DIFF
--- a/src/main/vct/main/modes/Verify.scala
+++ b/src/main/vct/main/modes/Verify.scala
@@ -85,7 +85,11 @@ case object Verify extends LazyLogging {
           logger.error(CollectString(s => err.printStackTrace(s)))
           EXIT_CODE_ERROR
         case Right((Nil, report)) =>
-          logger.info("Verification completed successfully.")
+          if(options.skipBackend){
+            logger.info("Verification skipped.")
+          } else {
+            logger.info("Verification completed successfully.")
+          }
           friendlyHandleBipReport(report, options.bipReportFile)
           EXIT_CODE_SUCCESS
         case Right((fails, report)) =>

--- a/src/main/vct/options/Options.scala
+++ b/src/main/vct/options/Options.scala
@@ -192,6 +192,11 @@ case object Options {
         .text("Indicate, in seconds, the timeout value for a single assert statement. If the verification gets stuck " +
           "on a single SMT check for longer than this timeout, the verification will fail."),
 
+      opt[Int]("dev-total-timeout").maybeHidden()
+        .action((amount, c) => c.copy(devSiliconTotalTimeout = amount))
+        .text("Indicate, in seconds, the timeout value for the backend verification. If the verification gets stuck " +
+          "for longer than this timeout, the verification will timeout."),
+
       opt[Path]("dev-silicon-z3-log-file").maybeHidden()
         .action((p, c) => c.copy(devSiliconZ3LogFile = Some(p)))
         .text("Path for z3 to write smt2 log file to"),
@@ -386,6 +391,7 @@ case class Options
   devSiliconNumVerifiers: Option[Int] = None,
   devSiliconZ3LogFile: Option[Path] = None,
   devSiliconAssertTimeout: Int = 30,
+  devSiliconTotalTimeout: Int = 0,
   devSiliconReportOnNoProgress: Boolean = true,
   devSiliconBranchConditionReportInterval: Option[Int] = Some(1000),
   devSiliconTraceBranchConditions: Boolean = false,

--- a/src/viper/viper/api/backend/Backend.scala
+++ b/src/viper/viper/api/backend/Backend.scala
@@ -5,5 +5,5 @@ import vct.col.ast.Program
 import java.nio.file.Path
 
 trait Backend {
-  def submit(program: Program[_], output: Option[Path]): Boolean
+  def submit(program: Program[_], output: Option[Path], skipVerification: Boolean): Boolean
 }

--- a/src/viper/viper/api/backend/SilverBackend.scala
+++ b/src/viper/viper/api/backend/SilverBackend.scala
@@ -56,7 +56,7 @@ trait SilverBackend extends Backend with LazyLogging {
   private def path(node: silver.Node): Seq[AccountedDirection] =
     info(node.asInstanceOf[silver.Infoed]).predicatePath.get
 
-  override def submit(colProgram: col.Program[_], output: Option[Path]): Boolean = {
+  override def submit(colProgram: col.Program[_], output: Option[Path], skipVerification: Boolean): Boolean = {
     val (silverProgram, nodeFromUniqueId) = ColToSilver.transform(colProgram)
 
     val silverProgramString =
@@ -96,6 +96,8 @@ trait SilverBackend extends Backend with LazyLogging {
             }
         }
     }
+    // Early out of verification
+    if(skipVerification) return true
 
     val (verifier, plugins) = createVerifier(NopViperReporter, nodeFromUniqueId)
 

--- a/src/viper/viper/api/backend/carbon/Carbon.scala
+++ b/src/viper/viper/api/backend/carbon/Carbon.scala
@@ -18,7 +18,7 @@ case class Carbon(
   proverLogFile: Option[Path] = None,
   options: Seq[String] = Nil,
 ) extends SilverBackend {
-  override def submit(colProgram: Program[_], output: Option[Path]): Boolean = synchronized { super.submit(colProgram, output) }
+  override def submit(colProgram: Program[_], output: Option[Path], skipVerification: Boolean): Boolean = synchronized { super.submit(colProgram, output, skipVerification) }
 
   override def createVerifier(reporter: Reporter, nodeFromUniqueId: Map[Int, col.Node[_]]): (viper.carbon.CarbonVerifier, SilverPluginManager) = {
     val carbon = viper.carbon.CarbonVerifier(reporter)

--- a/src/viper/viper/api/backend/silicon/Silicon.scala
+++ b/src/viper/viper/api/backend/silicon/Silicon.scala
@@ -49,6 +49,7 @@ case class Silicon(
   traceBranchConditions: Boolean = false,
   branchConditionReportInterval: Option[Int] = Some(1000),
   timeoutValue: Int = 30,
+  totalTimeOut: Int = 0,
   options: Seq[String] = Nil,
 ) extends SilverBackend {
 
@@ -87,6 +88,7 @@ case class Silicon(
 
     var siliconConfig = Seq(
       "--assertTimeout", (timeoutValue*1000).toString,
+      "--timeout", totalTimeOut.toString,
       "--z3Exe", z3Path.toString,
       "--z3ConfigArgs", z3Config,
       "--ideModeAdvanced",

--- a/test/viper/viper/api/VerifySpec.scala
+++ b/test/viper/viper/api/VerifySpec.scala
@@ -25,7 +25,7 @@ abstract class VerifySpec(backend: Backend) extends AnyFlatSpec {
 
   def program(program: => Program[G]): Unit = {
     _registry = Some(new ExpectedErrorsRegistry())
-    backend.submit(program, None)
+    backend.submit(program, None, false)
     _registry.get.check()
     _registry = None
   }


### PR DESCRIPTION
Makes sure that the option `--skip-backend` is actually used. (Thus fixes https://github.com/utwente-fmt/vercors/issues/1152).

Additionally adds the option `dev-total-timeout`. This adds a timeout towards only the verification part of the back-end, which kills the process via Silver after a timeout. I found this useful, since with this timeout, back-end processes always get killed correctly.  In contracts, sometimes if I killed VerCors with the bash program `timeout` and some Z3 programs kept running in the background.