### PR TITLE
Add AutoValue

### DIFF
--- a/examples/concepts/autovalue/copy.pvl
+++ b/examples/concepts/autovalue/copy.pvl
@@ -1,0 +1,35 @@
+class A {
+    int a;
+}
+
+context (\let A c = b; c != null ==> AutoValue(c.a));
+ensures Perm(\result.a, write);
+ensures b != null ==> \result.a == b.a;
+A makeCopy(A b) {
+    A c = new A();
+    if (b != null) {
+        c.a = b.a;
+    }
+    return c;
+}
+
+// In functions AutoValue gets automatically transformed into Value since
+// functions don't consume any permissions anyway and if we were to add a leak
+// check then we would have a postcondition which is not valid for functions
+// since it refers to permissions
+requires AutoValue(b.a);
+pure int extractA(A b) = b.a;
+
+void test() {
+    A b = new A();
+    b.a = 10;
+    A c = makeCopy(b);
+    // Successful copy
+    assert c.a == 10;
+    // b.a is unchanged
+    assert b.a == 10;
+    // Stil mutable
+    b.a = 5;
+    assert b.a == 5;
+
+}

--- a/examples/concepts/autovalue/leak.pvl
+++ b/examples/concepts/autovalue/leak.pvl
@@ -1,0 +1,49 @@
+class A {
+    int a;
+}
+
+/*[/expect autoValueLeak:perm]*/
+// Since this AutoValue only appears in the precondition a leak check is added
+// as a postcondition
+requires (\let A c = b; c != null ==> AutoValue(c.a));
+ensures Perm(\result.a, write);
+A makeLeakyCopyWithLeakCheck(A b) {
+    A c = new A();
+    if (b != null) {
+        c.a = b.a;
+    }
+    // Leak some of our read permission using the read wildcard
+    // Equivalent to Perm(c.a, read) and in Viper acc(c.a, wildcard)
+    exhale Value(b.a);
+
+    return c;
+}
+/*[/end]*/
+
+/*[/expect postFailed:perm]*/
+context (\let A c = b; c != null ==> AutoValue(c.a));
+ensures Perm(\result.a, write);
+A makeLeakyCopy(A b) {
+    A c = new A();
+    if (b != null) {
+        c.a = b.a;
+    }
+    // Leak some of our read permission using the read wildcard
+    // Equivalent to Perm(c.a, read) and in Viper acc(c.a, wildcard)
+    exhale Value(b.a);
+
+    return c;
+}
+/*[/end]*/
+
+void test() {
+    A b = new A();
+    b.a = 10;
+    A c = makeLeakyCopy(b);
+    // b.a is unchanged
+    assert b.a == 10;
+    // Still mutable
+    b.a = 5;
+    assert b.a == 5;
+
+}

