### PR TITLE
Collect bip_annotation modifier in all ToCol classes

### DIFF
--- a/src/parsers/vct/parsers/transform/CPPToCol.scala
+++ b/src/parsers/vct/parsers/transform/CPPToCol.scala
@@ -1443,6 +1443,7 @@ case class CPPToCol[G](
           case "pure" => collector.pure += mod
           case "inline" => collector.inline += mod
           case "thread_local" => collector.threadLocal += mod
+          case "bip_annotation" => collector.bipAnnotation += mod
         }
       case ValStatic(_) => collector.static += mod
     }

--- a/src/parsers/vct/parsers/transform/CToCol.scala
+++ b/src/parsers/vct/parsers/transform/CToCol.scala
@@ -1181,6 +1181,7 @@ case class CToCol[G](
           case "pure" => collector.pure += mod
           case "inline" => collector.inline += mod
           case "thread_local" => collector.threadLocal += mod
+          case "bip_annotation" => collector.bipAnnotation += mod
         }
       case ValStatic(_) => collector.static += mod
     }

--- a/src/parsers/vct/parsers/transform/PVLToCol.scala
+++ b/src/parsers/vct/parsers/transform/PVLToCol.scala
@@ -1025,6 +1025,7 @@ case class PVLToCol[G](
           case "pure" => collector.pure += mod
           case "inline" => collector.inline += mod
           case "thread_local" => collector.threadLocal += mod
+          case "bip_annotation" => collector.bipAnnotation += mod
         }
       case ValStatic(_) => collector.static += mod
     }


### PR DESCRIPTION
The bip_annotation modifier is part of the specification grammar for all input languages, so a PVL program like this parses according to ANTLR:

```
bip_annotation
void foo() {
}
```

...but then hits a MatchError ("VerCors has crashed") in the PVLToCol transform.

This PR changes PVLToCol, CToCol and CPPToCol to follow the same strategy as LLVMContractToCol, which is to pass through the BIP annotation. (Actually, the methods are now identical.) In practice, this results in a "modifier cannot be attached to this declaration" message in the example above.