### PR TITLE
Don't try to delete nonexistent preprocessor output if clang fails

### DIFF
--- a/src/parsers/vct/parsers/parser/ColCPPParser.scala
+++ b/src/parsers/vct/parsers/parser/ColCPPParser.scala
@@ -94,6 +94,6 @@ case class ColCPPParser(
       val result = ColIPPParser(debugOptions, blameProvider, Some(baseOrigin))
         .parse[G](ireadable)
       result
-    } finally { Files.delete(interpreted) }
+    } finally { Files.deleteIfExists(interpreted) }
   }
 }

--- a/src/parsers/vct/parsers/parser/ColCParser.scala
+++ b/src/parsers/vct/parsers/parser/ColCParser.scala
@@ -94,6 +94,6 @@ case class ColCParser(
       val result = ColIParser(debugOptions, blameProvider, Some(baseOrigin))
         .parse[G](ireadable)
       result
-    } finally { Files.delete(interpreted) }
+    } finally { Files.deleteIfExists(interpreted) }
   }
 }

--- a/test/main/vct/test/integration/examples/CPPSpec.scala
+++ b/test/main/vct/test/integration/examples/CPPSpec.scala
@@ -23,4 +23,9 @@ class CPPSpec extends VercorsSpec {
   vercors should verify using silicon example "concepts/cpp/methods/Permissions.cpp"
   vercors should verify using silicon example "concepts/cpp/methods/Predicates.cpp"
   vercors should verify using silicon example "concepts/cpp/methods/PureGhostMethod.cpp"
+
+  vercors should error withCode "preprocessorError" in "Source file with preprocessor error" cpp
+  """
+  #define foo(
+  """
 }

--- a/test/main/vct/test/integration/examples/CSpec.scala
+++ b/test/main/vct/test/integration/examples/CSpec.scala
@@ -346,6 +346,11 @@ class CSpec extends VercorsSpec {
     }
     """
 
+    vercors should error withCode "preprocessorError" in "Source file with preprocessor error" c
+    """
+    #define foo(
+    """
+
     vercors should verify using silicon in "Parallel omp loop with declarations inside" c
     """
     #include <omp.h>

--- a/test/main/vct/test/integration/helper/VercorsSpec.scala
+++ b/test/main/vct/test/integration/helper/VercorsSpec.scala
@@ -212,26 +212,17 @@ abstract class VercorsSpec extends AnyFlatSpec {
   }
 
   class DescPhrase(val verdict: Verdict, val backends: Seq[Backend], val desc: String, val flags: Seq[String]) {
-    def pvl(data: String)(implicit pos: source.Position): Unit = {
-      val inputs = Seq(LiteralReadable("test.pvl", data))
+    private def literal(suffix: String, data: String)(implicit pos: source.Position): Unit = {
+      val inputs = Seq(LiteralReadable(s"test.$suffix", data))
       for(backend <- backends) {
         registerTest(verdict, desc, Seq(new Tag("literalCase")), backend, inputs, flags)
       }
     }
 
-    def java(data: String)(implicit pos: source.Position): Unit = {
-      val inputs = Seq(LiteralReadable("test.java", data))
-      for(backend <- backends) {
-        registerTest(verdict, desc, Seq(new Tag("literalCase")), backend, inputs, flags)
-      }
-    }
-
-    def c(data: String)(implicit pos: source.Position): Unit = {
-      val inputs = Seq(LiteralReadable("test.c", data))
-      for(backend <- backends) {
-        registerTest(verdict, desc, Seq(new Tag("literalCase")), backend, inputs, flags)
-      }
-    }
+    def pvl(data: String)(implicit pos: source.Position): Unit = literal("pvl", data)
+    def java(data: String)(implicit pos: source.Position): Unit = literal("java", data)
+    def c(data: String)(implicit pos: source.Position): Unit = literal("c", data)
+    def cpp(data: String)(implicit pos: source.Position): Unit = literal("cpp", data)
   }
 
   val vercors: VercorsWord = new VercorsWord


### PR DESCRIPTION
Clang can remove the output file on its own, so only delete the file if it hasn't already been deleted.

Adds (integration) tests, fixes #1235.