### PR TITLE
Some fixes for GPUs shared memory

### DIFF
--- a/examples/concepts/gpgpu/cuda_blur.cu
+++ b/examples/concepts/gpgpu/cuda_blur.cu
@@ -1,0 +1,59 @@
+//:: cases SharedCuda
+//:: tool silicon
+//:: verdict Pass
+
+#include <cuda.h>
+
+/*@
+  context blockDim.x == 32 && blockDim.y == 1 && blockDim.z == 1;
+  context gridDim.x > 0 && gridDim.y == 1 && gridDim.z == 1;
+  context in != NULL && out != NULL;
+  context \pointer_length(in) == n;
+  context \pointer_length(out) == n-2;
+  context blockDim.x * gridDim.x >= n;
+  context (\forall* int i; 0<=i && i<n; Perm(&in[i], write \ (blockDim.x * gridDim.x)));
+
+  context \gtid<n-2 ==> Perm(&out[\gtid], write);
+
+  context \shared_mem_size(s) == blockDim.x+2;
+  requires Perm(&s[\ltid], write);
+  requires threadIdx.x < 2 ==> Perm(&s[\ltid + blockDim.x], write);
+
+  ensures \gtid<n-2 ==>out[\gtid] == (in[\gtid] + in[\gtid+1] + in[\gtid+2])/3;
+  
+@*/
+__global__ void blur_x(int* in, int* out, int n) {
+  extern __shared__ int s[];
+  int tid = blockIdx.x * blockDim.x + threadIdx.x;
+  if(tid < n) {
+    s[threadIdx.x] = in[tid];
+  }
+  if(threadIdx.x < 2 && tid+blockDim.x < n){
+    s[blockDim.x+threadIdx.x] = in[tid+blockDim.x];
+  }
+
+  /*@
+    context (\forall* int i; 0<=i && i<n; Perm(&in[i], write \ (blockDim.x * gridDim.x)));
+    context blockIdx.x * blockDim.x + threadIdx.x<n-2 ==> Perm(&out[blockIdx.x * blockDim.x + threadIdx.x], write);
+
+    requires Perm(&s[threadIdx.x], write);
+    requires threadIdx.x < 2 ==> Perm(&s[threadIdx.x + blockDim.x], write);
+
+    requires blockIdx.x * blockDim.x + threadIdx.x < n
+      ==> s[threadIdx.x] == in[blockIdx.x * blockDim.x + threadIdx.x];
+    requires threadIdx.x < 2 && blockIdx.x * blockDim.x + threadIdx.x+blockDim.x < n
+      ==> s[threadIdx.x+blockDim.x] == in[blockIdx.x * blockDim.x + threadIdx.x+blockDim.x];
+
+
+    ensures (\forall* int i; 0 <= i && i < blockDim.x+2; Perm(&s[i], write \ (blockDim.x+2)));
+
+    ensures 
+      (\forall int i; 0 <= i && i < blockDim.x+2 && blockIdx.x*blockDim.x + i <n
+        ==> s[i] == in[blockIdx.x * blockDim.x+i]);
+  @*/
+  __syncthreads();
+
+  if(tid < n-2) {
+    out[tid] = (s[threadIdx.x] + s[threadIdx.x+1] + s[threadIdx.x+2])/3;
+  }
+}

--- a/examples/concepts/gpgpu/dynamic_shared_cuda.cu
+++ b/examples/concepts/gpgpu/dynamic_shared_cuda.cu
@@ -1,4 +1,4 @@
-//:: cases StaticSharedCuda
+//:: cases DynamicSharedCuda
 //:: tool silicon
 //:: verdict Pass
 
@@ -16,12 +16,13 @@
   context Perm(&in[0], write \ (blockDim.x * gridDim.x));
   context \gtid<n ==> Perm(&out[\gtid], write);
 
