### PR TITLE
Focus/minimization functionality

### DIFF
--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -696,7 +696,7 @@ final class Function[G](
     val contract: ApplicableContract[G],
     val inline: Boolean = false,
     val threadLocal: Boolean = false,
-    val filter: FilterMode[G] = NeutralFilterMode(),
+    val filter: FilterMode[G] = NeutralFilterMode[G](),
 )(val blame: Blame[ContractedFailure])(implicit val o: Origin)
     extends GlobalDeclaration[G] with AbstractFunction[G] with FunctionImpl[G]
 @scopes[LabelDecl]
@@ -710,7 +710,7 @@ final class Procedure[G](
     val inline: Boolean = false,
     val pure: Boolean = false,
     val vesuv_entry: Boolean = false,
-    val filter: FilterMode[G] = NeutralFilterMode(),
+    val filter: FilterMode[G] = NeutralFilterMode[G](),
 )(val blame: Blame[CallableFailure])(implicit val o: Origin)
     extends GlobalDeclaration[G] with AbstractMethod[G] with ProcedureImpl[G]
 @scopes[LabelDecl]
@@ -725,7 +725,7 @@ final class Predicate[G](
     val body: Option[Expr[G]],
     val threadLocal: Boolean = false,
     val inline: Boolean = false,
-    val filter: FilterMode[G] = NeutralFilterMode(),
+    val filter: FilterMode[G] = NeutralFilterMode[G](),
 )(implicit val o: Origin)
     extends GlobalDeclaration[G] with AbstractPredicate[G] with PredicateImpl[G]
 final class Enum[G](val constants: Seq[EnumConstant[G]])(implicit val o: Origin)
@@ -763,7 +763,7 @@ final class InstanceFunction[G](
     val contract: ApplicableContract[G],
     val inline: Boolean,
     val threadLocal: Boolean = false,
-    val filter: FilterMode[G] = NeutralFilterMode(),
+    val filter: FilterMode[G] = NeutralFilterMode[G](),
 )(val blame: Blame[ContractedFailure])(implicit val o: Origin)
     extends ClassDeclaration[G]
     with AbstractFunction[G]
@@ -777,7 +777,7 @@ final class Constructor[G](
     val body: Option[Statement[G]],
     val contract: ApplicableContract[G],
     val inline: Boolean = false,
-    val filter: FilterMode[G] = NeutralFilterMode(),
+    val filter: FilterMode[G] = NeutralFilterMode[G](),
 )(val blame: Blame[CallableFailure])(implicit val o: Origin)
     extends ClassDeclaration[G] with AbstractMethod[G] with ConstructorImpl[G]
 @scopes[LabelDecl]
@@ -790,7 +790,7 @@ final class InstanceMethod[G](
     val contract: ApplicableContract[G],
     val inline: Boolean = false,
     val pure: Boolean = false,
-    val filter: FilterMode[G] = NeutralFilterMode(),
+    val filter: FilterMode[G] = NeutralFilterMode[G](),
 )(val blame: Blame[CallableFailure])(implicit val o: Origin)
     extends ClassDeclaration[G]
     with AbstractMethod[G]
@@ -802,7 +802,7 @@ final class InstancePredicate[G](
     val body: Option[Expr[G]],
     val threadLocal: Boolean = false,
     val inline: Boolean = false,
-    val filter: FilterMode[G] = NeutralFilterMode(),
+    val filter: FilterMode[G] = NeutralFilterMode[G](),
 )(implicit val o: Origin)
     extends ClassDeclaration[G]
     with AbstractPredicate[G]
@@ -824,7 +824,7 @@ final class InstanceOperatorFunction[G](
     val contract: ApplicableContract[G],
     val inline: Boolean,
     val threadLocal: Boolean = false,
-    val filter: FilterMode[G] = NeutralFilterMode(),
+    val filter: FilterMode[G] = NeutralFilterMode[G](),
 )(val blame: Blame[ContractedFailure])(implicit val o: Origin)
     extends ClassDeclaration[G]
     with AbstractFunction[G]
@@ -837,7 +837,7 @@ final class InstanceOperatorMethod[G](
     val contract: ApplicableContract[G],
     val inline: Boolean = false,
     val pure: Boolean = false,
-    val filter: FilterMode[G] = NeutralFilterMode(),
+    val filter: FilterMode[G] = NeutralFilterMode[G](),
 )(val blame: Blame[CallableFailure])(implicit val o: Origin)
     extends ClassDeclaration[G]
     with AbstractMethod[G]
@@ -907,10 +907,10 @@ final class ParInvariantDecl[G]()(implicit val o: Origin)
     extends Declaration[G] with ParInvariantDeclImpl[G]
 
 sealed trait Applicable[G] extends ApplicableImpl[G] with Declaration[G]
+sealed trait FilterApplicable[G]
+    extends Applicable[G] with FilterApplicableImpl[G]
 sealed trait InlineableApplicable[G]
-    extends Applicable[G]
-    with InlineableApplicableImpl[G]
-    with FilterApplicable[G]
+    extends FilterApplicable[G] with InlineableApplicableImpl[G]
 sealed trait AbstractPredicate[G]
     extends InlineableApplicable[G] with AbstractPredicateImpl[G]
 sealed trait ContractApplicable[G]
@@ -920,10 +920,6 @@ sealed trait AbstractFunction[G]
 sealed trait AbstractMethod[G]
     extends ContractApplicable[G] with AbstractMethodImpl[G]
 sealed trait Field[G] extends FieldImpl[G]
-
-sealed trait FilterApplicable[G] {
-  def filter: FilterMode[G]
-}
 
 @family
 sealed trait FilterMode[G] extends NodeFamily[G] with FilterModeImpl[G]
@@ -3559,7 +3555,7 @@ final class LLVMSpecFunction[G](
     val contract: ApplicableContract[G],
     val inline: Boolean = false,
     val threadLocal: Boolean = false,
-    val filter: FilterMode[G] = NeutralFilterMode(),
+    val filter: FilterMode[G] = NeutralFilterMode[G](),
 )(val blame: Blame[ContractedFailure])(implicit val o: Origin)
     extends LLVMCallable[G]
     with AbstractFunction[G]

--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -899,7 +899,9 @@ final class ParInvariantDecl[G]()(implicit val o: Origin)
 
 sealed trait Applicable[G] extends ApplicableImpl[G] with Declaration[G]
 sealed trait InlineableApplicable[G]
-    extends Applicable[G] with InlineableApplicableImpl[G]
+    extends Applicable[G]
+    with InlineableApplicableImpl[G]
+    with FocusApplicable[G]
 sealed trait AbstractPredicate[G]
     extends InlineableApplicable[G] with AbstractPredicateImpl[G]
 sealed trait ContractApplicable[G]
@@ -909,6 +911,8 @@ sealed trait AbstractFunction[G]
 sealed trait AbstractMethod[G]
     extends ContractApplicable[G] with AbstractMethodImpl[G]
 sealed trait Field[G] extends FieldImpl[G]
+
+sealed trait FocusApplicable[G]
 
 @family @scopes[Variable]
 @scopes[LocalHeapVariable]

--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -696,6 +696,7 @@ final class Function[G](
     val contract: ApplicableContract[G],
     val inline: Boolean = false,
     val threadLocal: Boolean = false,
+    val filter: FilterMode[G] = NeutralFilterMode(),
 )(val blame: Blame[ContractedFailure])(implicit val o: Origin)
     extends GlobalDeclaration[G] with AbstractFunction[G] with FunctionImpl[G]
 @scopes[LabelDecl]
@@ -709,6 +710,7 @@ final class Procedure[G](
     val inline: Boolean = false,
     val pure: Boolean = false,
     val vesuv_entry: Boolean = false,
+    val filter: FilterMode[G] = NeutralFilterMode(),
 )(val blame: Blame[CallableFailure])(implicit val o: Origin)
     extends GlobalDeclaration[G] with AbstractMethod[G] with ProcedureImpl[G]
 @scopes[LabelDecl]
@@ -723,6 +725,7 @@ final class Predicate[G](
     val body: Option[Expr[G]],
     val threadLocal: Boolean = false,
     val inline: Boolean = false,
+    val filter: FilterMode[G] = NeutralFilterMode(),
 )(implicit val o: Origin)
     extends GlobalDeclaration[G] with AbstractPredicate[G] with PredicateImpl[G]
 final class Enum[G](val constants: Seq[EnumConstant[G]])(implicit val o: Origin)
@@ -760,6 +763,7 @@ final class InstanceFunction[G](
     val contract: ApplicableContract[G],
     val inline: Boolean,
     val threadLocal: Boolean = false,
+    val filter: FilterMode[G] = NeutralFilterMode(),
 )(val blame: Blame[ContractedFailure])(implicit val o: Origin)
     extends ClassDeclaration[G]
     with AbstractFunction[G]
@@ -773,6 +777,7 @@ final class Constructor[G](
     val body: Option[Statement[G]],
     val contract: ApplicableContract[G],
     val inline: Boolean = false,
+    val filter: FilterMode[G] = NeutralFilterMode(),
 )(val blame: Blame[CallableFailure])(implicit val o: Origin)
     extends ClassDeclaration[G] with AbstractMethod[G] with ConstructorImpl[G]
 @scopes[LabelDecl]
@@ -785,6 +790,7 @@ final class InstanceMethod[G](
     val contract: ApplicableContract[G],
     val inline: Boolean = false,
     val pure: Boolean = false,
+    val filter: FilterMode[G] = NeutralFilterMode(),
 )(val blame: Blame[CallableFailure])(implicit val o: Origin)
     extends ClassDeclaration[G]
     with AbstractMethod[G]
