### PR TITLE
Fix crash that can occur after vercors finishes executing

### DIFF
--- a/src/main/vct/main/Main.scala
+++ b/src/main/vct/main/Main.scala
@@ -138,8 +138,11 @@ case object Main extends LazyLogging {
       val thisThread = Thread.currentThread()
       Thread.getAllStackTraces.keySet().stream().filter(_ != thisThread)
         .filter(!_.isDaemon).forEach { thread =>
-          logger.warn(s"Non-daemon thread ${thread.getThreadGroup
-              .getName}.${thread.getName} (#${thread.getId}) is still running")
+          val tg = Option(thread.getThreadGroup)
+          logger.warn(
+            s"Non-daemon thread ${tg.map(_.getName)
+                .getOrElse("UnknownThreadGroup")}.${thread.getName} (#${thread.getId}) is still running"
+          )
           logger.warn(
             "Due to this VerCors will not exit and sit idly until that thread is done. You may want to stop the program manually."
           )


### PR DESCRIPTION
After VerCors finishes executing while printing the message warning of daemon threads sometimes the thread stops executing before the message is printed which can cause the following NPE:

```
java.lang.NullPointerException: Cannot invoke "java.lang.ThreadGroup.getName()" because the return value of "java.lang.Thread.getThreadGroup()" is null
        at vct.main.Main$.$anonfun$runOptions$7(Main.scala:141)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
        at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
        at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
        at java.base/java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1707)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
        at vct.main.Main$.runOptions(Main.scala:140)
        at vct.main.Main$.main(Main.scala:47)
        at vct.main.Main.main(Main.scala)
```

This happens to me fairly often for some reason