### PR TITLE
Fixed issue #924: context_everywhere was not propagated correctly in run methods. 

### DIFF
--- a/src/col/vct/col/origin/Blame.scala
+++ b/src/col/vct/col/origin/Blame.scala
@@ -359,6 +359,16 @@ case class ContextEverywhereFailedInPost(
   override def inlineDescWithSource(node: String, failure: String): String =
     s"Context of `$node` may not hold in the postcondition, since $failure."
 }
+case class ContextEverywhereFailedInRunPost(
+                                          failure: ContractFailure,
+                                          node: RunMethod[_],
+                                        ) extends ContractedFailure with WithContractFailure {
+  override def baseCode: String = "contextRunPostFailed"
+  override def descInContext: String =
+    "Context may not hold in postcondition, since"
+  override def inlineDescWithSource(node: String, failure: String): String =
+    s"Context of `$node` may not hold in the postcondition, since $failure."
+}
 case class AutoValueLeakCheckFailed(
     failure: ContractFailure,
     node: ContractApplicable[_],

--- a/src/col/vct/col/origin/Blame.scala
+++ b/src/col/vct/col/origin/Blame.scala
@@ -360,9 +360,9 @@ case class ContextEverywhereFailedInPost(
     s"Context of `$node` may not hold in the postcondition, since $failure."
 }
 case class ContextEverywhereFailedInRunPost(
-                                          failure: ContractFailure,
-                                          node: RunMethod[_],
-                                        ) extends ContractedFailure with WithContractFailure {
+    failure: ContractFailure,
+    node: RunMethod[_],
+) extends ContractedFailure with WithContractFailure {
   override def baseCode: String = "contextRunPostFailed"
   override def descInContext: String =
     "Context may not hold in postcondition, since"

--- a/test/main/vct/test/integration/examples/ForkJoinSpec.scala
+++ b/test/main/vct/test/integration/examples/ForkJoinSpec.scala
@@ -9,4 +9,27 @@ class ForkJoinSpec extends VercorsSpec {
   vercors should verify using anyBackend example "concepts/forkjoin/fibonacci.pvl"
   vercors should verify using anyBackend examples("concepts/forkjoin/OwickiGries.pvl", "concepts/forkjoin/Worker.pvl")
   vercors should error withCode "runnableMethodMissing" example "concepts/forkjoin/TestFork.pvl"
+  vercors should verify using anyBackend in "The context_everywhere of a run method" pvl
+    """
+    pure int f();
+
+    class C {
+      context_everywhere f() == 3;
+      run {
+        assert f() == 3;
+      }
+    }
+
+    requires f() == 3;
+    void main() {
+        C c = new C();
+        fork c;
+        join c;
+    }
+    """
+
+
+
+
+
 }


### PR DESCRIPTION
Checklist: <!-- Please first submit your pull request, you can check the checkboxes later. Feel free to ask for help if you don't know how/where to make changes. -->

- [x] The wiki is updated in accordance with the changes in this PR. For example: syntax changes, semantics changes, VerCors flags changes, etc.

# PR description

<!-- Describe the motivation of the PR and the changes it introduces. Why is it needed, and what does it change? -->
context_everywhere was not propagated correctly in run methods. This fixes issue #924. Added a new blame node for the postcondition part of the context_everywhere and now also propagate context_everywhere to the run methods. 