@@ -796,6 +802,7 @@ final class InstancePredicate[G](
     val body: Option[Expr[G]],
     val threadLocal: Boolean = false,
     val inline: Boolean = false,
+    val filter: FilterMode[G] = NeutralFilterMode(),
 )(implicit val o: Origin)
     extends ClassDeclaration[G]
     with AbstractPredicate[G]
@@ -817,6 +824,7 @@ final class InstanceOperatorFunction[G](
     val contract: ApplicableContract[G],
     val inline: Boolean,
     val threadLocal: Boolean = false,
+    val filter: FilterMode[G] = NeutralFilterMode(),
 )(val blame: Blame[ContractedFailure])(implicit val o: Origin)
     extends ClassDeclaration[G]
     with AbstractFunction[G]
@@ -829,6 +837,7 @@ final class InstanceOperatorMethod[G](
     val contract: ApplicableContract[G],
     val inline: Boolean = false,
     val pure: Boolean = false,
+    val filter: FilterMode[G] = NeutralFilterMode(),
 )(val blame: Blame[CallableFailure])(implicit val o: Origin)
     extends ClassDeclaration[G]
     with AbstractMethod[G]
@@ -901,7 +910,7 @@ sealed trait Applicable[G] extends ApplicableImpl[G] with Declaration[G]
 sealed trait InlineableApplicable[G]
     extends Applicable[G]
     with InlineableApplicableImpl[G]
-    with FocusApplicable[G]
+    with FilterApplicable[G]
 sealed trait AbstractPredicate[G]
     extends InlineableApplicable[G] with AbstractPredicateImpl[G]
 sealed trait ContractApplicable[G]
@@ -912,7 +921,19 @@ sealed trait AbstractMethod[G]
     extends ContractApplicable[G] with AbstractMethodImpl[G]
 sealed trait Field[G] extends FieldImpl[G]
 
-sealed trait FocusApplicable[G]
+sealed trait FilterApplicable[G] {
+  def filter: FilterMode[G]
+}
+
+@family
+sealed trait FilterMode[G] extends NodeFamily[G] with FilterModeImpl[G]
+case class Include[G]()(implicit val o: Origin = DiagnosticOrigin)
+    extends FilterMode[G] with IncludeImpl[G]
+case class Exclude[G]()(implicit val o: Origin = DiagnosticOrigin)
+    extends FilterMode[G] with ExcludeImpl[G]
+// Slightly longer name here to avoid claiming the keyword "Neutral", just Option[FilterMode] can be avoided.
+case class NeutralFilterMode[G]()(implicit val o: Origin = DiagnosticOrigin)
+    extends FilterMode[G] with NeutralFilterModeImpl[G]
 
 @family @scopes[Variable]
 @scopes[LocalHeapVariable]
@@ -3538,6 +3559,7 @@ final class LLVMSpecFunction[G](
     val contract: ApplicableContract[G],
     val inline: Boolean = false,
     val threadLocal: Boolean = false,
+    val filter: FilterMode[G] = NeutralFilterMode(),
 )(val blame: Blame[ContractedFailure])(implicit val o: Origin)
     extends LLVMCallable[G]
     with AbstractFunction[G]

--- a/src/col/vct/col/ast/declaration/category/AbstractPredicateImpl.scala
+++ b/src/col/vct/col/ast/declaration/category/AbstractPredicateImpl.scala
@@ -1,9 +1,10 @@
 package vct.col.ast.declaration.category
 
-import vct.col.ast.{AbstractPredicate, TResource, Type}
+import vct.col.ast.{AbstractPredicate, Expr, TResource, Type}
 
 trait AbstractPredicateImpl[G] extends InlineableApplicableImpl[G] {
   this: AbstractPredicate[G] =>
+  def body: Option[Expr[G]]
   def threadLocal: Boolean
   override def returnType: Type[G] = TResource()
 }

--- a/src/col/vct/col/ast/declaration/category/FilterApplicableImpl.scala
+++ b/src/col/vct/col/ast/declaration/category/FilterApplicableImpl.scala
@@ -1,0 +1,8 @@
+package vct.col.ast.declaration.category
+
+import vct.col.ast.{FilterApplicable, FilterMode}
+
+trait FilterApplicableImpl[G] extends ApplicableImpl[G] {
+  this: FilterApplicable[G] =>
+  def filter: FilterMode[G]
+}

--- a/src/col/vct/col/ast/declaration/category/InlineableApplicableImpl.scala
+++ b/src/col/vct/col/ast/declaration/category/InlineableApplicableImpl.scala
@@ -2,7 +2,7 @@ package vct.col.ast.declaration.category
 
 import vct.col.ast.InlineableApplicable
 
-trait InlineableApplicableImpl[G] extends ApplicableImpl[G] {
+trait InlineableApplicableImpl[G] extends FilterApplicableImpl[G] {
   this: InlineableApplicable[G] =>
   def inline: Boolean
 }

--- a/src/col/vct/col/ast/unsorted/AmbiguousFoldTargetImpl.scala
+++ b/src/col/vct/col/ast/unsorted/AmbiguousFoldTargetImpl.scala
@@ -1,10 +1,13 @@
 package vct.col.ast.unsorted
 
-import vct.col.ast.AmbiguousFoldTarget
+import vct.col.ast.{AmbiguousFoldTarget, ApplyAnyPredicate}
 import vct.col.ast.ops.AmbiguousFoldTargetOps
 import vct.col.print._
 
 trait AmbiguousFoldTargetImpl[G] extends AmbiguousFoldTargetOps[G] {
   this: AmbiguousFoldTarget[G] =>
   override def layout(implicit ctx: Ctx): Doc = target.show
+
+  // Not supported, until someone implements it
+  def apply: ApplyAnyPredicate[G] = ???
 }

--- a/src/col/vct/col/ast/unsorted/ExcludeImpl.scala
+++ b/src/col/vct/col/ast/unsorted/ExcludeImpl.scala
@@ -1,0 +1,10 @@
+package vct.col.ast.unsorted
+
+import vct.col.ast.{Exclude, FilterMode, Include}
+import vct.col.ast.ops.ExcludeOps
+import vct.col.print._
+
+trait ExcludeImpl[G] extends ExcludeOps[G] {
+  this: Exclude[G] =>
+  // override def layout(implicit ctx: Ctx): Doc = ???
+}

--- a/src/col/vct/col/ast/unsorted/FilterModeImpl.scala
+++ b/src/col/vct/col/ast/unsorted/FilterModeImpl.scala
@@ -1,0 +1,10 @@
+package vct.col.ast.unsorted
+
+import vct.col.ast.FilterMode
+import vct.col.ast.ops.FilterModeFamilyOps
+import vct.col.print._
+
+trait FilterModeImpl[G] extends FilterModeFamilyOps[G] {
+  this: FilterMode[G] =>
+  // override def layout(implicit ctx: Ctx): Doc = ???
+}

--- a/src/col/vct/col/ast/unsorted/FoldTargetImpl.scala
+++ b/src/col/vct/col/ast/unsorted/FoldTargetImpl.scala
@@ -1,6 +1,6 @@
 package vct.col.ast.unsorted
 
-import vct.col.ast.FoldTarget
+import vct.col.ast.{AbstractPredicate, ApplyAnyPredicate, FoldTarget}
 import vct.col.ast.node.NodeFamilyImpl
 import vct.col.ast.ops.FoldTargetFamilyOps
 import vct.col.print._
@@ -8,4 +8,5 @@ import vct.col.print._
 trait FoldTargetImpl[G] extends NodeFamilyImpl[G] with FoldTargetFamilyOps[G] {
   this: FoldTarget[G] =>
 
+  def apply: ApplyAnyPredicate[G]
 }

--- a/src/col/vct/col/ast/unsorted/IncludeImpl.scala
+++ b/src/col/vct/col/ast/unsorted/IncludeImpl.scala
@@ -1,0 +1,10 @@
+package vct.col.ast.unsorted
+
+import vct.col.ast.{Exclude, FilterMode, Include}
+import vct.col.ast.ops.IncludeOps
+import vct.col.print._
+
+trait IncludeImpl[G] extends IncludeOps[G] {
+  this: Include[G] =>
+  // override def layout(implicit ctx: Ctx): Doc = ???
+}

--- a/src/col/vct/col/ast/unsorted/NeutralFilterModeImpl.scala
+++ b/src/col/vct/col/ast/unsorted/NeutralFilterModeImpl.scala
@@ -1,0 +1,10 @@
+package vct.col.ast.unsorted
+
+import vct.col.ast.NeutralFilterMode
+import vct.col.ast.ops.NeutralFilterModeOps
+import vct.col.print._
+
+trait NeutralFilterModeImpl[G] extends NeutralFilterModeOps[G] {
+  this: NeutralFilterMode[G] =>
+  // override def layout(implicit ctx: Ctx): Doc = ???
+}

--- a/src/col/vct/col/typerules/CoercingRewriter.scala
+++ b/src/col/vct/col/typerules/CoercingRewriter.scala
@@ -364,6 +364,7 @@ abstract class CoercingRewriter[Pre <: Generation]()
       case node: ApplyAnyPredicate[Pre] => coerce(node)
       case node: FoldTarget[Pre] => coerce(node)
       case node: LLVMFloatType[Pre] => node
+      case node: FilterMode[Pre] => coerce(node)
     }
 
   def preCoerce(decl: Declaration[Pre]): Declaration[Pre] = decl
@@ -2973,4 +2974,5 @@ abstract class CoercingRewriter[Pre <: Generation]()
   def coerce(node: PVLEndpointName[Pre]): PVLEndpointName[Pre] = node
   def coerce(node: EndpointName[Pre]): EndpointName[Pre] = node
 
