### PR TITLE
Add stringToName special case for all-underscores identifier strings

### DIFF
--- a/src/col/vct/col/origin/Origin.scala
+++ b/src/col/vct/col/origin/Origin.scala
@@ -89,7 +89,9 @@ case class IndirectName(name: Name) extends NameStrategy {
 object SourceName {
   def stringToName(name: String): Name =
     Name.Preferred(
-      if (name.forall(c => !c.isLetter || c.isUpper))
+      if (name.matches("[_]+"))
+        Seq(name)
+      else if (name.forall(c => !c.isLetter || c.isUpper))
         name.split("[_]+").toIndexedSeq
       else
         name.split("[_]+").toIndexedSeq.flatMap(splitNameRec)

--- a/test/col/origin/OriginSpec.scala
+++ b/test/col/origin/OriginSpec.scala
@@ -1,0 +1,35 @@
+package origin
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.prop.TableDrivenPropertyChecks.{Table, forAll}
+import vct.col.origin.SourceName
+
+class OriginSpec extends AnyFlatSpec {
+  behavior of "SourceName.stringToName"
+
+  it should "come up with a reasonable name for any identifier" in {
+    val cases = Table(
+      ("string", "snake", "camel"),
+      ("foo", "foo", "foo"),
+      ("foo_bar", "foo_bar", "fooBar"),
+      ("foo_bar_baz", "foo_bar_baz", "fooBarBaz"),
+      ("montAiguille", "mont_aiguille", "montAiguille"),
+      ("GERVANNE", "gervanne", "gervanne"),
+      ("VeRnAiSoN", "ve_rn_ai_so_n", "veRnAiSoN"),
+      ("_", "_", "_"),
+      ("___", "___", "___"),
+      ("_a", "a", "a"),
+      ("a_", "a", "a"),
+      ("a_b_", "a_b", "aB"),
+      ("_a_b", "a_b", "aB"),
+      ("do__ob", "do_ob", "doOb"),
+      ("do____ob", "do_ob", "doOb"),
+    )
+
+    forAll(cases) { (string, snake, camel) =>
+      val name = SourceName.stringToName(string)
+      assert(name.snake == snake)
+      assert(name.camel == camel)
+    }
+  }
+}


### PR DESCRIPTION
Before, parsing the following PVL program like the following would give an assertion error, since it would attempt to build a preferred name with no parts:

```php
void ___() {
}
```

It now gets a preferred name with one part, the string "___".

Also adds a unit test for stringToName.