+  context \shared_mem_size(s) == 1;
   requires \ltid == 0 ==> Perm(&s[0], write);
 
   ensures \gtid<n ==> out[\gtid] == \old(out[\gtid]) + in[0];
 @*/
 __global__ void blur_x(int* in, int* out, int n) {
-  __shared__ int s[1];
+  extern __shared__ int s[];
   int tid = blockIdx.x * blockDim.x + threadIdx.x;
   if(threadIdx.x == 0) {
     s[threadIdx.x] = in[0];

--- a/examples/concepts/gpgpu/dynamic_shared_opencl.cl
+++ b/examples/concepts/gpgpu/dynamic_shared_opencl.cl
@@ -1,4 +1,4 @@
-//:: cases StaticSharedOpenCl
+//:: cases DynamicSharedOpenCl
 //:: tool silicon
 //:: verdict Pass
 
@@ -16,12 +16,12 @@
   context Perm(&in[0], write \ (get_local_size(0) * get_num_groups(0)));
   context \gtid<n ==> Perm(&out[\gtid], write);
 
+  context \shared_mem_size(s) == 1;
   requires \ltid == 0 ==> Perm(&s[0], write);
 
   ensures \gtid<n ==> out[\gtid] == \old(out[\gtid]) + in[0];
 @*/
-__kernel void blur_x(global int* in, global int* out, int n) {
-  local int s[1];
+__kernel void blur_x(global int* in, global int* out, int n, local int* s) {
   int tid = get_group_id(0) * get_local_size(0) + get_local_id(0);
   if(get_local_id(0) == 0) {
     s[get_local_id(0)] = in[0];
@@ -39,7 +39,7 @@ __kernel void blur_x(global int* in, global int* out, int n) {
 
     ensures s[0] == in[0];
   @*/
-  barrier(CLK_LOCAL_MEM_FENCE);
+  barrier(CLK_GLOBAL_MEM_FENCE | CLK_LOCAL_MEM_FENCE);
 
   if(tid < n) {
     out[tid] += s[0];

--- a/examples/concepts/gpgpu/global_fence_opencl.cl
+++ b/examples/concepts/gpgpu/global_fence_opencl.cl
@@ -1,0 +1,47 @@
+//:: cases DynamicSharedOpenCl
+//:: tool silicon
+//:: verdict Pass
+
+#include <opencl.h>
+
+/*@
+  context get_local_size(0) == 32 && get_local_size(1) == 1 && get_local_size(2) == 1;
+  context get_num_groups(0) == 4 && get_num_groups(1) == 1 && get_num_groups(2) == 1;
+
+  context in != NULL && out != NULL;
+  context \pointer_length(in) == 1;
+  context \pointer_length(out) == n;
+  context n > 0;
+  context get_local_size(0) * get_num_groups(0) >= n;
+  context Perm(&in[0], write \ (get_local_size(0) * get_num_groups(0)));
+  context \gtid<n ==> Perm(&out[\gtid], write);
+
+  context s != NULL && \pointer_length(s) == get_num_groups(0);
+  requires \ltid == 0 ==> Perm(&s[get_group_id(0)], write);
+
+  ensures \gtid<n ==> out[\gtid] == \old(out[\gtid]) + in[0];
+@*/
+__kernel void blur_x(global int* in, global int* out, int n, global int* s) {
+  int tid = get_group_id(0) * get_local_size(0) + get_local_id(0);
+  if(get_local_id(0) == 0) {
+    s[get_group_id(0)] = in[0];
+  }
+
+  /*@
+    context Perm(&in[0], write \ (get_local_size(0) * get_num_groups(0)));
+    context get_group_id(0) * get_local_size(0) + get_local_id(0)<n ==> Perm(&out[get_group_id(0) * get_local_size(0) + get_local_id(0)], write);
+    context get_group_id(0) * get_local_size(0) + get_local_id(0)<n ==> \old(out[get_group_id(0) * get_local_size(0) + get_local_id(0)]) == out[get_group_id(0) * get_local_size(0) + get_local_id(0)];
+
+    requires get_local_id(0) == 0 ==> Perm(&s[get_group_id(0)], write);
+    requires get_local_id(0) == 0 ==> s[get_group_id(0)] == in[0];
+
+    ensures Perm(&s[get_group_id(0)], write \ get_local_size(0));
+
+    ensures s[get_group_id(0)] == in[0];
+  @*/
+  barrier(CLK_GLOBAL_MEM_FENCE);
+
+  if(tid < n) {
+    out[tid] += s[get_group_id(0)];
+  }
+}

--- a/examples/concepts/gpgpu/static_shared_cuda.cu
+++ b/examples/concepts/gpgpu/static_shared_cuda.cu
@@ -1,0 +1,47 @@
+//:: cases StaticSharedCuda
+//:: tool silicon
+//:: verdict Pass
+
+#include <cuda.h>
+
+/*@
+  context blockDim.x > 1 && blockDim.y == 1 && blockDim.z == 1;
+  context gridDim.x > 0 && gridDim.y == 1 && gridDim.z == 1;
+
+  context in != NULL && out != NULL;
+  context \pointer_length(in) == 1;
+  context \pointer_length(out) == n;
+  context n > 0;
+  context blockDim.x * gridDim.x >= n;
+  context Perm(&in[0], write \ (blockDim.x * gridDim.x));
+  context \gtid<n ==> Perm(&out[\gtid], write);
+
+  requires \ltid == 0 ==> Perm(&s[0], write);
+
+  ensures \gtid<n ==> out[\gtid] == \old(out[\gtid]) + in[0];
+@*/
+__global__ void blur_x(int* in, int* out, int n) {
+  __shared__ int s[1];
+  int tid = blockIdx.x * blockDim.x + threadIdx.x;
+  if(threadIdx.x == 0) {
+    s[threadIdx.x] = in[0];
+  }
+
+  /*@
+    context Perm(&in[0], write \ (blockDim.x * gridDim.x));
+    context tid<n ==> Perm(&out[tid], write);
+    context tid<n ==> \old(out[tid]) == out[tid];
+
+    requires threadIdx.x == 0 ==> Perm(&s[0], write);
+    requires threadIdx.x == 0 ==> s[0] == in[0];
+
+    ensures Perm(&s[0], write \ blockDim.x);
+
+    ensures s[0] == in[0];
+  @*/
+  __syncthreads();
+
+  if(tid < n) {
+    out[tid] += s[0];
+  }
+}

--- a/examples/concepts/gpgpu/static_shared_opencl.cl
+++ b/examples/concepts/gpgpu/static_shared_opencl.cl
@@ -1,0 +1,47 @@
+//:: cases StaticSharedCuda
+//:: tool silicon
+//:: verdict Pass
+
+#include <opencl.h>
+
+/*@
+  context get_local_size(0) > 1 && get_local_size(1) == 1 && get_local_size(2) == 1;
+  context get_num_groups(0) > 0 && get_num_groups(1) == 1 && get_num_groups(2) == 1;
+
+  context in != NULL && out != NULL;
+  context \pointer_length(in) == 1;
+  context \pointer_length(out) == n;
+  context n > 0;
+  context get_local_size(0) * get_num_groups(0) >= n;
+  context Perm(&in[0], write \ (get_local_size(0) * get_num_groups(0)));
+  context \gtid<n ==> Perm(&out[\gtid], write);
+
+  requires \ltid == 0 ==> Perm(&s[0], write);
+
+  ensures \gtid<n ==> out[\gtid] == \old(out[\gtid]) + in[0];
+@*/
+__kernel void blur_x(global int* in, global int* out, int n) {
+  local int s[1];
+  int tid = get_group_id(0) * get_local_size(0) + get_local_id(0);
+  if(get_local_id(0) == 0) {
+    s[get_local_id(0)] = in[0];
+  }
+
+  /*@
+    context Perm(&in[0], write \ (get_local_size(0) * get_num_groups(0)));
+    context tid<n ==> Perm(&out[tid], write);
+    context tid<n ==> \old(out[tid]) == out[tid];
+
+    requires get_local_id(0) == 0 ==> Perm(&s[0], write);
+    requires get_local_id(0) == 0 ==> s[0] == in[0];
+
+    ensures Perm(&s[0], write \ get_local_size(0));
+
+    ensures s[0] == in[0];
+  @*/
+  barrier(CLK_LOCAL_MEM_FENCE);
+
+  if(tid < n) {
+    out[tid] += s[0];
+  }
+}

--- a/examples/concepts/summation/TestCountFail.java
+++ b/examples/concepts/summation/TestCountFail.java
@@ -5,11 +5,11 @@
 class TestCount {
   public void test_count_E1(){
     //@ ghost seq<int> xs = seq<int>{ 1, 2 , 2 , 1 };
-    //@ assert \sum({ 0 .. 0 },\vcmp(xs,\vrep(1))) == 0;
-    //@ assert \sum({ 0 .. 1 },\vcmp(xs,\vrep(1))) == 1;
-    //@ assert \sum({ 0 .. 2 },\vcmp(xs,\vrep(1))) == 1;
-    //@ assert \sum({ 0 .. 3 },\vcmp(xs,\vrep(1))) == 1;
-    //@ assert \sum({ 0 .. 4 },\vcmp(xs,\vrep(1))) == 1;
+    //@ assert \sum([ 0 .. 0 ],\vcmp(xs,\vrep(1))) == 0;
+    //@ assert \sum([ 0 .. 1 ],\vcmp(xs,\vrep(1))) == 1;
+    //@ assert \sum([ 0 .. 2 ],\vcmp(xs,\vrep(1))) == 1;
+    //@ assert \sum([ 0 .. 3 ],\vcmp(xs,\vrep(1))) == 1;
+    //@ assert \sum([ 0 .. 4 ],\vcmp(xs,\vrep(1))) == 1;
   }
 }
 

--- a/examples/concepts/summation/TestCountPass.java
+++ b/examples/concepts/summation/TestCountPass.java
@@ -11,13 +11,13 @@ class TestCount {
       ** (vals.size==array.length)
       ** (\forall int i ; 0 <= i && i < array.length ; array[i]== vals[i])
       ;
-    ensures \result == \sum({0 .. array.length},\vcmp(vals,\vrep(3)));
+    ensures \result == \sum([0 .. array.length],\vcmp(vals,\vrep(3)));
   @*/
   public int test_count_1(int array[]){
     int res=0;
     int k=0;
     //@ loop_invariant 0 <= k && k <= array.length;
-    //@ loop_invariant res == \sum({0 .. k},\vcmp(vals,\vrep(3)));
+    //@ loop_invariant res == \sum([0 .. k],\vcmp(vals,\vrep(3)));
     while(k<array.length){
       if (array[k]==3){
         res = res + 1;
@@ -29,11 +29,11 @@ class TestCount {
 
   public void test_count_2(){
     //@ ghost seq<int> xs = seq<int>{ 1, 2 , 2 , 3 };
-    //@ assert \sum({ 0 .. 0 },\vcmp(xs,\vrep(1))) == 0;
-    //@ assert \sum({ 0 .. 1 },\vcmp(xs,\vrep(1))) == 1;
-    //@ assert \sum({ 0 .. 2 },\vcmp(xs,\vrep(1))) == 1;
-    //@ assert \sum({ 0 .. 3 },\vcmp(xs,\vrep(1))) == 1;
-    //@ assert \sum({ 0 .. 4 },\vcmp(xs,\vrep(1))) == 1;
+    //@ assert \sum([ 0 .. 0 ],\vcmp(xs,\vrep(1))) == 0;
+    //@ assert \sum([ 0 .. 1 ],\vcmp(xs,\vrep(1))) == 1;
+    //@ assert \sum([ 0 .. 2 ],\vcmp(xs,\vrep(1))) == 1;
+    //@ assert \sum([ 0 .. 3 ],\vcmp(xs,\vrep(1))) == 1;
+    //@ assert \sum([ 0 .. 4 ],\vcmp(xs,\vrep(1))) == 1;
   }
   
 }

--- a/examples/concepts/summation/TestFloat.java
+++ b/examples/concepts/summation/TestFloat.java
@@ -18,14 +18,14 @@ class TestFloat {
     /*@
       ghost seq<float> s=seq<float>{};
       
-      assert \sum({0 .. 0},s)==((float)0);
+      assert \sum([0 .. 0],s)==((float)0);
 
       ghost seq<seq<float>> M=seq<seq<float>>{seq<float>{(float)1}};
       
-      assert \sum({0 .. 0}, M[0] ) == ((float)0);
-      assert \sum({0 .. 1}, M[0] ) == ((float)1);
-      assert \msum({0 .. 0} * {0 .. 1},M) == ((float)0);
-      assert \msum({0 .. 1} * {0 .. 1},M) == ((float)1);
+      assert \sum([0 .. 0], M[0] ) == ((float)0);
+      assert \sum([0 .. 1], M[0] ) == ((float)1);
+      assert \msum([0 .. 0] * [0 .. 1],M) == ((float)0);
+      assert \msum([0 .. 1] * [0 .. 1],M) == ((float)1);
     */
   }
 
@@ -33,13 +33,13 @@ class TestFloat {
     given seq<float> vals;
     context_everywhere a!=null ** (a.length == |vals|);
     context_everywhere (\forall* int i; 0 <= i && i < a.length;PointsTo(a[i],1\2,vals[i]));
-    ensures \result == \sum({0 .. a.length},vals);
+    ensures \result == \sum([0 .. a.length],vals);
   @*/
   public float add(float a[]){
     int k=0;
     float res=(float)0;
     //@ loop_invariant 0 <= k && k <= a.length;
-    //@ loop_invariant \sum(({0 ..k}),vals) == res;
+    //@ loop_invariant \sum(([0 ..k]),vals) == res;
     while(k<a.length){
       res=res+a[k];
       k=k+1;
@@ -53,14 +53,14 @@ class TestFloat {
     context_everywhere b!=null ** (a.length == b.length);
     context_everywhere (\forall* int i; 0 <= i && i < a.length;PointsTo(a[i],1\2,vals[i]));
     context_everywhere (\forall* int i; 0 <= i && i < a.length;Perm(b[i],1));
-    ensures (\forall int i ; 0 <= i && i < b.length ; b[i] == \sum({0 ..i},vals));
+    ensures (\forall int i ; 0 <= i && i < b.length ; b[i] == \sum([0 ..i],vals));
   @*/
   public void prefixsum(float a[],float b[]){
     int k=0;
     float res=(float)0;
     //@ loop_invariant 0 <= k && k <= a.length;
-    //@ loop_invariant \sum({0 ..k},vals) == res;
-    //@ loop_invariant (\forall int i ; 0 <= i && i < k ; b[i] == \sum({0 ..i},vals));
+    //@ loop_invariant \sum([0 ..k],vals) == res;
+    //@ loop_invariant (\forall int i ; 0 <= i && i < k ; b[i] == \sum([0 ..i],vals));
     while(k<a.length){
       b[k]=res;
       res=res+a[k];
@@ -74,14 +74,14 @@ class TestFloat {
     context_everywhere b!=null ** (a.length == b.length);
     context_everywhere (\forall* int i; 0 <= i && i < a.length;PointsTo(a[i],1\2,vals[i]));
     context_everywhere (\forall* int i; 0 <= i && i < a.length;Perm(b[i],1));
-    ensures (\forall int i ; 0 <= i && i < b.length ; b[i] == \sum({0 ..i},vals));
+    ensures (\forall int i ; 0 <= i && i < b.length ; b[i] == \sum([0 ..i],vals));
   @*/
   public void prefixisum(int a[],int b[]){
     int k=0;
     int res=0;
     //@ loop_invariant 0 <= k && k <= a.length;
-    //@ loop_invariant \sum({0 ..k},vals) == res;
-    //@ loop_invariant (\forall int i ; 0 <= i && i < k ; b[i] == \sum({0 ..i},vals));
+    //@ loop_invariant \sum([0 ..k],vals) == res;
+    //@ loop_invariant (\forall int i ; 0 <= i && i < k ; b[i] == \sum([0 ..i],vals));
     while(k<a.length){
       b[k]=res;
       res=res+a[k];

--- a/examples/concepts/summation/TestHist.java
+++ b/examples/concepts/summation/TestHist.java
@@ -13,13 +13,13 @@ class Testhist {
     context_everywhere (\forall int i; 0 <= i && i < a.length ; 0 <= a[i] && a[i] < hist.length);
     context_everywhere (\forall int i; 0 <= i && i < a.length ; a[i] == vals[i] );
     ensures   (\forall int i; 0 <= i && i < hist.length ;
-                 hist[i]==\sum({0 .. a.length},\vcmp(vals,\vrep(i))));
+                 hist[i]==\sum([0 .. a.length],\vcmp(vals,\vrep(i))));
   @*/
   public void histogram(int a[],int hist[]){
     int k=0;
     //@ loop_invariant 0 <= k && k <= hist.length;
     /*@ loop_invariant (\forall int i; 0 <= i && i < k ;
-         hist[i]==\sum({0 .. 0},\vcmp(vals,\vrep(i))) );
+         hist[i]==\sum([0 .. 0],\vcmp(vals,\vrep(i))) );
      */
     while(k<hist.length){
       hist[k]=0;
@@ -28,7 +28,7 @@ class Testhist {
     k=0;
     //@ loop_invariant 0 <= k && k <= a.length;
     /*@ loop_invariant (\forall int i; 0 <= i && i < hist.length ;
-                          hist[i]==\sum({0 .. k},\vcmp(vals,\vrep(i)))  ); @*/
+                          hist[i]==\sum([0 .. k],\vcmp(vals,\vrep(i)))  ); @*/
     while(k<a.length){
       int v=a[k];
       hist[v]++;

--- a/res/universal/res/adt/range.pvl
+++ b/res/universal/res/adt/range.pvl
@@ -4,5 +4,5 @@ pure set<int> set_range(int l, int r);
 
 ensures (\forall int i; {:i \in \result:} == (l >= i && i < r));
 ensures l <= r ? \result.size == r - l : \result.size == 0;
-ensures (\forall int i=l..r; {:\result[i]:} == l + i);
+ensures (\forall int i=0..(r-l); {:\result[i]:} == l + i);
 pure seq<int> seq_range(int l, int r);

--- a/src/rewrite/vct/rewrite/ParBlockEncoder.scala
+++ b/src/rewrite/vct/rewrite/ParBlockEncoder.scala
@@ -168,95 +168,6 @@ case class ParBlockEncoder[Pre <: Generation]() extends Rewriter[Pre] {
     case _ => false
   }
 
-  def constantExpression[A](e: Expr[A], nonConstVars: Set[Variable[A]]): Boolean = e match {
-    case _: Constant[_] => true
-    case op: BinExpr[_] => constantExpression(op.left, nonConstVars) && constantExpression(op.right, nonConstVars)
-    case l@Local(v) if isConstType(l.t) => true
-    case Local(v) => !nonConstVars.contains(v.decl)
-    case _ => false
-  }
-
-  def applyFunc[A, B](f: A => Option[Set[B]], xs: Iterable[A]): Option[Set[B]] =
-    xs.foldLeft(Some(Set()): Option[Set[B]]) { case (res, x) => res.flatMap(r => f(x).map(s => r ++ s)) }
-
-  def combine[A](xs: Option[Set[A]], ys: Option[Set[A]]): Option[Set[A]] =
-    xs.flatMap(xs => ys.map(ys => xs ++ ys))
-
-  def scanIter(xs: Iterable[Statement[Pre]]): Option[Set[Variable[Pre]]] =
-    applyFunc(scanForAssign, xs)
-
-  def scanIterE(xs: Iterable[Expr[Pre]]): Option[Set[Variable[Pre]]] =
-    applyFunc(scanForAssignE, xs)
-
-  /* Scans statements and returns a set of variables, which will change value. Meaning other variables, did not change value.
-  * The analysis is conservative, if we are not sure, we return None, meaning we are not sure about any variable if it
-  * is potentially constant
-   */
-  def scanForAssign(s: Statement[Pre]): Option[Set[Variable[Pre]]] = s match {
-    case Block(statements) => scanIter(statements)
-    case Scope(_, statement) => scanForAssign(statement)
-    case Branch(branches) =>
-      for {
-        set1 <- scanIter(branches.map(_._2))
-        set2 <- scanIterE(branches.map(_._1))
-      } yield set1 ++ set2
-    case IndetBranch(statements) => scanIter(statements)
-    case Switch(expr, body) => combine(scanForAssignE(expr), scanForAssign(body))
-    case Loop(init, cond, update, _, body) =>
-      scanForAssign(init).flatMap(r1 => scanForAssignE(cond).flatMap(r2 => scanForAssign(update)
-        .flatMap(r3 => scanForAssign(body).map(r4 => r1 ++ r2 ++ r3 ++ r4))))
-    case Assign(target, value) => combine(scanAssignTarget(target), scanForAssignE(value))
-    case ParStatement(par) => scanForAssignP(par)
-    case ParBarrier(_, _, _, _, content) => scanForAssign(content)
-    case Eval(e) => scanForAssignE(e)
-    case _ => None
-  }
-
-  def scanForAssignP(par: ParRegion[Pre]): Option[Set[Variable[Pre]]] = par match {
-    case ParParallel(pars) => applyFunc(scanForAssignP, pars)
-    case ParSequential(pars) => applyFunc(scanForAssignP, pars)
-    case ParBlock(_, _, _, _, _, content) => scanForAssign(content)
-  }
-
-  def scanForAssignE(e: Expr[Pre]): Option[Set[Variable[Pre]]] = e match {
-    case _: Constant[Pre] => Some(Set())
-    case Local(_) => Some(Set())
-    case op: BinExpr[Pre] => combine(scanForAssignE(op.left), scanForAssignE(op.right))
-    case ProcedureInvocation(_, args, outArgs, _, givenMap, yields) =>
-      // Primitive types cannot be changed due to a function call, so we filter them
-      // Other arguments can possibly be changed, so we collect them
-      applyFunc(scanAssignTarget, args.filterNot(e => isPrimitive(e.t)))
-        .flatMap(r1 => scanIterE(givenMap.map(_._2))
-          .flatMap(r2 => scanIterE(outArgs)
-            .flatMap(r3 => scanIterE(yields.map(_._1))
-              .map(r4 => r1 ++ r2 ++ r3 ++ r4))))
-    case FunctionInvocation(_, args, _, givenMap, yields) =>
-      applyFunc(scanAssignTarget, args.filterNot(e => isPrimitive(e.t)))
-        .flatMap(r1 => scanIterE(givenMap.map(_._2))
-          .flatMap(r2 => scanIterE(yields.map(_._1))
-            .map(r3 => r1 ++ r2 ++ r3)))
-    case PreAssignExpression(target, value) => combine(scanAssignTarget(target), scanForAssignE(value))
-    case PointerSubscript(pointer, index) => combine(scanForAssignE(pointer), scanForAssignE(index))
-    case ArraySubscript(pointer, index) => combine(scanForAssignE(pointer), scanForAssignE(index))
-    case SeqSubscript(seq, index) => combine(scanForAssignE(seq), scanForAssignE(index))
-    case _ => None
-  }
-
-  def scanAssignTarget(e: Expr[Pre]): Option[Set[Variable[Pre]]] = e match {
-    case Local(v) => Some(Set(v.decl))
-    case ArraySubscript(arr, index) => combine(scanAssignTarget(arr), scanForAssignE(index))
-    case PointerSubscript(pointer, index) => combine(scanAssignTarget(pointer), scanForAssignE(index))
-    case SeqSubscript(seq, index) => combine(scanAssignTarget(seq), scanForAssignE(index))
-    case _ => None
-  }
-
-  def isPrimitive(t: Type[_]): Boolean = t match {
-    case _: PrimitiveType[_] => true
-    case _ => false
-  }
-
-  case class NonConstantVariables(vars: Set[Variable[Pre]])
-
   def isConstant(e: Expr[Post]): Boolean = e match {
     case _ : Constant[Post] => true
     case l: Local[_] if isConstType(l.t) => true
@@ -275,23 +186,15 @@ case class ParBlockEncoder[Pre <: Generation]() extends Rewriter[Pre] {
         implicit val o: Origin = v.o
         val from = dispatch(v.from)
         val to = dispatch(v.to)
-        val nonConstVars = scanForAssign(block.content)
-        if (nonConstVars.nonEmpty && constantExpression(v.from, nonConstVars.get) && constantExpression(v.to, nonConstVars.get)) {
-          rangeValues(v.variable) = (from, to)
-          res
-        } else {
-          val lo = variables.declare(new Variable[Post](TInt())(LowEvalOrigin(v)))
-          val hi = variables.declare(new Variable[Post](TInt())(HighEvalOrigin(v)))
-          val from = dispatch(v.from)
-          val to = dispatch(v.to)
-          val low = if(isConstant(from)) from else lo.get
-          val high = if(isConstant(to)) to else hi.get
-          rangeValues(v.variable) = (low, high)
-          res ++ Seq(
-            assignLocal(lo.get, from),
-            assignLocal(hi.get, to),
-          )
-        }
+        val lo = variables.declare(new Variable[Post](TInt())(LowEvalOrigin(v)))
+        val hi = variables.declare(new Variable[Post](TInt())(HighEvalOrigin(v)))
+        val low = if(isConstant(from)) from else lo.get
+        val high = if(isConstant(to)) to else hi.get
+        rangeValues(v.variable) = (low, high)
+        res ++ Seq(
+          assignLocal(lo.get, from),
+          assignLocal(hi.get, to),
+        )
       })(region.o)
   }
 

--- a/src/rewrite/vct/rewrite/ResolveScale.scala
+++ b/src/rewrite/vct/rewrite/ResolveScale.scala
@@ -37,14 +37,16 @@ case class ResolveScale[Pre <: Generation]() extends Rewriter[Pre] {
 
     val v = new Variable[Post](TRational())(CheckScale("amount"))
 
-    globalDeclarations.declare(function[Post](
+    globalDeclarations.declare(withResult((result: Result[Post]) => {
+      function[Post](
       blame = PanicBlame("scale ensures nothing"),
       contractBlame = PanicBlame("scale only requires a positive rational"),
       args = Seq(v),
       returnType = TRational(),
       body = Some(v.get),
       requires = UnitAccountedPredicate(v.get >= const(0)),
-    )(CheckScale("scale")))
+      ensures = UnitAccountedPredicate(result >= const(0)),
+    )(CheckScale("scale"))}))
   }
 
   def scaleValue(e: Scale[Pre]): Expr[Post] =

--- a/src/rewrite/vct/rewrite/lang/LangCToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangCToCol.scala
@@ -458,8 +458,10 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre]) extends Laz
     case _ => throw Unreachable("Already checked on pointer or array type")
   }
 
-  def declareSharedMemory(): (Seq[Variable[Post]], Seq[Statement[Post]]) = rw.variables.collect {
-    var result: Seq[Statement[Post]] = Seq()
+  def declareSharedMemory(): (Seq[Variable[Post]], (Seq[Variable[Post]], Seq[Statement[Post]])) =
+    rw.variables.collect {
+    var declarations: Seq[Variable[Post]] = Seq()
+    var inits: Seq[Statement[Post]] = Seq()
     dynamicSharedMemNames.foreach(d =>
     {
       implicit val o: Origin = getCDecl(d).o
@@ -467,21 +469,23 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre]) extends Laz
       val v = new Variable[Post](TCInt())(varO)
       dynamicSharedMemLengthVar(d) = v
       rw.variables.declare(v)
-      val decl: Statement[Post] = LocalDecl(cNameSuccessor(d))
+//      val decl: Statement[Post] = LocalDecl(cNameSuccessor(d))
       val assign: Statement[Post] = assignLocal(Local(cNameSuccessor(d).ref),
         NewPointerArray[Post](getInnerType(cNameSuccessor(d).t), Local(v.ref))(PanicBlame("Shared memory sizes cannot be negative.")))
-      result ++= Seq(decl, assign)
+      declarations ++= Seq(cNameSuccessor(d))
+      inits ++= Seq(assign)
     })
     staticSharedMemNames.foreach{case (d,(size, blame)) =>
     implicit val o: Origin = getCDecl(d).o
-      val decl: Statement[Post] = LocalDecl(cNameSuccessor(d))
+//      val decl: Statement[Post] = LocalDecl(cNameSuccessor(d))
       val assign: Statement[Post] = assignLocal(Local(cNameSuccessor(d).ref),
         // Since we set the size and blame together, we can assume the blame is not None
         NewPointerArray[Post](getInnerType(cNameSuccessor(d).t), CIntegerValue(size))(blame.get))
-      result ++= Seq(decl, assign)
+      declarations ++= Seq(cNameSuccessor(d))
+      inits ++= Seq(assign)
     }
 
-    result
+    (declarations, inits)
   }
 
   def kernelProcedure(o: Origin, contract: ApplicableContract[Pre], info: C.DeclaratorInfo[Pre], body: Option[Statement[Pre]]
@@ -495,10 +499,11 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre]) extends Laz
     cudaCurrentBlockDim.having(blockDim) {
       cudaCurrentGridDim.having(gridDim) {
         val args = rw.variables.collect { info.params.get.foreach(rw.dispatch) }._1
+        val implFiltered = body.map(init => filterSharedDecl(init))
+
         rw.variables.collect { dynamicSharedMemNames.foreach(d => rw.variables.declare(cNameSuccessor(d)) ) }
         rw.variables.collect { staticSharedMemNames.foreach(d => rw.variables.declare(cNameSuccessor(d._1)) ) }
-        val implFiltered = body.map(init => filterSharedDecl(init))
-        val (sharedMemSizes, sharedMemInit: Seq[Statement[Post]]) = declareSharedMemory()
+        val (sharedMemSizes, (sharedMemDecls: Seq[Variable[Post]], sharedMemInits: Seq[Statement[Post]])) = declareSharedMemory()
 
         val newArgs = blockDim.indices.values.toSeq ++ gridDim.indices.values.toSeq ++ args ++ sharedMemSizes
         val newGivenArgs = rw.variables.dispatch(contract.givenArgs)
@@ -557,7 +562,7 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre]) extends Laz
                             .map(allThreadsInBlock(KernelNotInjective(kernelSpec)))) )
                       ),
                     // Add shared memory initialization before beginning of inner parallel block
-                    content = Block[Post](sharedMemInit ++ Seq(innerContent))
+                    content =  Scope[Post](sharedMemDecls, Block[Post](sharedMemInits ++ Seq(innerContent)))
                   )(KernelParFailure(kernelSpec)))
                 }
               }
@@ -626,24 +631,25 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre]) extends Laz
 
   def addDynamicShared(cRef: CNameTarget[Pre], t: Type[Pre], o: Origin): Unit = {
     dynamicSharedMemNames.add(cRef)
-    val v = new Variable[Post](TArray[Post](rw.dispatch(t)))(o)
+    val v = new Variable[Post](TPointer[Post](rw.dispatch(t)))(o)
     cNameSuccessor(cRef) = v
   }
 
   def addStaticShared(decl:  CDeclarator[Pre], cRef: CNameTarget[Pre], t: Type[Pre], o: Origin,
                       declStatement: CLocalDeclaration[Pre], arraySize: Option[Expr[Pre]], sizeBlame: Option[Blame[ArraySizeError]]): Unit = arraySize match {
       case Some(CIntegerValue(size)) =>
-        val v = new Variable[Post](TArray[Post](rw.dispatch(t)))(o)
+        val v = new Variable[Post](TPointer[Post](rw.dispatch(t)))(o)
         staticSharedMemNames(cRef) = (size, sizeBlame)
         cNameSuccessor(cRef) = v
       case _ => throw WrongGPULocalType(declStatement)
   }
 
   def isShared(s: Statement[Pre]): Boolean = {
-    if(!s.isInstanceOf[CDeclarationStatement[Pre]])
-      return false
-
-    val CDeclarationStatement(decl) = s
+    val decl = s match {
+      case CDeclarationStatement(decl) => decl
+      case Block(Seq(s_inner)) => return isShared(s_inner)
+      case _ => return false
+    }
 
     if (decl.decl.inits.size != 1)
       throw MultipleSharedMemoryDeclaration(decl)
@@ -889,6 +895,7 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre]) extends Laz
     case PointerAdd(arr : CLocal[Pre], _) => Seq(arr.ref.get)
     case AmbiguousSubscript(arr : CLocal[Pre], _) => Seq(arr.ref.get)
     case AmbiguousPlus(l, r) if isPointer(l.t) && isNumeric(r.t) => searchNames(l, original)
+    case AddrOf(inner) => searchNames(inner, original)
     case _ => throw UnsupportedBarrierPermission(original)
   }
 
@@ -1177,14 +1184,18 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre]) extends Laz
     */
   def cudaGlobalThreadId(global: GlobalThreadId[Pre]): Expr[Post] = {
     implicit val o: Origin = global.o
-    Plus(
-      Plus(
-        Mult(
-          Mult(getCudaGroupThread(2, o), getCudaGroupSize(1, o)),   // (get_global_id(2) * get_global_size(1)
-          getCudaGroupSize(0, o)),                                         //   * get_global_size(0)
-        Mult(getCudaGroupThread(1, o), getCudaGroupSize(0, o))),    //   + get_global_id(1) * get_global_size(0)
-      getCudaGroupThread(0, o)                                             //   + get_global_id(0)
-    )
+    val res =
+      (getGlobalId(2)*getGlobalSize(1)*getGlobalSize(0)) +
+        getGlobalId(1)*getGlobalSize(0) + getGlobalId(0)
+    return res;
+  }
+
+  def getGlobalId(idx: Int)(implicit o: Origin): Expr[Post] = {
+    getCudaGroupThread(idx, o) * getCudaLocalSize(idx, o) + getCudaLocalThread(idx, o)
+  }
+
+  def getGlobalSize(idx: Int)(implicit o: Origin): Expr[Post] = {
+    getCudaLocalSize(idx, o)*getCudaGroupSize(idx, o)
   }
 
   def globalInvocation(e: RefCGlobalDeclaration[Pre], inv: CInvocation[Pre], rewrittenArgs: Seq[Expr[Post]]): Expr[Post] = {

--- a/test/main/vct/test/integration/examples/GpgpuSpec.scala
+++ b/test/main/vct/test/integration/examples/GpgpuSpec.scala
@@ -5,10 +5,13 @@ import vct.test.integration.helper.VercorsSpec
 class GpgpuSpec extends VercorsSpec {
   vercors should verify using silicon example "concepts/gpgpu/cuda.cu"
   vercors should verify using silicon example "concepts/gpgpu/cuda_blur.cu"
+
   vercors should verify using silicon example "concepts/gpgpu/dynamic_shared_cuda.cu"
   vercors should verify using silicon example "concepts/gpgpu/dynamic_shared_opencl.cl"
   vercors should verify using silicon example "concepts/gpgpu/static_shared_cuda.cu"
   vercors should verify using silicon example "concepts/gpgpu/static_shared_opencl.cl"
+
+  vercors should verify using silicon example "concepts/gpgpu/global_fence_opencl.cl"
   // https://github.com/utwente-fmt/vercors/issues/852
   // vercors should verify using silicon example "concepts/gpgpu/GPGPU-Example-updates.cu"
   // https://github.com/utwente-fmt/vercors/issues/856

--- a/test/main/vct/test/integration/examples/GpgpuSpec.scala
+++ b/test/main/vct/test/integration/examples/GpgpuSpec.scala
@@ -4,6 +4,8 @@ import vct.test.integration.helper.VercorsSpec
 
 class GpgpuSpec extends VercorsSpec {
   vercors should verify using silicon example "concepts/gpgpu/cuda.cu"
+  vercors should verify using silicon example "concepts/gpgpu/static_shared_cuda.cu"
+  vercors should verify using silicon example "concepts/gpgpu/static_shared_opencl.cl"
   // https://github.com/utwente-fmt/vercors/issues/852
   // vercors should verify using silicon example "concepts/gpgpu/GPGPU-Example-updates.cu"
   // https://github.com/utwente-fmt/vercors/issues/856

--- a/test/main/vct/test/integration/examples/GpgpuSpec.scala
+++ b/test/main/vct/test/integration/examples/GpgpuSpec.scala
@@ -4,6 +4,9 @@ import vct.test.integration.helper.VercorsSpec
 
 class GpgpuSpec extends VercorsSpec {
   vercors should verify using silicon example "concepts/gpgpu/cuda.cu"
+  vercors should verify using silicon example "concepts/gpgpu/cuda_blur.cu"
+  vercors should verify using silicon example "concepts/gpgpu/dynamic_shared_cuda.cu"
+  vercors should verify using silicon example "concepts/gpgpu/dynamic_shared_opencl.cl"
   vercors should verify using silicon example "concepts/gpgpu/static_shared_cuda.cu"
   vercors should verify using silicon example "concepts/gpgpu/static_shared_opencl.cl"
   // https://github.com/utwente-fmt/vercors/issues/852


### PR DESCRIPTION
Some fixes to let shared memory work as intended again.

Added 2 test cases for both opencl and cuda.

Also cleaned up par block encoder and just do what I describe in https://github.com/utwente-fmt/vercors/issues/1165

which works, since all the par blocks ranges from gpu's or other cases are just mostly using integer variables.

Also, \gtid was wrongly implemented. Fixed it here.

Planning to add some more examples, when they are working.
