### PR TITLE
Make contract of free (for C) conditional on ptr being non-null

### DIFF
--- a/src/rewrite/vct/rewrite/EncodeArrayValues.scala
+++ b/src/rewrite/vct/rewrite/EncodeArrayValues.scala
@@ -150,7 +150,6 @@ case class EncodeArrayValues[Pre <: Generation]() extends Rewriter[Pre] {
         (and recurse for struct fields)
        */
       var requiresT: Seq[(Expr[Post], Expr[Pre] => PointerFreeError)] = Seq(
-        (ptr !== Null(), (p: Expr[Pre]) => PointerNull(p)),
         (
           PointerBlockOffset(ptr)(FramedPtrBlockOffset) === zero,
           (p: Expr[Pre]) => PointerOffsetNonZero(p),
@@ -166,7 +165,7 @@ case class EncodeArrayValues[Pre <: Generation]() extends Rewriter[Pre] {
           (p: Expr[Pre]) => PointerInsufficientFreePermission(p),
         ),
       )
-      var requires = (ptr !== Null()) &*
+      var requires =
         (PointerBlockOffset(ptr)(FramedPtrBlockOffset) === zero) &*
         makeStruct.makePerm(
           i =>
@@ -197,7 +196,7 @@ case class EncodeArrayValues[Pre <: Generation]() extends Rewriter[Pre] {
           requiresT
         else
           requiresT ++ permFields
-      val requiresPred = foldPredicate(requiresT.map(_._1))
+      val requiresPred = foldPredicate(requiresT.map((ptr !== Null()) ==> _._1))
       errors = requiresT.map(_._2)
 
       procedure(

--- a/test/main/vct/test/integration/examples/CSpec.scala
+++ b/test/main/vct/test/integration/examples/CSpec.scala
@@ -40,7 +40,18 @@ class CSpec extends VercorsSpec {
     }
     """
 
-  vercors should fail withCode "ptrNull" using silicon in "free null pointer" c
+  vercors should verify using silicon in "free null pointer" c
+    """
+      #include <stdlib.h>
+      int main(){
+          int* xs = NULL;
+          free(xs);
+          free(xs);
+          free(xs);
+      }
+    """
+
+  vercors should fail withCode "ptrOffsetNonZero" using silicon in "free stack garbage pointer" c
     """
       #include <stdlib.h>
       int main(){


### PR DESCRIPTION
In C, passing NULL to `free` has no effect. This change weakens the precondition on the argument to `free` so that it only applies if the pointer is non-null, so this program now verifies:

      #include <stdlib.h>
      int main(){
          int* xs = NULL;
          free(xs);
          free(xs);
          free(xs);
      }

Adds test; changes existing test; fixes #1240. As @bobismijnnaam mentioned in that issue, this does introduce a number of branches - the hope there was that this "would not influence verification significantly", but I'm not sure how to check this; the existing examples seem to be okay, but those are quite small.