### PR TITLE
Encode that malloc may return NULL in C (weaken postcondition)

### DIFF
--- a/examples/concepts/c/malloc_free.c
+++ b/examples/concepts/c/malloc_free.c
@@ -13,6 +13,7 @@ struct e{
 
 int main(){
     int* xs = (int*) malloc(sizeof(int)*3);
+    if (xs == NULL) return 1;
 
     xs[0] = 3;
     xs[1] = 2;
@@ -20,6 +21,7 @@ int main(){
     free(xs);
 
     int** xxs = (int * *) malloc(sizeof(int *)*3);
+    if (xxs == NULL) return 1;
 
     int temp[3] = {1,2,3};
     xxs[0] = temp;
@@ -27,17 +29,23 @@ int main(){
     free(xxs);
 
     struct d* ys = (struct d*) malloc(3*sizeof(struct d));
+    if (ys == NULL) return 1;
+
     ys[0].x = 3;
     ys[1].x = 2;
     ys[2].x = 1;
     free(ys);
 
     struct e* a = (struct e*) malloc(1*sizeof(struct e));
+    if (a == NULL) return 1;
+
     a->s.x = 1;
     struct d* b = &(a->s);
     free(a);
 
     float * z = (float *) malloc(sizeof(float));
+    if (z == NULL) return 1;
+
     z[0] = 3.0;
     *z = 2.0;
     free(z);

--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -1820,9 +1820,11 @@ final case class NewArray[G](
     initialize: Boolean,
 )(val blame: Blame[ArraySizeError])(implicit val o: Origin)
     extends Expr[G] with NewArrayImpl[G]
-final case class NewPointerArray[G](element: Type[G], size: Expr[G])(
-    val blame: Blame[ArraySizeError]
-)(implicit val o: Origin)
+final case class NewPointerArray[G](
+    element: Type[G],
+    size: Expr[G],
+    fallible: Boolean,
+)(val blame: Blame[ArraySizeError])(implicit val o: Origin)
     extends Expr[G] with NewPointerArrayImpl[G]
 final case class FreePointer[G](pointer: Expr[G])(
     val blame: Blame[PointerFreeError]

--- a/src/col/vct/col/typerules/CoercingRewriter.scala
+++ b/src/col/vct/col/typerules/CoercingRewriter.scala
@@ -1552,8 +1552,8 @@ abstract class CoercingRewriter[Pre <: Generation]()
         Neq(coerce(left, sharedType), coerce(right, sharedType))
       case na @ NewArray(element, dims, moreDims, initialize) =>
         NewArray(element, dims.map(int), moreDims, initialize)(na.blame)
-      case na @ NewPointerArray(element, size) =>
-        NewPointerArray(element, size)(na.blame)
+      case na @ NewPointerArray(element, size, fallible) =>
+        NewPointerArray(element, size, fallible)(na.blame)
       case NewObject(cls) => NewObject(cls)
       case NoPerm() => NoPerm()
       case Not(arg) => Not(bool(arg))

--- a/src/rewrite/vct/rewrite/TrivialAddrOf.scala
+++ b/src/rewrite/vct/rewrite/TrivialAddrOf.scala
@@ -98,7 +98,7 @@ case class TrivialAddrOf[Pre <: Generation]() extends Rewriter[Pre] {
     val newPointer = Eval(
       PreAssignExpression(
         newTarget,
-        NewPointerArray(newValue.t, const[Post](1))(PanicBlame("Size is > 0")),
+        NewPointerArray(newValue.t, const[Post](1), fallible=false)(PanicBlame("Size is > 0")),
       )(blame)
     )
     (newPointer, newTarget, newValue)

--- a/src/rewrite/vct/rewrite/lang/LangCPPToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangCPPToCol.scala
@@ -2737,11 +2737,11 @@ case class LangCPPToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
         (sizeOption, init.init) match {
           case (None, None) => throw WrongCPPType(decl)
           case (Some(size), None) =>
-            val newArr = NewPointerArray[Post](t, rw.dispatch(size))(cta.blame)
+            val newArr = NewPointerArray[Post](t, rw.dispatch(size), fallible=false)(cta.blame)
             Block(Seq(LocalDecl(v), assignLocal(v.get, newArr)))
           case (None, Some(CPPLiteralArray(exprs))) =>
             val newArr =
-              NewPointerArray[Post](t, c_const[Post](exprs.size))(cta.blame)
+              NewPointerArray[Post](t, c_const[Post](exprs.size), fallible=false)(cta.blame)
             Block(
               Seq(LocalDecl(v), assignLocal(v.get, newArr)) ++
                 assignliteralArray(v, exprs, o)
@@ -2752,7 +2752,7 @@ case class LangCPPToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
             if (realSize < exprs.size)
               logger.warn(s"Excess elements in array initializer: '${decl}'")
             val newArr =
-              NewPointerArray[Post](t, c_const[Post](realSize))(cta.blame)
+              NewPointerArray[Post](t, c_const[Post](realSize), fallible=false)(cta.blame)
             Block(
               Seq(LocalDecl(v), assignLocal(v.get, newArr)) ++
                 assignliteralArray(v, exprs.take(realSize.intValue), o)

--- a/src/rewrite/vct/rewrite/lang/LangCToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangCToCol.scala
@@ -424,7 +424,7 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
               (t1, rw.dispatch(r))
             case _ => throw UnsupportedMalloc(c)
           }
-        NewPointerArray(rw.dispatch(t1), size)(ArrayMallocFailed(inv))(c.o)
+        NewPointerArray(rw.dispatch(t1), size, fallible=true)(ArrayMallocFailed(inv))(c.o)
       case CCast(CInvocation(CLocal("__vercors_malloc"), _, _, _), _) =>
         throw UnsupportedMalloc(c)
       case CCast(n @ Null(), t) if t.asPointer.isDefined => rw.dispatch(n)
@@ -650,6 +650,7 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
           NewPointerArray[Post](
             getInnerType(cNameSuccessor(d).t),
             Local(v.ref),
+            fallible=false,
           )(PanicBlame("Shared memory sizes cannot be negative.")),
         )
         declarations ++= Seq(cNameSuccessor(d))
@@ -664,6 +665,7 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
           NewPointerArray[Post](
             getInnerType(cNameSuccessor(d).t),
             CIntegerValue(size),
+            fallible=false
           )(blame.get),
         )
         declarations ++= Seq(cNameSuccessor(d))
@@ -1127,11 +1129,11 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
         (sizeOption, init.init) match {
           case (None, None) => throw WrongCType(decl)
           case (Some(size), None) =>
-            val newArr = NewPointerArray[Post](t, rw.dispatch(size))(cta.blame)
+            val newArr = NewPointerArray[Post](t, rw.dispatch(size), fallible=false)(cta.blame)
             Block(Seq(LocalDecl(v), assignLocal(v.get, newArr)))
           case (None, Some(CLiteralArray(exprs))) =>
             val newArr =
-              NewPointerArray[Post](t, c_const[Post](exprs.size))(cta.blame)
+              NewPointerArray[Post](t, c_const[Post](exprs.size), fallible=false)(cta.blame)
             Block(
               Seq(LocalDecl(v), assignLocal(v.get, newArr)) ++
                 assignliteralArray(v, exprs, o)
@@ -1142,7 +1144,7 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
             if (realSize < exprs.size)
               logger.warn(s"Excess elements in array initializer: '${decl}'")
             val newArr =
-              NewPointerArray[Post](t, c_const[Post](realSize))(cta.blame)
+              NewPointerArray[Post](t, c_const[Post](realSize), fallible=false)(cta.blame)
             Block(
               Seq(LocalDecl(v), assignLocal(v.get, newArr)) ++
                 assignliteralArray(v, exprs.take(realSize.intValue), o)

--- a/test/main/vct/test/integration/examples/CSpec.scala
+++ b/test/main/vct/test/integration/examples/CSpec.scala
@@ -33,11 +33,23 @@ class CSpec extends VercorsSpec {
 
     int main(){
       struct e* a = (struct e*) malloc(1*sizeof(struct e));
+      if (a == NULL) return 1;
+
       a->s.x = 1;
       struct d* b = &(a->s);
       free(a);
       b->x = 2;
     }
+    """
+
+  vercors should fail withCode "ptrNull" using silicon in "use malloc result without null check" c
+    """
+      #include <stdlib.h>
+      int main(){
+          int* xs = (int*) malloc(1*sizeof(int));
+          *xs = 12;
+          free(xs);
+      }
     """
 
   vercors should verify using silicon in "free null pointer" c
@@ -402,6 +414,7 @@ class CSpec extends VercorsSpec {
       struct nested *np = NULL;                    
       np = (struct nested*) NULL;               
       np = (struct nested*) malloc(sizeof(struct nested));
+      if (np == NULL) return;
       np->inner = NULL;
       np->inner = (struct nested*) NULL;         
     }


### PR DESCRIPTION
The new field 'fallible' on the NewPointerArray AST node stores whether you are guaranteed to get a new pointer array (false) or merely probably get one (true).

Updates tests, fixes #1233.