+  def coerce(node: FilterMode[Pre]): FilterMode[Pre] = node
 }

--- a/src/col/vct/col/util/AstBuildHelpers.scala
+++ b/src/col/vct/col/util/AstBuildHelpers.scala
@@ -372,6 +372,8 @@ object AstBuildHelpers {
     def rewrite(
         args: => Seq[Variable[Post]] = rewriter.variables
           .dispatch(predicate.args),
+        body: => Option[Expr[Post]] = predicate.body
+          .map((e: Expr[Pre]) => rewriter.dispatch(e)),
         inline: => Boolean = predicate.inline,
         threadLocal: => Boolean = predicate.threadLocal,
     ): AbstractPredicate[Post] =
@@ -379,12 +381,14 @@ object AstBuildHelpers {
         case predicate: Predicate[Pre] =>
           predicate.rewrite(
             args = args,
+            body = body,
             inline = Some(inline),
             threadLocal = Some(threadLocal),
           )
         case predicate: InstancePredicate[Pre] =>
           predicate.rewrite(
             args = args,
+            body = body,
             inline = Some(inline),
             threadLocal = Some(threadLocal),
           )

--- a/src/parsers/antlr4/SpecLexer.g4
+++ b/src/parsers/antlr4/SpecLexer.g4
@@ -58,6 +58,8 @@ VAL_STRING: 'string';
 VAL_PURE: 'pure';
 VAL_THREAD_LOCAL: 'thread_local';
 VAL_BIP_ANNOTATION: 'bip_annotation';
+VAL_INCLUDE: 'include';
+VAL_EXCLUDE: 'exclude';
 
 VAL_WITH: 'with';
 VAL_THEN: 'then';

--- a/src/parsers/antlr4/SpecParser.g4
+++ b/src/parsers/antlr4/SpecParser.g4
@@ -321,7 +321,7 @@ valKeywordNonExpr: (
  | VAL_RESOURCE | VAL_PROCESS | VAL_FRAC | VAL_ZFRAC | VAL_BOOL | VAL_REF | VAL_RATIONAL | VAL_SEQ | VAL_SET | VAL_BAG
  | VAL_POINTER | VAL_MAP | VAL_OPTION | VAL_EITHER | VAL_TUPLE | VAL_TYPE | VAL_ANY | VAL_NOTHING | VAL_STRING
  // Annotation keywords
- | VAL_PURE | VAL_THREAD_LOCAL | VAL_WITH | VAL_THEN | VAL_GIVEN | VAL_YIELDS | VAL_BIP_ANNOTATION
+ | VAL_PURE | VAL_THREAD_LOCAL | VAL_WITH | VAL_THEN | VAL_GIVEN | VAL_YIELDS | VAL_BIP_ANNOTATION | VAL_INCLUDE | VAL_EXCLUDE
  // Declaration keywords
  | VAL_AXIOM | VAL_MODEL | VAL_ADT | VAL_PROVER_TYPE | VAL_PROVER_FUNCTION
  // Contract clause keywords
@@ -415,7 +415,7 @@ valImpureDef
  ;
 
 valModifier
- : ('pure' | 'inline' | 'thread_local' | 'bip_annotation')
+ : ('pure' | 'inline' | 'thread_local' | 'bip_annotation' | 'include' | 'exclude')
  | langStatic # valStatic
  ;
 

--- a/src/parsers/vct/parsers/transform/PVLToCol.scala
+++ b/src/parsers/vct/parsers/transform/PVLToCol.scala
@@ -1032,6 +1032,8 @@ case class PVLToCol[G](
           case "thread_local" => collector.threadLocal += mod
           case "bip_annotation" =>
             fail(mod, "This modifier is not allowed here.")
+          case "include" => ???
+          case "exclude" => ???
         }
       case ValStatic(_) => collector.static += mod
     }

--- a/src/parsers/vct/parsers/transform/ToCol.scala
+++ b/src/parsers/vct/parsers/transform/ToCol.scala
@@ -130,6 +130,9 @@ abstract class ToCol[G](
     val static: mutable.ArrayBuffer[ParserRuleContext] = mutable.ArrayBuffer()
     val bipAnnotation: mutable.ArrayBuffer[ParserRuleContext] = mutable
       .ArrayBuffer()
+    val include: mutable.ArrayBuffer[ParserRuleContext] = mutable.ArrayBuffer()
+    val exclude: mutable.ArrayBuffer[ParserRuleContext] = mutable.ArrayBuffer()
+    // TODO (RR): Continue here. Need to extend modifierCollector a bit I think...
 
     def consume(buffer: mutable.ArrayBuffer[ParserRuleContext]): Boolean = {
       val result = buffer.nonEmpty
@@ -138,7 +141,8 @@ abstract class ToCol[G](
     }
 
     def nodes: Seq[ParserRuleContext] =
-      Seq(pure, inline, threadLocal, static, bipAnnotation).flatten
+      Seq(pure, inline, threadLocal, static, bipAnnotation, include, exclude)
+        .flatten
   }
 
   /** Used to convert ParserRuleContext nodes into origin implicitly

--- a/src/parsers/vct/parsers/transform/systemctocol/engine/ExpressionTransformer.java
+++ b/src/parsers/vct/parsers/transform/systemctocol/engine/ExpressionTransformer.java
@@ -22,10 +22,7 @@ import vct.parsers.transform.systemctocol.exceptions.UnsupportedException;
 import vct.parsers.transform.systemctocol.colmodel.COLClass;
 import vct.parsers.transform.systemctocol.colmodel.COLSystem;
 import vct.parsers.transform.systemctocol.colmodel.ProcessClass;
-import vct.parsers.transform.systemctocol.util.Constants;
-import vct.parsers.transform.systemctocol.util.GeneratedBlame;
-import vct.parsers.transform.systemctocol.util.OriGen;
-import vct.parsers.transform.systemctocol.util.Timing;
+import vct.parsers.transform.systemctocol.util.*;
 
 /*
 This class is responsible for translating SystemC intermediate representation expressions to either COL statements, if
@@ -1127,7 +1124,7 @@ public class ExpressionTransformer<T> {
                 new UnitAccountedPredicate<>(col_system.TRUE, OriGen.create()), col_system.TRUE, col_system.NO_SIGNALS,
                 col_system.NO_VARS, col_system.NO_VARS, Option.empty(), new GeneratedBlame<>(), OriGen.create());
         InstanceMethod<T> randomizer = new InstanceMethod<>(return_type, col_system.NO_VARS, col_system.NO_VARS, col_system.NO_VARS,
-                Option.empty(), contract, false, true, new GeneratedBlame<>(), OriGen.create(name));
+                Option.empty(), contract, false, true, AstHelpers.neutral(), new GeneratedBlame<>(), OriGen.create(name));
         newly_generated_methods.add(randomizer);
 
         // Return reference to the new method

--- a/src/parsers/vct/parsers/transform/systemctocol/engine/FunctionTransformer.java
+++ b/src/parsers/vct/parsers/transform/systemctocol/engine/FunctionTransformer.java
@@ -17,6 +17,7 @@ import vct.parsers.transform.systemctocol.exceptions.UnsupportedException;
 import vct.parsers.transform.systemctocol.colmodel.COLClass;
 import vct.parsers.transform.systemctocol.colmodel.COLSystem;
 import vct.parsers.transform.systemctocol.colmodel.ProcessClass;
+import vct.parsers.transform.systemctocol.util.AstHelpers;
 import vct.parsers.transform.systemctocol.util.GeneratedBlame;
 import vct.parsers.transform.systemctocol.util.OriGen;
 import vct.parsers.transform.systemctocol.util.Seqs;
@@ -91,7 +92,7 @@ public class FunctionTransformer<T> {
 
         // Create method
         InstanceMethod<T> new_method = new InstanceMethod<>(return_type, parameters, col_system.NO_VARS, col_system.NO_VARS,
-                Option.apply(body), contract, false, pure, new GeneratedBlame<>(), OriGen.create(function.getName()));
+                Option.apply(body), contract, false, pure, AstHelpers.neutral(), new GeneratedBlame<>(), OriGen.create(function.getName()));
 
         // Register method in COL system context and return
         col_system.add_instance_method(function, sc_inst, process, new_method);

--- a/src/parsers/vct/parsers/transform/systemctocol/engine/KnownTypeTransformer.java
+++ b/src/parsers/vct/parsers/transform/systemctocol/engine/KnownTypeTransformer.java
@@ -16,10 +16,7 @@ import vct.col.ref.LazyRef;
 import vct.col.ref.Ref;
 import vct.parsers.transform.systemctocol.exceptions.UnsupportedException;
 import vct.parsers.transform.systemctocol.colmodel.COLSystem;
-import vct.parsers.transform.systemctocol.util.Constants;
-import vct.parsers.transform.systemctocol.util.GeneratedBlame;
-import vct.parsers.transform.systemctocol.util.OriGen;
-import vct.parsers.transform.systemctocol.util.Seqs;
+import vct.parsers.transform.systemctocol.util.*;
 
 /**
  * Transforms an SCKnownType (i.e. a SystemC-predefined primitive channel instance) into a COL class. We currently
@@ -209,6 +206,7 @@ public class KnownTypeTransformer<T> {
         java.util.List<Expr<T>> comps = java.util.List.of(perm_fifo, fifo_not_null, perm_m, m_is_this, perm_buf, perm_read,
                 read_n_neg, read_in_bound, perm_written, buf_in_bound);
         return new InstancePredicate<>(col_system.NO_VARS, Option.apply(col_system.fold_star(comps)), false, true,
+                AstHelpers.neutral(),
                 OriGen.create(generate_class_name().toLowerCase() + "_permission_invariant"));
     }
 
@@ -337,6 +335,7 @@ public class KnownTypeTransformer<T> {
         ApplicableContract<T> contract = new ApplicableContract<>(precondition, postcondition, col_system.TRUE, col_system.NO_SIGNALS, col_system.NO_VARS,
                 col_system.NO_VARS, Option.empty(), new GeneratedBlame<>(), OriGen.create());
         return new InstanceMethod<>(t, col_system.NO_VARS, col_system.NO_VARS, col_system.NO_VARS, Option.empty(), contract, false, false,
+                AstHelpers.neutral(),
                 new GeneratedBlame<>(), OriGen.create("fifo_read"));
     }
 
@@ -408,6 +407,7 @@ public class KnownTypeTransformer<T> {
         ApplicableContract<T> contract = new ApplicableContract<>(precondition, postcondition, col_system.TRUE, col_system.NO_SIGNALS, col_system.NO_VARS,
                 col_system.NO_VARS, Option.empty(), new GeneratedBlame<>(), OriGen.create());
         return new InstanceMethod<>(col_system.T_VOID, params, col_system.NO_VARS, col_system.NO_VARS, Option.empty(), contract, false, false,
+                AstHelpers.neutral(),
                 new GeneratedBlame<>(), OriGen.create("fifo_write"));
     }
 
@@ -511,7 +511,9 @@ public class KnownTypeTransformer<T> {
         ApplicableContract<T> contract = new ApplicableContract<>(precondition, postcondition, col_system.TRUE, col_system.NO_SIGNALS,
                 col_system.NO_VARS, col_system.NO_VARS, Option.empty(), new GeneratedBlame<>(), OriGen.create());
         return new InstanceMethod<>(col_system.T_VOID, col_system.NO_VARS, col_system.NO_VARS, col_system.NO_VARS, Option.empty(),
-                contract, false, false, new GeneratedBlame<>(), OriGen.create("fifo_update"));
+                contract, false, false,
+                AstHelpers.neutral(),
+                new GeneratedBlame<>(), OriGen.create("fifo_update"));
     }
 
     /**
@@ -588,7 +590,9 @@ public class KnownTypeTransformer<T> {
         // Put it all together and return
         return new InstancePredicate<>(col_system.NO_VARS,
                 Option.apply(col_system.fold_star(java.util.List.of(perm_signal, signal_not_null, perm_m, m_is_this, perm_val, perm__val))),
-                false, true, OriGen.create(generate_class_name().toLowerCase() + "_permission_invariant"));
+                false, true,
+                AstHelpers.neutral(),
+                OriGen.create(generate_class_name().toLowerCase() + "_permission_invariant"));
     }
 
     /**
@@ -670,6 +674,7 @@ public class KnownTypeTransformer<T> {
         ApplicableContract<T> contract = new ApplicableContract<>(precondition, postcondition, col_system.TRUE, col_system.NO_SIGNALS, col_system.NO_VARS,
                 col_system.NO_VARS, Option.empty(), new GeneratedBlame<>(), OriGen.create());
         return new InstanceMethod<>(t, col_system.NO_VARS, col_system.NO_VARS, col_system.NO_VARS, Option.empty(), contract, false, false,
+                AstHelpers.neutral(),
                 new GeneratedBlame<>(), OriGen.create("signal_read"));
     }
 
@@ -727,7 +732,9 @@ public class KnownTypeTransformer<T> {
         ApplicableContract<T> contract = new ApplicableContract<>(precondition, postcondition, col_system.TRUE, col_system.NO_SIGNALS,
                 col_system.NO_VARS, col_system.NO_VARS, Option.empty(), new GeneratedBlame<>(), OriGen.create());
         return new InstanceMethod<>(col_system.T_VOID, params, col_system.NO_VARS, col_system.NO_VARS, Option.empty(), contract,
-                false, false, new GeneratedBlame<>(), OriGen.create("signal_write"));
+                false, false,
+                AstHelpers.neutral(),
+                new GeneratedBlame<>(), OriGen.create("signal_write"));
     }
 
     /**
@@ -800,7 +807,9 @@ public class KnownTypeTransformer<T> {
         ApplicableContract<T> contract = new ApplicableContract<>(precondition, postcondition, col_system.TRUE, col_system.NO_SIGNALS,
                 col_system.NO_VARS, col_system.NO_VARS, Option.empty(), new GeneratedBlame<>(), OriGen.create());
         return new InstanceMethod<>(col_system.T_VOID, col_system.NO_VARS, col_system.NO_VARS, col_system.NO_VARS, Option.empty(),
-                contract, false, false, new GeneratedBlame<>(), OriGen.create("signal_update"));
+                contract, false, false,
+                AstHelpers.neutral(),
+                new GeneratedBlame<>(), OriGen.create("signal_update"));
     }
 
     /**

--- a/src/parsers/vct/parsers/transform/systemctocol/engine/MainTransformer.java
+++ b/src/parsers/vct/parsers/transform/systemctocol/engine/MainTransformer.java
@@ -24,10 +24,7 @@ import vct.parsers.transform.systemctocol.colmodel.COLClass;
 import vct.parsers.transform.systemctocol.colmodel.COLSystem;
 import vct.parsers.transform.systemctocol.colmodel.ProcessClass;
 import vct.parsers.transform.systemctocol.colmodel.StateClass;
-import vct.parsers.transform.systemctocol.util.Constants;
-import vct.parsers.transform.systemctocol.util.GeneratedBlame;
-import vct.parsers.transform.systemctocol.util.OriGen;
-import vct.parsers.transform.systemctocol.util.Seqs;
+import vct.parsers.transform.systemctocol.util.*;
 
 /**
  * Generates a Main class encoding the SystemC scheduler. The Main class contains all class instances from the SystemC
@@ -255,7 +252,7 @@ public class MainTransformer<T> {
         // Put it all together and register the predicate in the COL system
         java.util.List<Expr<T>> conditions = java.util.List.of(update_perm, update_length);
         update_permission_invariant = new InstancePredicate<>(col_system.NO_VARS, Option.apply(col_system.fold_star(conditions)),
-                false, true, OriGen.create("update_permission_invariant"));
+                false, true, AstHelpers.neutral(), OriGen.create("update_permission_invariant"));
         col_system.set_update_perms(update_permission_invariant);
     }
 
@@ -314,7 +311,9 @@ public class MainTransformer<T> {
         // Put it all together and register the invariant in the COL system context
         java.util.List<Expr<T>> conditions = java.util.List.of(apply_update_perms, perm_to_proc, proc_length, perm_to_ev, ev_length, forall);
         scheduler_invariant = new InstancePredicate<>(col_system.NO_VARS, Option.apply(col_system.fold_star(conditions)),
-                false, true, OriGen.create("scheduler_invariant"));
+                false, true,
+                AstHelpers.neutral(),
+                OriGen.create("scheduler_invariant"));
         col_system.set_scheduler_perms(scheduler_invariant);
     }
 
@@ -346,7 +345,7 @@ public class MainTransformer<T> {
 
         // Put it all together and register the invariant in the COL system context
         parameter_invariant = new InstancePredicate<>(col_system.NO_VARS, Option.apply(col_system.fold_star(conditions)),
-                false, true, OriGen.create("parameter_invariant"));
+                false, true, AstHelpers.neutral(), OriGen.create("parameter_invariant"));
         col_system.set_parameter_perms(parameter_invariant);
     }
 
@@ -394,7 +393,7 @@ public class MainTransformer<T> {
 
         // Put the predicate together and register it in the COL system context
         global_invariant = new InstancePredicate<>(col_system.NO_VARS, Option.apply(col_system.fold_star(conditions)),
-                false, true, OriGen.create("global_invariant"));
+                false, true, AstHelpers.neutral(), OriGen.create("global_invariant"));
         col_system.set_global_perms(global_invariant);
     }
 
@@ -810,7 +809,7 @@ public class MainTransformer<T> {
         // Generate contract and method and return
         ApplicableContract<T> contract = col_system.to_applicable_contract(col_system.TRUE, col_system.fold_star(ensures));
         return new InstanceMethod<>(col_system.T_INT, params, col_system.NO_VARS, col_system.NO_VARS, Option.empty(), contract,
-                false, true, new GeneratedBlame<>(), OriGen.create("find_minimum_advance"));
+                false, true, AstHelpers.neutral(), new GeneratedBlame<>(), OriGen.create("find_minimum_advance"));
     }
 
     /**
@@ -873,7 +872,7 @@ public class MainTransformer<T> {
         // Generate contract and method and return
         ApplicableContract<T> contract = col_system.to_applicable_contract(context, col_system.fold_star(ensures));
         return new InstanceMethod<>(col_system.T_VOID, params, col_system.NO_VARS, col_system.NO_VARS, Option.empty(), contract,
-                false, false, new GeneratedBlame<>(), OriGen.create("update_events"));
+                false, false, AstHelpers.neutral(), new GeneratedBlame<>(), OriGen.create("update_events"));
     }
 
     /**
@@ -1039,7 +1038,7 @@ public class MainTransformer<T> {
      */
     private InstanceMethod<T> create_abstract_method(ApplicableContract<T> contract, String method_name) {
         return new InstanceMethod<>(col_system.T_VOID, col_system.NO_VARS, col_system.NO_VARS, col_system.NO_VARS, Option.empty(),
-                contract, false, false, new GeneratedBlame<>(), OriGen.create(method_name));
+                contract, false, false, AstHelpers.neutral(), new GeneratedBlame<>(), OriGen.create(method_name));
     }
 
     /**
@@ -1052,7 +1051,7 @@ public class MainTransformer<T> {
         Expr<T> context = create_scheduler_contract();
         ApplicableContract<T> contract = col_system.to_applicable_contract(context, context);
         scheduler = new InstanceMethod<>(col_system.T_VOID, col_system.NO_VARS, col_system.NO_VARS, col_system.NO_VARS,
-                Option.apply(body), contract, false, false, new GeneratedBlame<>(), OriGen.create("main"));
+                Option.apply(body), contract, false, false, AstHelpers.neutral(), new GeneratedBlame<>(), OriGen.create("main"));
     }
 
     /**

--- a/src/parsers/vct/parsers/transform/systemctocol/util/AstHelpers.scala
+++ b/src/parsers/vct/parsers/transform/systemctocol/util/AstHelpers.scala
@@ -1,0 +1,9 @@
+package vct.parsers.transform.systemctocol.util
+
+import vct.col.ast.{FilterMode, Include, Exclude, NeutralFilterMode}
+
+object AstHelpers {
+  def neutral[G](): FilterMode[G] = NeutralFilterMode()
+  def include[G](): FilterMode[G] = Include()
+  def exclude[G](): FilterMode[G] = Exclude()
+}

--- a/src/rewrite/vct/rewrite/FilterDeclarations.scala
+++ b/src/rewrite/vct/rewrite/FilterDeclarations.scala
@@ -35,6 +35,7 @@ import vct.col.ast.{
   NeutralFilterMode,
   Predicate,
   PredicateApply,
+  PredicateApplyExpr,
   Procedure,
   ProcedureInvocation,
   Program,
@@ -57,7 +58,7 @@ import scala.collection.mutable
     In addition, I don't think removing an ADT can enable removing of other callables (method, predicate, etc.)
     So optimizing unused ADTs away should be a separate pass (or triggered by a --minimize flag or smth)
 
-   TODO: Add a pass that optimizes unused ADTs away
+   TODO: Add a pass that optimizes unused ADTs away, and also unused fields
  */
 case object FilterDeclarations extends RewriterBuilder {
   override def key: String = "filterDeclarations"
@@ -86,12 +87,10 @@ case object FilterDeclarations extends RewriterBuilder {
     // Returns true if there are Include nodes in the program, and hence filtering needs to be done
     def rewrite(program: Program[Pre]): (Program[Post], Boolean) = {
       val excluded = program.collect {
-        case app: FilterApplicable[Pre] if app.filterMode == Some(Exclude()) =>
-          app
+        case app: FilterApplicable[Pre] if app.filter == Exclude[Pre]() => app
       }
       val included = program.collect {
-        case app: FilterApplicable[Pre] if app.filterMode == Some(Include()) =>
-          app
+        case app: FilterApplicable[Pre] if app.filter == Include[Pre]() => app
       }
 
       (included, excluded) match {
@@ -146,10 +145,10 @@ case object FilterDeclarations extends RewriterBuilder {
   def getUsedFilterApplicables[G <: Generation](
       p: Program[G]
   ): Set[FilterApplicable[G]] = {
-    val collected = ScopedStack[mutable.Set[Declaration[G]]]()
+    val collected = ScopedStack[mutable.Set[FilterApplicable[G]]]()
 
     case class Collector() extends Rewriter[G] {
-      def decls: mutable.Set[Declaration[G]] = collected.top
+      def decls: mutable.Set[FilterApplicable[G]] = collected.top
 
       override def dispatch(expr: Expr[G]): Expr[Rewritten[G]] = {
         expr match {
@@ -160,11 +159,8 @@ case object FilterDeclarations extends RewriterBuilder {
           case fi: FunctionInvocation[G] => decls.add(fi.ref.decl)
           case ipi: MethodInvocation[G] => decls.add(ipi.ref.decl)
           case ifi: InstanceFunctionInvocation[G] => decls.add(ifi.ref.decl)
-          case pa: PredicateApply[G] => decls.add(pa.ref.decl)
-          case pa: InstancePredicateApply[G] => decls.add(pa.ref.decl)
-          case afi: ADTFunctionInvocation[G] => decls.add(afi.ref.decl)
+          case app: PredicateApplyExpr[G] => decls.add(app.apply.ref.decl)
           case inv: ConstructorInvocation[G] => decls.add(inv.ref.decl)
-          case Deref(_, r) => decls.add(r.decl)
           case _ =>
         }
         super.dispatch(expr)
@@ -184,16 +180,16 @@ case object FilterDeclarations extends RewriterBuilder {
       override def dispatch(declaration: Declaration[G]): Unit =
         declaration match {
           case app: FilterApplicable[G] =>
-            val newDecls = mutable.Set[Declaration[G]]()
-            collected.having(newDecls) { super.dispatch(declaration) }
+            val newDecls = mutable.Set[FilterApplicable[G]]()
+            collected.having(newDecls) { super.dispatch(app) }
             // A decl using itself should not be counted as an actual use
-            newDecls.remove(declaration)
+            newDecls.remove(app)
             decls.addAll(newDecls)
           case d => super.dispatch(d)
         }
     }
 
-    val decls = mutable.Set[Declaration[G]]()
+    val decls = mutable.Set[FilterApplicable[G]]()
     collected.having(decls) { Collector().dispatch(p) }
     decls.toSet
   }
@@ -227,9 +223,12 @@ case object FilterDeclarations extends RewriterBuilder {
       getUsedFilterApplicables(abstractProgram).union(includedAbstract)
     )
     val reducedProgram = removeUnused.dispatch(abstractProgram)
+    val includedReduced = includedAbstract.map(
+      removeUnused.anySucc[FilterApplicable[Rewritten[Rewritten[G]]]](_).decl
+    )
 
     if (removeUnused.dropped.nonEmpty) {
-      filterAndAbstract(reducedProgram, includedAbstract)
+      filterAndAbstract(reducedProgram, includedReduced)
     } else { reducedProgram }
   }
 }
@@ -243,9 +242,10 @@ case class FilterDeclarations[Pre <: Generation]()
     // If there are no includes, stop early
     if (!containsInclude) { return includeOnlyProgram }
 
-    val includes = includeOnlyProgram.collect {
-      case app: FilterApplicable[Post] if app.filter == Include[Post]() => app
-    }
+    val includes =
+      includeOnlyProgram.collect {
+        case app: FilterApplicable[Post] if app.filter == Include[Post]() => app
+      }.toSet
 
     val filteredProgram = filterAndAbstract(includeOnlyProgram, includes)
 

--- a/src/rewrite/vct/rewrite/FilterDeclarations.scala
+++ b/src/rewrite/vct/rewrite/FilterDeclarations.scala
@@ -1,0 +1,273 @@
+package vct.rewrite
+
+import com.typesafe.scalalogging.LazyLogging
+import hre.util.ScopedStack
+import vct.col.ast.RewriteHelpers.{RewriteProcedure, RewriteProgram}
+import vct.col.ast.{
+  ADTFunctionInvocation,
+  AbstractMethod,
+  AbstractPredicate,
+  ApplicableContract,
+  AxiomaticDataType,
+  ContractApplicable,
+  Declaration,
+  Deref,
+  Expr,
+  FilterFocus,
+  FilterIgnore,
+  FilterIndicator,
+  Fold,
+  Function,
+  FunctionInvocation,
+  InstanceField,
+  InstanceFunction,
+  InstanceFunctionInvocation,
+  InstanceMethod,
+  InstancePredicate,
+  InstancePredicateApply,
+  InvokeMethod,
+  InvokeProcedure,
+  MethodInvocation,
+  Predicate,
+  PredicateApply,
+  Procedure,
+  ProcedureInvocation,
+  Program,
+  Statement,
+  TAxiomatic,
+  Type,
+  Unfold,
+  Unfolding,
+}
+import vct.col.origin.{DiagnosticOrigin, Origin}
+import vct.col.ref.Ref
+import vct.col.rewrite.FilterDeclarations.{filterAndAbstract, ignoreToFocus}
+import vct.col.util.AstBuildHelpers.{MethodBuildHelpers, PredicateBuildHelpers}
+
+import scala.collection.mutable
+
+case object FilterDeclarations extends RewriterBuilder {
+  override def key: String = "filterDeclarations"
+
+  override def desc: String = "Filter focused declarations appropriately"
+
+  // Returns true if focusing work needs to be done
+  case class IgnoreToFocus[Pre <: Generation]() extends Rewriter[Pre]() {
+    var containsFocus = false
+    override def dispatch(p: Program[Pre]): Program[Post] = {
+      val ignored = p.collect {
+        case FilterIndicator(Ref(decl), FilterIgnore()) => decl
+      }
+      val focused = p.collect {
+        case FilterIndicator(Ref(decl), FilterFocus()) => decl
+      }
+
+      // Focus overrides ignore, so only need to do work if there are only ignores
+      if (focused.isEmpty && ignored.nonEmpty) {
+        containsFocus = true
+
+        val newFocused =
+          p.collect {
+            // Only select contractapplicables here, not sure how to handle non-contractapplicable decls
+            case ca: ContractApplicable[Pre] if !ignored.contains(ca) => ca
+          }.toSet
+
+        p.rewrite(globalDeclarations.collect {
+          p.declarations.foreach(dispatch(_))
+          newFocused.foreach { ca: ContractApplicable[Pre] =>
+            implicit val o = DiagnosticOrigin
+            globalDeclarations.declare(FilterIndicator(
+              anySucc[Declaration[Post]](ca.asInstanceOf[Declaration[Pre]]),
+              FilterFocus(),
+            ))
+          }
+        }._1)
+      } else {
+        containsFocus = focused.nonEmpty
+        // Sneakily use the old program
+        p.asInstanceOf[Program[Post]]
+      }
+    }
+  }
+
+  def ignoreToFocus[G <: Generation](
+      p: Program[G]
+  ): (Program[Rewritten[G]], Boolean) = {
+    val pass = IgnoreToFocus[G]()
+    (pass.dispatch(p), pass.containsFocus)
+  }
+  case class AbstractMaker[Pre <: Generation](
+      focusTargets: Seq[Declaration[Pre]]
+  ) extends Rewriter[Pre] {
+    var program: Program[Pre] = null
+
+    lazy val openedPredicates: Set[AbstractPredicate[Pre]] =
+      program.collect {
+        case Unfold(e) => getPredicate(e)
+        case Fold(e) => getPredicate(e)
+        case Unfolding(e, _) => getPredicate(e)
+      }.toSet
+
+    def getPredicate(e: Expr[Pre]): AbstractPredicate[Pre] =
+      e match {
+        case InstancePredicateApply(_, Ref(p), _, _) => p
+        case PredicateApply(Ref(p), _, _) => p
+      }
+
+    override def dispatch(decl: Declaration[Pre]): Unit = {
+      decl match {
+        case m: AbstractMethod[Pre] if !focusTargets.contains(m) =>
+          allScopes.anySucceedOnly(m, m.rewrite(body = None))
+        case p: AbstractPredicate[Pre] if !openedPredicates.contains(p) =>
+          allScopes.anySucceedOnly(p, p.rewrite(body = None))
+        case d => super.dispatch(d)
+      }
+    }
+
+    override def dispatch(program: Program[Pre]): Program[Post] = {
+      this.program = program
+      rewriteDefault(program)
+    }
+  }
+
+  // Get all predicate usages, method usages, field usages, adt usages, adt function usages
+  def getUsedDecls[G <: Generation](p: Program[G]): Seq[Declaration[G]] = {
+    val collected = ScopedStack[mutable.Set[Declaration[G]]]()
+
+    case class Collector() extends Rewriter[G] {
+      override def dispatch(expr: Expr[G]): Expr[Rewritten[G]] = {
+        expr match {
+          case pi: ProcedureInvocation[G] => collected.top.add(pi.ref.decl)
+          case fi: FunctionInvocation[G] => collected.top.add(fi.ref.decl)
+          case ipi: MethodInvocation[G] => collected.top.add(ipi.ref.decl)
+          case ifi: InstanceFunctionInvocation[G] =>
+            collected.top.add(ifi.ref.decl)
+          case pa: PredicateApply[G] => collected.top.add(pa.ref.decl)
+          case pa: InstancePredicateApply[G] => collected.top.add(pa.ref.decl)
+          case afi: ADTFunctionInvocation[G] => collected.top.add(afi.ref.decl)
+          case Deref(_, r) => collected.top.add(r.decl)
+          case _ =>
+        }
+        super.dispatch(expr)
+      }
+
+      override def dispatch(t: Type[G]): Type[Rewritten[G]] = {
+        t match {
+          case TAxiomatic(r, _) => collected.top.add(r.decl)
+          case _ =>
+        }
+        super.dispatch(t)
+      }
+
+      override def dispatch(s: Statement[G]): Statement[Rewritten[G]] = {
+        s match {
+          case ip: InvokeProcedure[G] => collected.top.add(ip.ref.decl)
+          case ip: InvokeMethod[G] => collected.top.add(ip.ref.decl)
+          case _ =>
+        }
+        super.dispatch(s)
+      }
+
+      override def dispatch(decl: Declaration[G]): Unit =
+        decl match {
+          case _: Procedure[G] | _: Predicate[G] | _: Function[G] |
+              _: AxiomaticDataType[G] | _: InstanceMethod[G] |
+              _: InstanceFunction[G] =>
+            val newCollected = mutable.Set[Declaration[G]]()
+            collected.having(newCollected) { super.dispatch(decl) }
+            // A decl using itself should not be counted as an actual use
+            newCollected.remove(decl)
+            // Same for an adt using its own functions
+            decl match {
+              case a: AxiomaticDataType[G] =>
+                a.decls.foreach(f => newCollected.remove(f))
+              case _ =>
+            }
+            collected.top.addAll(newCollected)
+          case d => super.dispatch(d)
+        }
+    }
+
+    val res = mutable.Set[Declaration[G]]()
+    collected.having(res) { Collector().dispatch(p) }
+    res.toSeq
+  }
+
+  case class RemoveUnused[Pre <: Generation](used: Seq[Declaration[Pre]])
+      extends Rewriter[Pre] with LazyLogging {
+    var dropped: mutable.Set[Declaration[Pre]] = mutable.Set()
+
+    def adtIsUsed(a: AxiomaticDataType[Pre]): Boolean =
+      used.contains(a) || a.decls.exists(used.contains(_))
+
+    override def dispatch(decl: Declaration[Pre]): Unit = {
+      decl match {
+        case _: Procedure[Pre] | _: Function[Pre] | _: Predicate[Pre] |
+            _: InstancePredicate[Pre] | _: InstanceField[Pre] |
+            _: InstanceMethod[Pre] | _: InstanceFunction[Pre]
+            if !used.contains(decl) =>
+          decl.drop()
+          dropped.add(decl)
+        case a: AxiomaticDataType[Pre] if !adtIsUsed(a) =>
+          a.drop()
+          a.decls.foreach({ d => d.drop(); dropped.add(d) })
+          dropped.add(decl)
+        case _ => rewriteDefault(decl)
+      }
+    }
+  }
+
+  def filterAndAbstract[G <: Generation](
+      p: Program[G],
+      inputFocused: Seq[ContractApplicable[G]],
+  ): (Program[Rewritten[G]], Seq[Declaration[_]]) = {
+    val am = AbstractMaker(inputFocused)
+    var program = am.dispatch(p)
+    var focused = inputFocused
+      .map(am.anySucc[Declaration[Rewritten[G]]](_).decl)
+    var dropped: Seq[Declaration[_]] = Nil
+    var totalDropped: Seq[Declaration[_]] = Nil
+
+    do {
+      val ru = RemoveUnused[Rewritten[G]](getUsedDecls(program) ++ focused)
+      val reducedProgram = ru.dispatch(program)
+      program = reducedProgram.asInstanceOf[Program[Rewritten[G]]]
+      focused = focused
+        .map(ru.anySucc[Declaration[Rewritten[Rewritten[G]]]](_).decl)
+        .asInstanceOf[Seq[Declaration[Rewritten[G]]]]
+      dropped = ru.dropped.toSeq
+      totalDropped ++= dropped
+    } while (dropped.nonEmpty)
+
+    (program, totalDropped)
+  }
+}
+
+case class FilterDeclarations[Pre <: Generation]()
+    extends Rewriter[Pre]() with LazyLogging {
+  override def dispatch(program: Program[Pre]): Program[Post] = {
+    // Turn all ignore directives into inverted focus directives
+    val (focusedProgram, containsFocus) = ignoreToFocus[Pre](program)
+
+    if (!containsFocus) { return focusedProgram }
+
+    val focused = focusedProgram.collect {
+      case FilterIndicator(
+            Ref(decl: ContractApplicable[Post]),
+            FilterFocus(),
+          ) =>
+        decl
+    }
+
+    val (filteredProgram, dropped) = filterAndAbstract[Post](
+      focusedProgram,
+      focused,
+    )
+
+    if (dropped.nonEmpty) {
+      logger.info(s"Dropped ${dropped.length} declarations")
+    }
+
+    filteredProgram.asInstanceOf[Program[Post]]
+  }
+}

--- a/src/rewrite/vct/rewrite/FilterDeclarations.scala
+++ b/src/rewrite/vct/rewrite/FilterDeclarations.scala
@@ -2,7 +2,6 @@ package vct.rewrite
 
 import com.typesafe.scalalogging.LazyLogging
 import hre.util.ScopedStack
-import vct.col.ast.RewriteHelpers.{RewriteProcedure, RewriteProgram}
 import vct.col.ast.{
   ADTFunctionInvocation,
   AbstractMethod,
@@ -12,13 +11,15 @@ import vct.col.ast.{
   ContractApplicable,
   Declaration,
   Deref,
+  Exclude,
   Expr,
-  FilterFocus,
-  FilterIgnore,
-  FilterIndicator,
+  FilterApplicable,
+  FilterMode,
   Fold,
   Function,
   FunctionInvocation,
+  Include,
+  InlineableApplicable,
   InstanceField,
   InstanceFunction,
   InstanceFunctionInvocation,
@@ -42,60 +43,70 @@ import vct.col.ast.{
 import vct.col.origin.{DiagnosticOrigin, Origin}
 import vct.col.ref.Ref
 import vct.col.rewrite.FilterDeclarations.{filterAndAbstract, ignoreToFocus}
+import vct.col.rewrite.{Generation, Rewriter, RewriterBuilder, Rewritten}
 import vct.col.util.AstBuildHelpers.{MethodBuildHelpers, PredicateBuildHelpers}
+import vct.rewrite.FilterDeclarations.toIncludeOnly
 
 import scala.collection.mutable
 
 case object FilterDeclarations extends RewriterBuilder {
   override def key: String = "filterDeclarations"
 
-  override def desc: String = "Filter focused declarations appropriately"
+  override def desc: String =
+    "Filter declarations based on inclusion/exclusion attributes"
 
-  // Returns true if focusing work needs to be done
-  case class IgnoreToFocus[Pre <: Generation]() extends Rewriter[Pre]() {
+  case class InvertFilterModes[Pre <: Generation]() extends Rewriter[Pre]() {
+    override def dispatch(filterMode: FilterMode[Pre]): FilterMode[Post] =
+      filterMode match {
+        case Include() => Exclude()(filterMode.o)
+        case Exclude() => Include()(filterMode.o)
+        case _ => filterMode.rewriteDefault()
+      }
+  }
+
+  case class DropExcludes[Pre <: Generation]() extends Rewriter[Pre]() {
+    override def dispatch(filterMode: FilterMode[Pre]): FilterMode[Post] =
+      filterMode match {
+        case Exclude() => NeutralFilterMode()
+        case _ => filterMode.rewriteDefault()
+      }
+  }
+
+  case class ToIncludeOnly[Pre <: Generation]() extends Rewriter[Pre]() {
     var containsFocus = false
-    override def dispatch(p: Program[Pre]): Program[Post] = {
-      val ignored = p.collect {
-        case FilterIndicator(Ref(decl), FilterIgnore()) => decl
+    // Returns true if there are Include nodes in the program, and hence filtering needs to be done
+    def rewrite(program: Program[Pre]): (Program[Post], Boolean) = {
+      val excluded = program.collect {
+        case app: FilterApplicable[Pre] if app.filterMode == Some(Exclude()) =>
+          app
       }
-      val focused = p.collect {
-        case FilterIndicator(Ref(decl), FilterFocus()) => decl
+      val included = program.collect {
+        case app: FilterApplicable[Pre] if app.filterMode == Some(Include()) =>
+          app
       }
 
-      // Focus overrides ignore, so only need to do work if there are only ignores
-      if (focused.isEmpty && ignored.nonEmpty) {
-        containsFocus = true
-
-        val newFocused =
-          p.collect {
-            // Only select contractapplicables here, not sure how to handle non-contractapplicable decls
-            case ca: ContractApplicable[Pre] if !ignored.contains(ca) => ca
-          }.toSet
-
-        p.rewrite(globalDeclarations.collect {
-          p.declarations.foreach(dispatch(_))
-          newFocused.foreach { ca: ContractApplicable[Pre] =>
-            implicit val o = DiagnosticOrigin
-            globalDeclarations.declare(FilterIndicator(
-              anySucc[Declaration[Post]](ca.asInstanceOf[Declaration[Pre]]),
-              FilterFocus(),
-            ))
-          }
-        }._1)
-      } else {
-        containsFocus = focused.nonEmpty
-        // Sneakily use the old program
-        p.asInstanceOf[Program[Post]]
+      (included, excluded) match {
+        // No includes, excludes, program is in include-only form. Nothing to transform
+        case (Seq(), Seq()) => (program.asInstanceOf[Program[Post]], false)
+        // Only includes: program is already in include-only form. Nothing to transform
+        case (includes, Seq()) => (program.asInstanceOf[Program[Post]], true)
+        // Only ignores: invert filtermodes to "include", to only have includes of all non-annotated declarations
+        case (Seq(), ignored) => (InvertFilterModes().dispatch(program), true)
+        // Both includes/excludes: just drop the excludes, as the includes will trigger deletion of everything else
+        // In theory the excludes could be left in. However, the invariant that after this pass there are only includes
+        // and neutrals is nice.
+        case (includes, excludes) => (DropExcludes().dispatch(program), true)
       }
     }
   }
 
-  def ignoreToFocus[G <: Generation](
+  def toIncludeOnly[G <: Generation](
       p: Program[G]
   ): (Program[Rewritten[G]], Boolean) = {
-    val pass = IgnoreToFocus[G]()
+    val pass = ToIncludeOnly[G]()
     (pass.dispatch(p), pass.containsFocus)
   }
+
   case class AbstractMaker[Pre <: Generation](
       focusTargets: Seq[Declaration[Pre]]
   ) extends Rewriter[Pre] {
@@ -126,7 +137,7 @@ case object FilterDeclarations extends RewriterBuilder {
 
     override def dispatch(program: Program[Pre]): Program[Post] = {
       this.program = program
-      rewriteDefault(program)
+      program.rewriteDefault()
     }
   }
 
@@ -246,10 +257,11 @@ case object FilterDeclarations extends RewriterBuilder {
 case class FilterDeclarations[Pre <: Generation]()
     extends Rewriter[Pre]() with LazyLogging {
   override def dispatch(program: Program[Pre]): Program[Post] = {
-    // Turn all ignore directives into inverted focus directives
-    val (focusedProgram, containsFocus) = ignoreToFocus[Pre](program)
+    // Remove exclude directions by making everything else include
+    val (includeOnlyProgram, containsInclude) = toIncludeOnly[Pre](program)
 
-    if (!containsFocus) { return focusedProgram }
+    // If there are no includes, stop early
+    if (!containsInclude) { return includeOnlyProgram }
 
     val focused = focusedProgram.collect {
       case FilterIndicator(

--- a/src/rewrite/vct/rewrite/FilterDeclarations.scala
+++ b/src/rewrite/vct/rewrite/FilterDeclarations.scala
@@ -8,6 +8,7 @@ import vct.col.ast.{
   AbstractPredicate,
   ApplicableContract,
   AxiomaticDataType,
+  ConstructorInvocation,
   ContractApplicable,
   Declaration,
   Deref,
@@ -16,6 +17,7 @@ import vct.col.ast.{
   FilterApplicable,
   FilterMode,
   Fold,
+  FoldTarget,
   Function,
   FunctionInvocation,
   Include,
@@ -26,9 +28,11 @@ import vct.col.ast.{
   InstanceMethod,
   InstancePredicate,
   InstancePredicateApply,
+  InvokeConstructor,
   InvokeMethod,
   InvokeProcedure,
   MethodInvocation,
+  NeutralFilterMode,
   Predicate,
   PredicateApply,
   Procedure,
@@ -42,13 +46,19 @@ import vct.col.ast.{
 }
 import vct.col.origin.{DiagnosticOrigin, Origin}
 import vct.col.ref.Ref
-import vct.col.rewrite.FilterDeclarations.{filterAndAbstract, ignoreToFocus}
 import vct.col.rewrite.{Generation, Rewriter, RewriterBuilder, Rewritten}
 import vct.col.util.AstBuildHelpers.{MethodBuildHelpers, PredicateBuildHelpers}
-import vct.rewrite.FilterDeclarations.toIncludeOnly
+import vct.rewrite.FilterDeclarations.{filterAndAbstract, toIncludeOnly}
 
 import scala.collection.mutable
 
+/* TODO: Here ADTs are handled specially, such that they are removed if they are unused.
+    This is not ideal, as ADT axioms might still influence program verification.
+    In addition, I don't think removing an ADT can enable removing of other callables (method, predicate, etc.)
+    So optimizing unused ADTs away should be a separate pass (or triggered by a --minimize flag or smth)
+
+   TODO: Add a pass that optimizes unused ADTs away
+ */
 case object FilterDeclarations extends RewriterBuilder {
   override def key: String = "filterDeclarations"
 
@@ -73,7 +83,6 @@ case object FilterDeclarations extends RewriterBuilder {
   }
 
   case class ToIncludeOnly[Pre <: Generation]() extends Rewriter[Pre]() {
-    var containsFocus = false
     // Returns true if there are Include nodes in the program, and hence filtering needs to be done
     def rewrite(program: Program[Pre]): (Program[Post], Boolean) = {
       val excluded = program.collect {
@@ -95,39 +104,30 @@ case object FilterDeclarations extends RewriterBuilder {
         // Both includes/excludes: just drop the excludes, as the includes will trigger deletion of everything else
         // In theory the excludes could be left in. However, the invariant that after this pass there are only includes
         // and neutrals is nice.
-        case (includes, excludes) => (DropExcludes().dispatch(program), true)
+        case (_, _) => (DropExcludes().dispatch(program), true)
       }
     }
   }
 
   def toIncludeOnly[G <: Generation](
       p: Program[G]
-  ): (Program[Rewritten[G]], Boolean) = {
-    val pass = ToIncludeOnly[G]()
-    (pass.dispatch(p), pass.containsFocus)
-  }
+  ): (Program[Rewritten[G]], Boolean) = ToIncludeOnly[G]().rewrite(p)
 
   case class AbstractMaker[Pre <: Generation](
-      focusTargets: Seq[Declaration[Pre]]
+      includes: Set[FilterApplicable[Pre]]
   ) extends Rewriter[Pre] {
     var program: Program[Pre] = null
 
     lazy val openedPredicates: Set[AbstractPredicate[Pre]] =
       program.collect {
-        case Unfold(e) => getPredicate(e)
-        case Fold(e) => getPredicate(e)
-        case Unfolding(e, _) => getPredicate(e)
+        case Unfold(e) => e.apply.ref.decl
+        case Fold(e) => e.apply.ref.decl
+        case Unfolding(e, _) => e.apply.ref.decl
       }.toSet
-
-    def getPredicate(e: Expr[Pre]): AbstractPredicate[Pre] =
-      e match {
-        case InstancePredicateApply(_, Ref(p), _, _) => p
-        case PredicateApply(Ref(p), _, _) => p
-      }
 
     override def dispatch(decl: Declaration[Pre]): Unit = {
       decl match {
-        case m: AbstractMethod[Pre] if !focusTargets.contains(m) =>
+        case m: AbstractMethod[Pre] if !includes.contains(m) =>
           allScopes.anySucceedOnly(m, m.rewrite(body = None))
         case p: AbstractPredicate[Pre] if !openedPredicates.contains(p) =>
           allScopes.anySucceedOnly(p, p.rewrite(body = None))
@@ -142,115 +142,95 @@ case object FilterDeclarations extends RewriterBuilder {
   }
 
   // Get all predicate usages, method usages, field usages, adt usages, adt function usages
-  def getUsedDecls[G <: Generation](p: Program[G]): Seq[Declaration[G]] = {
+  // Messy because usages internal to the type (e.g. using an adt function in an axiom) should be ignored
+  def getUsedFilterApplicables[G <: Generation](
+      p: Program[G]
+  ): Set[FilterApplicable[G]] = {
     val collected = ScopedStack[mutable.Set[Declaration[G]]]()
 
     case class Collector() extends Rewriter[G] {
+      def decls: mutable.Set[Declaration[G]] = collected.top
+
       override def dispatch(expr: Expr[G]): Expr[Rewritten[G]] = {
         expr match {
-          case pi: ProcedureInvocation[G] => collected.top.add(pi.ref.decl)
-          case fi: FunctionInvocation[G] => collected.top.add(fi.ref.decl)
-          case ipi: MethodInvocation[G] => collected.top.add(ipi.ref.decl)
-          case ifi: InstanceFunctionInvocation[G] =>
-            collected.top.add(ifi.ref.decl)
-          case pa: PredicateApply[G] => collected.top.add(pa.ref.decl)
-          case pa: InstancePredicateApply[G] => collected.top.add(pa.ref.decl)
-          case afi: ADTFunctionInvocation[G] => collected.top.add(afi.ref.decl)
-          case Deref(_, r) => collected.top.add(r.decl)
+          // This whole match statement could be factored out into a common Uses[Declaration] trait.
+          // Or maybe reuse the Invocation/InvokingNode hierarchy?
+          // Then this whole getUsedDecls method could be generic. But I dislike increasing trait pressure in Node.scala
+          case pi: ProcedureInvocation[G] => decls.add(pi.ref.decl)
+          case fi: FunctionInvocation[G] => decls.add(fi.ref.decl)
+          case ipi: MethodInvocation[G] => decls.add(ipi.ref.decl)
+          case ifi: InstanceFunctionInvocation[G] => decls.add(ifi.ref.decl)
+          case pa: PredicateApply[G] => decls.add(pa.ref.decl)
+          case pa: InstancePredicateApply[G] => decls.add(pa.ref.decl)
+          case afi: ADTFunctionInvocation[G] => decls.add(afi.ref.decl)
+          case inv: ConstructorInvocation[G] => decls.add(inv.ref.decl)
+          case Deref(_, r) => decls.add(r.decl)
           case _ =>
         }
         super.dispatch(expr)
       }
 
-      override def dispatch(t: Type[G]): Type[Rewritten[G]] = {
-        t match {
-          case TAxiomatic(r, _) => collected.top.add(r.decl)
-          case _ =>
-        }
-        super.dispatch(t)
-      }
-
+      // Just in case this pass is moved, let's match on the low-level statements as well
       override def dispatch(s: Statement[G]): Statement[Rewritten[G]] = {
         s match {
-          case ip: InvokeProcedure[G] => collected.top.add(ip.ref.decl)
-          case ip: InvokeMethod[G] => collected.top.add(ip.ref.decl)
+          case ip: InvokeProcedure[G] => decls.add(ip.ref.decl)
+          case ip: InvokeMethod[G] => decls.add(ip.ref.decl)
+          case inv: InvokeConstructor[G] => decls.add(inv.ref.decl)
           case _ =>
         }
         super.dispatch(s)
       }
 
-      override def dispatch(decl: Declaration[G]): Unit =
-        decl match {
-          case _: Procedure[G] | _: Predicate[G] | _: Function[G] |
-              _: AxiomaticDataType[G] | _: InstanceMethod[G] |
-              _: InstanceFunction[G] =>
-            val newCollected = mutable.Set[Declaration[G]]()
-            collected.having(newCollected) { super.dispatch(decl) }
+      override def dispatch(declaration: Declaration[G]): Unit =
+        declaration match {
+          case app: FilterApplicable[G] =>
+            val newDecls = mutable.Set[Declaration[G]]()
+            collected.having(newDecls) { super.dispatch(declaration) }
             // A decl using itself should not be counted as an actual use
-            newCollected.remove(decl)
-            // Same for an adt using its own functions
-            decl match {
-              case a: AxiomaticDataType[G] =>
-                a.decls.foreach(f => newCollected.remove(f))
-              case _ =>
-            }
-            collected.top.addAll(newCollected)
+            newDecls.remove(declaration)
+            decls.addAll(newDecls)
           case d => super.dispatch(d)
         }
     }
 
-    val res = mutable.Set[Declaration[G]]()
-    collected.having(res) { Collector().dispatch(p) }
-    res.toSeq
+    val decls = mutable.Set[Declaration[G]]()
+    collected.having(decls) { Collector().dispatch(p) }
+    decls.toSet
   }
 
-  case class RemoveUnused[Pre <: Generation](used: Seq[Declaration[Pre]])
+  case class RemoveUnused[Pre <: Generation](used: Set[FilterApplicable[Pre]])
       extends Rewriter[Pre] with LazyLogging {
     var dropped: mutable.Set[Declaration[Pre]] = mutable.Set()
-
-    def adtIsUsed(a: AxiomaticDataType[Pre]): Boolean =
-      used.contains(a) || a.decls.exists(used.contains(_))
+    lazy val usedSet = used.toSet
 
     override def dispatch(decl: Declaration[Pre]): Unit = {
       decl match {
-        case _: Procedure[Pre] | _: Function[Pre] | _: Predicate[Pre] |
-            _: InstancePredicate[Pre] | _: InstanceField[Pre] |
-            _: InstanceMethod[Pre] | _: InstanceFunction[Pre]
-            if !used.contains(decl) =>
-          decl.drop()
-          dropped.add(decl)
-        case a: AxiomaticDataType[Pre] if !adtIsUsed(a) =>
-          a.drop()
-          a.decls.foreach({ d => d.drop(); dropped.add(d) })
-          dropped.add(decl)
-        case _ => rewriteDefault(decl)
+        case app: FilterApplicable[Pre] if !usedSet.contains(app) =>
+          app.drop()
+          dropped.add(app)
+        case _ => decl.rewriteDefault()
       }
     }
   }
 
   def filterAndAbstract[G <: Generation](
-      p: Program[G],
-      inputFocused: Seq[ContractApplicable[G]],
-  ): (Program[Rewritten[G]], Seq[Declaration[_]]) = {
-    val am = AbstractMaker(inputFocused)
-    var program = am.dispatch(p)
-    var focused = inputFocused
-      .map(am.anySucc[Declaration[Rewritten[G]]](_).decl)
-    var dropped: Seq[Declaration[_]] = Nil
-    var totalDropped: Seq[Declaration[_]] = Nil
+      program: Program[G],
+      included: Set[FilterApplicable[G]],
+  ): Program[_] = {
+    val am = AbstractMaker(included)
+    val abstractProgram = am.dispatch(program)
+    // Maintain set of applicables to retain through the transformation
+    val includedAbstract = included
+      .map(am.anySucc[FilterApplicable[Rewritten[G]]](_).decl)
 
-    do {
-      val ru = RemoveUnused[Rewritten[G]](getUsedDecls(program) ++ focused)
-      val reducedProgram = ru.dispatch(program)
-      program = reducedProgram.asInstanceOf[Program[Rewritten[G]]]
-      focused = focused
-        .map(ru.anySucc[Declaration[Rewritten[Rewritten[G]]]](_).decl)
-        .asInstanceOf[Seq[Declaration[Rewritten[G]]]]
-      dropped = ru.dropped.toSeq
-      totalDropped ++= dropped
-    } while (dropped.nonEmpty)
+    val removeUnused = RemoveUnused[Rewritten[G]](
+      getUsedFilterApplicables(abstractProgram).union(includedAbstract)
+    )
+    val reducedProgram = removeUnused.dispatch(abstractProgram)
 
-    (program, totalDropped)
+    if (removeUnused.dropped.nonEmpty) {
+      filterAndAbstract(reducedProgram, includedAbstract)
+    } else { reducedProgram }
   }
 }
 
@@ -263,22 +243,11 @@ case class FilterDeclarations[Pre <: Generation]()
     // If there are no includes, stop early
     if (!containsInclude) { return includeOnlyProgram }
 
-    val focused = focusedProgram.collect {
-      case FilterIndicator(
-            Ref(decl: ContractApplicable[Post]),
-            FilterFocus(),
-          ) =>
-        decl
+    val includes = includeOnlyProgram.collect {
+      case app: FilterApplicable[Post] if app.filter == Include[Post]() => app
     }
 
-    val (filteredProgram, dropped) = filterAndAbstract[Post](
-      focusedProgram,
-      focused,
-    )
-
-    if (dropped.nonEmpty) {
-      logger.info(s"Dropped ${dropped.length} declarations")
-    }
+    val filteredProgram = filterAndAbstract(includeOnlyProgram, includes)
 
     filteredProgram.asInstanceOf[Program[Post]]
   }


### PR DESCRIPTION
Checklist: <!-- Please first submit your pull request, you can check the checkboxes later. Feel free to ask for help if you don't know how/where to make changes. -->

- [ ] The wiki is updated in accordance with the changes in this PR. For example: syntax changes, semantics changes, VerCors flags changes, etc.

# PR description

Based on the previous ast-minimize, ast-minimize-2 branches. Allows adding a `focus`/`ignore` modifier to callables, after which vercors will filter out any declarations that are not focused.

Before merging this PR, the two old branches should be deleted.
