### PR TITLE
Fix build on JDK 21+, resolves #1146

### DIFF
--- a/src/helpers/scala/meta/ResultStream.scala
+++ b/src/helpers/scala/meta/ResultStream.scala
@@ -108,7 +108,7 @@ object ResultStream {
       case Function(fn) =>
         if (
           fn.getClass.getName.startsWith(
-            "scala.meta.internal.prettyprinters.TreeSyntax$SyntaxInstances$$Lambda$"
+            "scala.meta.internal.prettyprinters.TreeSyntax$SyntaxInstances$$Lambda"
           )
         ) {
           // Currently the only instance: prepends a space if the surrounding output is dangerous.


### PR DESCRIPTION
Files were not being generated leading to the missing packages in #1146 

It seems on newer JDKs there is no $ after Lambda so that caused our name matching to fail.

Example of what a class name looks like now:
```
scala.meta.internal.prettyprinters.TreeSyntax$SyntaxInstances$$Lambda/0x00007f00eac376f8
```
