### PR TITLE
Restrict C++ character literals to a single UTF-8 char

### DIFF
--- a/src/parsers/vct/parsers/transform/CPPToCol.scala
+++ b/src/parsers/vct/parsers/transform/CPPToCol.scala
@@ -765,7 +765,8 @@ case class CPPToCol[G](
 
   private def parseChar(value: String)(implicit o: Origin): Option[Expr[G]] = {
     val fixedValue = fixEscapeAndUnicodeChars(value)
-    val pattern = "^'(.|\n|\r)'$".r
+    // Only allow characters that fit 1 char in UTF-8, the assumed execution character set
+    val pattern = "^'([ -~\n\r])'$".r
     fixedValue match {
       case pattern(char, _*) => Some(CharValue(char.codePointAt(0)))
       case _ => None

--- a/test/main/vct/test/integration/examples/CPPSpec.scala
+++ b/test/main/vct/test/integration/examples/CPPSpec.scala
@@ -28,4 +28,20 @@ class CPPSpec extends VercorsSpec {
   """
   #define foo(
   """
+
+  vercors should verify using silicon in "Character literal" cpp
+  """
+  char a = 'a';
+  char b = '\u0062';
+  """
+
+  vercors should error withCode "parseError" in "Multicharacter literal" cpp
+  """
+  char c = 'bad!';
+  """
+
+  vercors should error withCode "parseError" in "Unrepresentable character literal" cpp
+  """
+  char d = 'é';
+  """
 }


### PR DESCRIPTION
Character literals that would require more than one code unit, and thus more than one char, to encode in UTF-8 (for instance: `'é'`) are now "syntactically valid, but not supported by VerCors".

This assumes the execution character set will be UTF-8.

Fixes #1243.