--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -639,6 +639,7 @@ final case class PointsTo[G](loc: Location[G], perm: Expr[G], value: Expr[G])(im
 final case class CurPerm[G](loc: Location[G])(implicit val o: Origin) extends Expr[G] with CurPermImpl[G]
 
 final case class Value[G](loc: Location[G])(implicit val o: Origin) extends Expr[G] with ValueImpl[G]
+final case class AutoValue[G](loc: Location[G])(implicit val o: Origin) extends Expr[G] with AutoValueImpl[G]
 
 final case class ValidArray[G](arr: Expr[G], len: Expr[G])(implicit val o: Origin) extends Expr[G] with ValidArrayImpl[G]
 final case class ValidMatrix[G](mat: Expr[G], w: Expr[G], h: Expr[G])(implicit val o: Origin) extends Expr[G] with ValidMatrixImpl[G]

--- a/src/col/vct/col/ast/expr/literal/constant/AutoValueImpl.scala
+++ b/src/col/vct/col/ast/expr/literal/constant/AutoValueImpl.scala
@@ -1,0 +1,11 @@
+package vct.col.ast.expr.literal.constant
+
+import vct.col.ast.ops.AutoValueOps
+import vct.col.ast.{AutoValue, TResource, Type}
+import vct.col.print._
+
+trait AutoValueImpl[G] extends AutoValueOps[G] { this: AutoValue[G] =>
+  override def t: Type[G] = TResource()
+
+  override def layout(implicit ctx: Ctx): Doc = Text("AutoValue(") <> loc <> ")"
+}

--- a/src/col/vct/col/origin/Blame.scala
+++ b/src/col/vct/col/origin/Blame.scala
@@ -253,6 +253,11 @@ case class ContextEverywhereFailedInPost(failure: ContractFailure, node: Contrac
   override def descInContext: String = "Context may not hold in postcondition, since"
   override def inlineDescWithSource(node: String, failure: String): String = s"Context of `$node` may not hold in the postcondition, since $failure."
 }
+case class AutoValueLeakCheckFailed(failure: ContractFailure, node: ContractApplicable[_]) extends ContractedFailure with SeqCallableFailure with WithContractFailure {
+  override def baseCode: String = "autoValueLeak"
+  override def descInContext: String = "The AutoValue leak check failed, since"
+  override def inlineDescWithSource(node: String, failure: String): String = s"Some of the permission from `$node` was leaked before the postcondition was evaluated, since $failure."
+}
 case class SignalsFailed(failure: ContractFailure, node: AbstractMethod[_]) extends CallableFailure with WithContractFailure {
   override def baseCode: String = "signalsFailed"
   override def descInContext: String = "Signals clause may not hold, since"

--- a/src/col/vct/col/typerules/CoercingRewriter.scala
+++ b/src/col/vct/col/typerules/CoercingRewriter.scala
@@ -1517,6 +1517,8 @@ abstract class CoercingRewriter[Pre <: Generation]() extends BaseCoercingRewrite
       case value: FloatValue[Pre] => e
       case value @ Value(loc) =>
         Value(loc)
+      case value @ AutoValue(loc) =>
+        value
       case values @ Values(arr, from, to) =>
         Values(array(arr)._1, int(from), int(to))(values.blame)
       case VectorCompare(left, right) =>

--- a/src/main/vct/main/stages/Transformation.scala
+++ b/src/main/vct/main/stages/Transformation.scala
@@ -24,7 +24,7 @@ import vct.options.types.{Backend, PathOrStd}
 import vct.resources.Resources
 import vct.result.VerificationError.SystemError
 import vct.rewrite.adt.ImportSetCompat
-import vct.rewrite.{EncodeRange, EncodeResourceValues, ExplicitResourceValues, HeapVariableToRef, MonomorphizeClass, SmtlibToProverTypes}
+import vct.rewrite.{EncodeAutoValue, EncodeRange, EncodeResourceValues, ExplicitResourceValues, HeapVariableToRef, MonomorphizeClass, SmtlibToProverTypes}
 import vct.rewrite.lang.ReplaceSYCLTypes
 import vct.rewrite.veymont.{DeduplicateChorGuards, EncodeChannels, EncodeChorBranchUnanimity, EncodeChoreography, EncodeChoreographyParameters, EncodeEndpointInequalities, EncodeUnpointedGuard, GenerateChoreographyPermissions, GenerateImplementation, InferEndpointContexts, SpecializeEndpointClasses, SplitChorGuards}
 
@@ -320,6 +320,7 @@ case class SilverTransformation
 
     // All locations with a value should now be SilverField
     EncodeForPermWithValue,
+    EncodeAutoValue,
 
     ExtractInlineQuantifierPatterns,
     RewriteTriggerADTFunctions,

--- a/src/parsers/antlr4/SpecLexer.g4
+++ b/src/parsers/antlr4/SpecLexer.g4
@@ -127,6 +127,7 @@ VAL_SOME: 'Some';
 VAL_LEFT: 'Left';
 VAL_RIGHT: 'Right';
 VAL_VALUE: 'Value';
+VAL_AUTO_VALUE: 'AutoValue';
 
 UNFOLDING: '\\unfolding';
 UNFOLDING_JAVA: '\\Unfolding';

--- a/src/parsers/antlr4/SpecParser.g4
+++ b/src/parsers/antlr4/SpecParser.g4
@@ -176,6 +176,7 @@ valPrimaryPermission
  : 'perm' '(' langExpr ')' # valCurPerm
  | 'Perm' '(' langExpr ',' langExpr ')' # valPerm
  | 'Value' '(' langExpr ')' # valValue
+ | 'AutoValue' '(' langExpr ')' # valAutoValue
  | 'PointsTo' '(' langExpr ',' langExpr ',' langExpr ')' #valPointsTo
  | 'HPerm' '(' langExpr ',' langExpr ')' # valHPerm
  | 'APerm' '(' langExpr ',' langExpr ')' # valAPerm

--- a/src/parsers/vct/parsers/transform/CPPToCol.scala
+++ b/src/parsers/vct/parsers/transform/CPPToCol.scala
@@ -1404,6 +1404,7 @@ case class CPPToCol[G](override val baseOrigin: Origin,
     case ValCurPerm(_, _, loc, _) => CurPerm(AmbiguousLocation(convert(loc))(blame(e)))
     case ValPerm(_, _, loc, _, perm, _) => Perm(AmbiguousLocation(convert(loc))(blame(e)), convert(perm))
     case ValValue(_, _, loc, _) => Value(AmbiguousLocation(convert(loc))(blame(e)))
+    case ValAutoValue(_, _, loc, _) => AutoValue(AmbiguousLocation(convert(loc))(blame(e)))
     case ValPointsTo(_, _, loc, _, perm, _, v, _) => PointsTo(AmbiguousLocation(convert(loc))(blame(e)), convert(perm), convert(v))
     case ValHPerm(_, _, loc, _, perm, _) => ModelPerm(convert(loc), convert(perm))
     case ValAPerm(_, _, loc, _, perm, _) => ActionPerm(convert(loc), convert(perm))

--- a/src/parsers/vct/parsers/transform/CToCol.scala
+++ b/src/parsers/vct/parsers/transform/CToCol.scala
@@ -1164,6 +1164,7 @@ case class CToCol[G](override val baseOrigin: Origin,
     case ValCurPerm(_, _, loc, _) => CurPerm(AmbiguousLocation(convert(loc))(blame(e)))
     case ValPerm(_, _, loc, _, perm, _) => Perm(AmbiguousLocation(convert(loc))(blame(e)), convert(perm))
     case ValValue(_, _, loc, _) => Value(AmbiguousLocation(convert(loc))(blame(e)))
+    case ValAutoValue(_, _, loc, _) => AutoValue(AmbiguousLocation(convert(loc))(blame(e)))
     case ValPointsTo(_, _, loc, _, perm, _, v, _) => PointsTo(AmbiguousLocation(convert(loc))(blame(e)), convert(perm), convert(v))
     case ValHPerm(_, _, loc, _, perm, _) => ModelPerm(convert(loc), convert(perm))
     case ValAPerm(_, _, loc, _, perm, _) => ActionPerm(convert(loc), convert(perm))

--- a/src/parsers/vct/parsers/transform/JavaToCol.scala
+++ b/src/parsers/vct/parsers/transform/JavaToCol.scala
@@ -1388,6 +1388,7 @@ case class JavaToCol[G](override val baseOrigin: Origin,
     case ValCurPerm(_, _, loc, _) => CurPerm(AmbiguousLocation(convert(loc))(blame(e)))
     case ValPerm(_, _, loc, _, perm, _) => Perm(AmbiguousLocation(convert(loc))(blame(e)), convert(perm))
     case ValValue(_, _, loc, _) => Value(AmbiguousLocation(convert(loc))(blame(e)))
+    case ValAutoValue(_, _, loc, _) => AutoValue(AmbiguousLocation(convert(loc))(blame(e)))
     case ValPointsTo(_, _, loc, _, perm, _, v, _) => PointsTo(AmbiguousLocation(convert(loc))(blame(e)), convert(perm), convert(v))
     case ValHPerm(_, _, loc, _, perm, _) => ModelPerm(convert(loc), convert(perm))
     case ValAPerm(_, _, loc, _, perm, _) => ActionPerm(convert(loc), convert(perm))

--- a/src/parsers/vct/parsers/transform/LLVMContractToCol.scala
+++ b/src/parsers/vct/parsers/transform/LLVMContractToCol.scala
@@ -268,6 +268,7 @@ case class LLVMContractToCol[G](override val baseOrigin: Origin,
     case ValCurPerm(_, _, loc, _) => CurPerm(AmbiguousLocation(convert(loc))(blame(e)))
     case ValPerm(_, _, loc, _, perm, _) => Perm(AmbiguousLocation(convert(loc))(blame(e)), convert(perm))
     case ValValue(_, _, loc, _) => Value(AmbiguousLocation(convert(loc))(blame(e)))
+    case ValAutoValue(_, _, loc, _) => AutoValue(AmbiguousLocation(convert(loc))(blame(e)))
     case ValPointsTo(_, _, loc, _, perm, _, v, _) => PointsTo(AmbiguousLocation(convert(loc))(blame(e)), convert(perm), convert(v))
     case ValHPerm(_, _, loc, _, perm, _) => ModelPerm(convert(loc), convert(perm))
     case ValAPerm(_, _, loc, _, perm, _) => ActionPerm(convert(loc), convert(perm))

--- a/src/parsers/vct/parsers/transform/PVLToCol.scala
+++ b/src/parsers/vct/parsers/transform/PVLToCol.scala
@@ -1104,6 +1104,7 @@ case class PVLToCol[G](override val baseOrigin: Origin,
     case ValCurPerm(_, _, loc, _) => CurPerm(AmbiguousLocation(convert(loc))(blame(e)))
     case ValPerm(_, _, loc, _, perm, _) => Perm(AmbiguousLocation(convert(loc))(blame(e)), convert(perm))
     case ValValue(_, _, loc, _) => Value(AmbiguousLocation(convert(loc))(blame(e)))
+    case ValAutoValue(_, _, loc, _) => AutoValue(AmbiguousLocation(convert(loc))(blame(e)))
     case ValPointsTo(_, _, loc, _, perm, _, v, _) => PointsTo(AmbiguousLocation(convert(loc))(blame(e)), convert(perm), convert(v))
     case ValHPerm(_, _, loc, _, perm, _) => ModelPerm(convert(loc), convert(perm))
     case ValAPerm(_, _, loc, _, perm, _) => ActionPerm(convert(loc), convert(perm))

--- a/src/rewrite/vct/rewrite/EncodeAutoValue.scala
+++ b/src/rewrite/vct/rewrite/EncodeAutoValue.scala
@@ -1,0 +1,221 @@
+package vct.rewrite
+
+import hre.util.ScopedStack
+import vct.col.ast._
+import vct.col.compare.Compare
+import vct.col.origin.{AbstractApplicable, AutoValueLeakCheckFailed, Blame, LabelContext, Origin, PanicBlame, PostBlameSplit, PostconditionFailed, PreferredName, TrueSatisfiable}
+import vct.col.util.AstBuildHelpers._
+import vct.col.rewrite.{Generation, Rewriter, RewriterBuilder, Rewritten}
+import vct.result.VerificationError.UserError
+
+import scala.collection.mutable
+
+case object EncodeAutoValue extends RewriterBuilder {
+  override def key: String = "encodeAutoValue"
+
+  override def desc: String = "Encodes the AutoValue permission value"
+
+  private def AnyReadOrigin: Origin = Origin(
+    Seq(
+      PreferredName(Seq("read$")),
+      LabelContext("encodeAutoValue")
+    )
+  )
+
+  case class InvalidAutoValue(e: Expr[_]) extends UserError {
+    override def code: String = "invalidAutoValue"
+
+    override def text: String = e.o.messageInContext("The AutoValue permission value may only be in pre and postconditions in expressions containing only ?:, **, ==>, and let")
+  }
+
+  private sealed class PreOrPost
+
+  private final case class InPrecondition() extends PreOrPost
+
+  private final case class InPostcondition() extends PreOrPost
+
+  case class AutoValueLeakCheckFailedBlame(app: ContractApplicable[_]) extends Blame[PostconditionFailed] {
+    override def blame(error: PostconditionFailed): Unit =
+      app.blame.blame(AutoValueLeakCheckFailed(error.failure, app))
+  }
+}
+
+case class EncodeAutoValue[Pre <: Generation]() extends Rewriter[Pre] {
+
+  import EncodeAutoValue._
+
+  private val conditionContext: ScopedStack[(PreOrPost, mutable.ArrayBuffer[(Expr[Pre], Expr[Post])])] = ScopedStack()
+  private val inFunction: ScopedStack[Unit] = ScopedStack()
+
+  private lazy val anyRead: Function[Post] = {
+    implicit val o: Origin = AnyReadOrigin
+    globalDeclarations.declare(withResult((result: Result[Post]) =>
+      function(AbstractApplicable, TrueSatisfiable, returnType = TRational(), ensures = UnitAccountedPredicate(result > NoPerm() &* result < WritePerm()))
+    ))
+  }
+
+  override def dispatch(node: Declaration[Pre]): Unit = node match {
+    case app: AbstractFunction[Pre] =>
+      inFunction.having(()) {
+        allScopes.anySucceed(app, app.rewrite(blame = PostBlameSplit.left(AutoValueLeakCheckFailedBlame(app), app.blame)))
+      }
+    case app: AbstractMethod[Pre] =>
+      allScopes.anySucceed(app, app.rewrite(blame = PostBlameSplit.left(AutoValueLeakCheckFailedBlame(app), app.blame)))
+    case _ => super.dispatch(node)
+  }
+
+  override def dispatch(node: ApplicableContract[Pre]): ApplicableContract[Post] = {
+    implicit val o: Origin = node.o
+    val preMap = mutable.ArrayBuffer[(Expr[Pre], Expr[Post])]()
+    val postMap = mutable.ArrayBuffer[(Expr[Pre], Expr[Post])]()
+    node.rewrite(requires = conditionContext.having((InPrecondition(), preMap)) {
+      dispatch(node.requires)
+    },
+      ensures = {
+        val predicate = conditionContext.having(((InPostcondition(), postMap))) {
+          dispatch(node.ensures)
+        }
+        val filtered = preMap.filterNot(pre => postMap.exists(post => {
+          Compare.isIsomorphic(pre._1, post._1, matchFreeVariables = true)
+        })).map(pre => pre._2)
+        SplitAccountedPredicate(
+          UnitAccountedPredicate(foldStar(filtered.toSeq)),
+          predicate
+        )
+      }
+    )
+  }
+
+  private def handleBinOp(e: Expr[Pre], left: Expr[Pre], right: Expr[Pre], preCons: (Expr[Pre], Expr[Pre]) => Expr[Pre], postCons: (Expr[Post], Expr[Post]) => Expr[Post]): Expr[Post] = {
+    val lMap = mutable.ArrayBuffer[(Expr[Pre], Expr[Post])]()
+    val rMap = mutable.ArrayBuffer[(Expr[Pre], Expr[Post])]()
+    val l = conditionContext.having((conditionContext.top._1, lMap)) {
+      dispatch(left)
+    }
+    val r = conditionContext.having((conditionContext.top._1, rMap)) {
+      dispatch(right)
+    }
+    lMap.foreach(postL => conditionContext.top._2.append((preCons(postL._1, tt), postCons(postL._2, tt))))
+    rMap.foreach(postR => conditionContext.top._2.append((preCons(tt, postR._1), postCons(tt, postR._2))))
+    postCons(l, r)
+  }
+
+  override def dispatch(e: Expr[Pre]): Expr[Post] = {
+    implicit val o: Origin = e.o
+    if (conditionContext.isEmpty) {
+      e match {
+        case AutoValue(_) => throw InvalidAutoValue(e)
+        case _ => e.rewriteDefault()
+      }
+    } else {
+      e match {
+        case AutoValue(loc) if inFunction.nonEmpty => Value(dispatch(loc))
+        case AutoValue(loc) => {
+          val x = new Variable[Post](TRef())
+          val postLoc = dispatch(loc)
+          val (genericLocation, obj) = postLoc match {
+            case SilverFieldLocation(obj, field) => (SilverFieldLocation(x.get, field), obj)
+          }
+          conditionContext.top match {
+            case (InPrecondition(), preMap) =>
+              preMap += ((e, PolarityDependent[Post](onInhale = tt, onExhale = Perm(postLoc, functionInvocation(AbstractApplicable, anyRead.ref)))))
+              PolarityDependent(
+                onInhale = Perm(postLoc, functionInvocation(AbstractApplicable, anyRead.ref)),
+                onExhale = !ForPerm(Seq(x), genericLocation, ff) &* !ForPerm(Seq(x), genericLocation, x.get !== obj)
+              )
+            case (InPostcondition(), postMap) =>
+              postMap += ((e, tt))
+              PolarityDependent(
+                onInhale = !ForPerm(Seq(x), genericLocation, ff) &* !ForPerm(Seq(x), genericLocation, x.get !== obj),
+                onExhale = Perm(postLoc, functionInvocation(AbstractApplicable, anyRead.ref))
+              )
+          }
+        }
+        case Let(binding, value, main) => variables.scope {
+          val top = conditionContext.pop()
+          val (b, v) = try {
+            (variables.dispatch(binding), dispatch(value))
+          } finally {
+            conditionContext.push(top)
+          }
+          val mMap = mutable.ArrayBuffer[(Expr[Pre], Expr[Post])]()
+          val m = conditionContext.having((conditionContext.top._1, mMap)) {
+            dispatch(main)
+          }
+          if (mMap.isEmpty) {
+            Let(b, v, m)
+          } else {
+            mMap.foreach(postM => conditionContext.top._2.append((Let(binding, value, postM._1), Let(b, v, postM._2))))
+            conditionContext.top._1 match {
+              case InPrecondition() => Let(b, v, m)
+              case InPostcondition() => Let(b, Old(v, None)(PanicBlame("Old should always be valid in a postcondition")), m)
+            }
+          }
+        }
+        // This one is probably useless since you can't use resource expressions with and...
+        case And(left, right) => handleBinOp(e, left, right, (l, r) => And(l, r), (l, r) => And(l, r))
+        case Select(condition, left, right) =>
+          val top = conditionContext.pop()
+          val c = try {
+            dispatch(condition)
+          } finally {
+            conditionContext.push(top)
+          }
+          conditionContext.top._1 match {
+            case InPrecondition() => handleBinOp(e, left, right, (l, r) => Select(condition, l, r), (l, r) => Select(c, l, r))
+            case InPostcondition() => handleBinOp(e, left, right, (l, r) => Select(condition, l, r), (l, r) => Select(Old(c, None)(PanicBlame("Old should always be valid in a postcondition")), l, r))
+          }
+        case Implies(left, right) =>
+          val rMap = mutable.ArrayBuffer[(Expr[Pre], Expr[Post])]()
+          val top = conditionContext.pop()
+          val l = try {
+            dispatch(left)
+          } finally {
+            conditionContext.push(top);
+          }
+          val r = conditionContext.having((conditionContext.top._1, rMap)) {
+            dispatch(right)
+          }
+          if (rMap.nonEmpty) {
+            conditionContext.top._1 match {
+              case InPrecondition() =>
+                rMap.foreach(postR => conditionContext.top._2.append((Implies(left, postR._1), Implies(l, postR._2))))
+                Implies(l, r)
+              case InPostcondition() =>
+                // We use the values in conditionContext just for checking
+                // duplicates therefore we don't include the old here since
+                // otherwise it wouldn't match the precondition case
+                rMap.foreach(postR => conditionContext.top._2.append((Implies(left, postR._1), tt)))
+                Implies(Old(l, None)(PanicBlame("Old should always be valid in a postcondition")), r)
+            }
+          } else {
+            Implies(l, r)
+          }
+        case Star(left, right) =>
+          val top = conditionContext.pop()
+          try {
+            val lMap = mutable.ArrayBuffer[(Expr[Pre], Expr[Post])]()
+            val rMap = mutable.ArrayBuffer[(Expr[Pre], Expr[Post])]()
+            val l = conditionContext.having((top._1, lMap)) {
+              dispatch(left)
+            }
+            val r = conditionContext.having((top._1, rMap)) {
+              dispatch(right)
+            }
+            top._2.addAll(lMap)
+            top._2.addAll(rMap)
+            Star(l, r)
+          } finally {
+            conditionContext.push(top);
+          }
+        case _ =>
+          val top = conditionContext.pop()
+          try {
+            e.rewriteDefault()
+          } finally {
+            conditionContext.push(top);
+          }
+      }
+    }
+  }
+}

--- a/src/rewrite/vct/rewrite/EncodeAutoValue.scala
+++ b/src/rewrite/vct/rewrite/EncodeAutoValue.scala
@@ -13,7 +13,7 @@ import scala.collection.mutable
 case object EncodeAutoValue extends RewriterBuilder {
   override def key: String = "encodeAutoValue"
 
-  override def desc: String = "Encodes the AutoValue permission value"
+  override def desc: String = "Encodes the AutoValue resource"
 
   private def AnyReadOrigin: Origin = Origin(
     Seq(
@@ -25,7 +25,7 @@ case object EncodeAutoValue extends RewriterBuilder {
   case class InvalidAutoValue(e: Expr[_]) extends UserError {
     override def code: String = "invalidAutoValue"
 
-    override def text: String = e.o.messageInContext("The AutoValue permission value may only be in pre and postconditions in expressions containing only ?:, **, ==>, and let")
+    override def text: String = e.o.messageInContext("The AutoValue resource may only be in pre and postconditions in expressions containing only ?:, **, ==>, and let")
   }
 
   private sealed class PreOrPost
@@ -138,7 +138,6 @@ case class EncodeAutoValue[Pre <: Generation]() extends Rewriter[Pre] {
             }
           }
         }
-        // This one is probably useless since you can't use resource expressions with and...
         case Select(condition, left, right) =>
           val top = conditionContext.pop()
           val c = try {

--- a/src/rewrite/vct/rewrite/ResolveScale.scala
+++ b/src/rewrite/vct/rewrite/ResolveScale.scala
@@ -62,6 +62,8 @@ case class ResolveScale[Pre <: Generation]() extends Rewriter[Pre] {
       case Perm(loc, p) => Perm(dispatch(loc), amount * dispatch(p))
       case Value(loc) =>
         (amount > NoPerm()) ==> Value(dispatch(loc))
+      case AutoValue(loc) =>
+        (amount > NoPerm()) ==> AutoValue(dispatch(loc))
       case apply: PredicateApply[Pre] => apply.rewrite(perm = amount * dispatch(apply.perm))
       case apply: InstancePredicateApply[Pre] => apply.rewrite(perm = amount * dispatch(apply.perm))
 

--- a/src/rewrite/vct/rewrite/rasi/AbstractProcess.scala
+++ b/src/rewrite/vct/rewrite/rasi/AbstractProcess.scala
@@ -76,7 +76,7 @@ case class AbstractProcess[G](obj: Expr[G]) {
         case Some(_) => take_viable_edges_from_state(succ, state)
         case None => take_viable_edges(succ, state, state.with_postcondition(ref.decl.contract.ensures, Map.from(ref.decl.args.zip(args))))
       })
-      case InvokeConstructor(ref, _, args, _, _, _, _, _) => (true, ref.decl.body match {
+      case InvokeConstructor(ref, _, _, args, _, _, _, _) => (true, ref.decl.body match {
         case Some(_) => take_viable_edges_from_state(succ, state)
         case None => take_viable_edges(succ, state, state.with_postcondition(ref.decl.contract.ensures, Map.from(ref.decl.args.zip(args))))
       })

--- a/src/rewrite/vct/rewrite/rasi/StaticScanner.scala
+++ b/src/rewrite/vct/rewrite/rasi/StaticScanner.scala
@@ -27,7 +27,7 @@ class StaticScanner[G](initial_node: CFGNode[G], state: AbstractState[G]) {
     case Inhale(res) => assumption_changes_vars(res)
     case InvokeProcedure(ref, args, _, _, _, _) if !ref.decl.pure && ref.decl.body.isEmpty =>
       postcondition_changes_vars(ref.decl.contract.ensures, Map.from(ref.decl.args.zip(args)))
-    case InvokeConstructor(ref, _, args, _, _, _, _) if !ref.decl.pure && ref.decl.body.isEmpty =>
+    case InvokeConstructor(ref, _, _, args, _, _, _, _) if !ref.decl.pure && ref.decl.body.isEmpty =>
       postcondition_changes_vars(ref.decl.contract.ensures, Map.from(ref.decl.args.zip(args)))
     case InvokeMethod(_, ref, args, _, _, _, _) if !ref.decl.pure && ref.decl.body.isEmpty =>
       postcondition_changes_vars(ref.decl.contract.ensures, Map.from(ref.decl.args.zip(args)))

--- a/test/main/vct/test/integration/examples/AutoValueSpec.scala
+++ b/test/main/vct/test/integration/examples/AutoValueSpec.scala
@@ -1,0 +1,8 @@
+package vct.test.integration.examples
+
+import vct.test.integration.helper.VercorsSpec
+
+class AutoValueSpec extends VercorsSpec {
+  vercors should verify using silicon example "concepts/autovalue/copy.pvl"
+  vercors should verify using silicon example "concepts/autovalue/leak.pvl"
+}

--- a/test/main/vct/test/integration/meta/ExampleCoverage.scala
+++ b/test/main/vct/test/integration/meta/ExampleCoverage.scala
@@ -62,6 +62,7 @@ class ExampleCoverage extends AnyFlatSpec {
       new VeyMontExamplesSpec(),
       new WaitNotifySpec(),
       new WandSpec(),
+      new AutoValueSpec(),
     )
 
     val testedFiles = specs.flatMap(_.coveredExamples).toSet


### PR DESCRIPTION
Checklist:

- [x] The wiki is updated in accordance with the changes in this PR. For example: syntax changes, semantics changes, VerCors flags changes, etc.

# PR description
Allows you to have a method that needs read permission to some field but doesn't modify the callers permission amount. (Unlike `Perm(loc, read)`/`Value(loc)` which result in the loss of write permission for the caller since the callee need not prove that it returns the same amount of permission it took)

This is related to #502 but it is not replacement for the idea described there since this implementation is more restricted. 

If we have a method:
```java
context AutoValue(a.b);
void doStuff(A a) {
    // Read from a.b
}
```

This is transformed into
```java
requires \polarity_dependent(Perm(a.b, read$()), !(\forperm A x \in x.b; false) ** !(\forperm A x \in x.b; x != a));
ensures \polarity_dependent(!(\forperm A x \in x.b; false) ** !(\forperm A x \in x.b; x != a), Perm(a.b, read$()));
void doStuff(A a) {
    // Read from a.b
}
```

Which essentially checks at the call site if the caller has access to the field and then inside the method we inhale some symbolic amount of permission (greater than 0 but less than 1) which has to be exhaled at the end of the method again.

Inhaling the `forperm` stuff in the postcondition is only necessary to be able to write other postconditions which require access to the field, it doesn't make any difference for the caller's heap. 

Unless the expression containing `AutoValue` is in the both the precondition and the postcondition (like is the case when you use `context`) an automatic leak check is added such that you cannot leak some part of the symbolic read permission which would make this unsound. In the above example (assuming instead of `context` we wrote `requires`) this leak check would look like this:

```java
ensures \polarity_dependent(true,Perm(a.b, read$()));
```

If the leak check fails there is an appropriate error returned to the user. (`autoValueLeak:perm`) An example of such a leak is given in https://github.com/superaxander/vercors/blob/b3396287f2fc91667df094138ccbdf90664e2d79/examples/concepts/autovalue/leak.pvl

Currently you can use `AutoValue` only in expressions containing `**`, `let`, `? :`, and `==>`. For `let`, `? :` and `==>` an implicit `\old` is added around the parts of the expression which do not contain the AutoValue when used in the postcondition such that you cannot leak the permission by for example having an expression `boolean ==> AutoValue(b.a)` where boolean is true when the method is called but false when it returns. 

An alternative way to encode the assertion that there exists read permission (instead of the `forperm` expressions) for the given field could be `perm(loc) > 0`. Intuitively this sounds like it might be more performant but I have not done any testing, nor do I know enough about how Viper works to evaluate that.