### PR TITLE
Small fixes

### DIFF
--- a/examples/publications/2023/FASE2023JavaBIP/casinoAdjusted/Casino.java
+++ b/examples/publications/2023/FASE2023JavaBIP/casinoAdjusted/Casino.java
@@ -127,13 +127,15 @@ public class Casino {
     @Pure
     @Guard(name = IS_OPERATOR)
     public boolean isOperator(@Data(name = OPERATOR) Integer sender) {
-        return sender == operator;
+        //@ ghost int x = (\assuming sender != null; sender.intValue());
+        return sender.intValue() == operator;
     }
 
     @Pure
     @Guard(name = IS_NOT_OPERATOR)
     public boolean isNotOperator(@Data(name = PLAYER) Integer sender) {
-        return sender != operator;
+        //@ ghost int x = (\assuming sender != null; sender.intValue());
+        return sender.intValue() != operator;
     }
 
     @Pure
@@ -153,11 +155,11 @@ public class Casino {
     public int getPot() {
         return pot;
     }
-    
+
     @Pure
     @Guard(name = ENOUGH_FUNDS)
     public boolean enoughFunds(@Data(name = INCOMING_FUNDS) int funds) {
-        return funds <= pot; 
+        return funds <= pot;
     }
 
     @Pure

--- a/examples/publications/2023/FASE2023JavaBIP/casinoBroken/Casino.java
+++ b/examples/publications/2023/FASE2023JavaBIP/casinoBroken/Casino.java
@@ -129,13 +129,15 @@ public class Casino {
     @Pure
     @Guard(name = IS_OPERATOR)
     public boolean isOperator(@Data(name = OPERATOR) Integer sender) {
-        return sender == operator;
+        //@ ghost int x = (\assuming sender != null; sender.intValue());
+        return sender.intValue() == operator;
     }
 
     @Pure
     @Guard(name = IS_NOT_OPERATOR)
     public boolean isNotOperator(@Data(name = PLAYER) Integer sender) {
-        return sender != operator;
+        //@ ghost int x = (\assuming sender != null; sender.intValue());
+        return sender.intValue() != operator;
     }
 
     @Pure
@@ -155,11 +157,11 @@ public class Casino {
     public int getPot() {
         return pot;
     }
-    
+
     @Pure
     @Guard(name = ENOUGH_FUNDS)
     public boolean enoughFunds(@Data(name = INCOMING_FUNDS) int funds) {
-        return funds <= pot; 
+        return funds <= pot;
     }
 
     @Pure

--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -1036,6 +1036,9 @@ final case class CoerceCPPArrayPointer[G](elementType: Type[G])(
 final case class CoerceCVectorVector[G](size: BigInt, elementType: Type[G])(
     implicit val o: Origin
 ) extends Coercion[G] with CoerceCVectorVectorImpl[G]
+final case class CoerceNullLLVMPointer[G](elementType: Option[Type[G]])(
+    implicit val o: Origin
+) extends Coercion[G] with CoerceNullLLVMPointerImpl[G]
 
 final case class CoerceFracZFrac[G]()(implicit val o: Origin)
     extends Coercion[G] with CoerceFracZFracImpl[G]

--- a/src/col/vct/col/ast/family/coercion/CoerceNullLLVMPointerImpl.scala
+++ b/src/col/vct/col/ast/family/coercion/CoerceNullLLVMPointerImpl.scala
@@ -1,0 +1,9 @@
+package vct.col.ast.family.coercion
+
+import vct.col.ast.ops.CoerceNullLLVMPointerOps
+import vct.col.ast.{CoerceNullLLVMPointer, LLVMTPointer}
+
+trait CoerceNullLLVMPointerImpl[G] extends CoerceNullLLVMPointerOps[G] {
+  this: CoerceNullLLVMPointer[G] =>
+  override def target: LLVMTPointer[G] = LLVMTPointer(elementType)
+}

--- a/src/col/vct/col/typerules/CoercingRewriter.scala
+++ b/src/col/vct/col/typerules/CoercingRewriter.scala
@@ -735,7 +735,7 @@ abstract class CoercingRewriter[Pre <: Generation]()
       case (TAnyValue(), _) | (_, TAnyValue()) =>
         cons(coerce(left, TAnyValue()), coerce(right, TAnyValue()))
       case (lt, rt) =>
-        val sharedType = Types.leastCommonSuperType(left.t, right.t)
+        val sharedType = Types.leastCommonSuperType(lt, rt)
         if (sharedType == TAnyValue[Pre]()) {
           throw IncoercibleExplanation(
             e,

--- a/src/col/vct/col/typerules/CoercionUtils.scala
+++ b/src/col/vct/col/typerules/CoercionUtils.scala
@@ -123,7 +123,9 @@ case object CoercionUtils {
       case (TNull(), TAnyClass()) => CoerceNullAnyClass()
       case (TNull(), TPointer(target)) => CoerceNullPointer(target)
       case (TNull(), CTPointer(target)) => CoerceNullPointer(target)
+      case (TNull(), CTArray(_, target)) => CoerceNullPointer(target)
       case (TNull(), TEnum(target)) => CoerceNullEnum(target)
+      case (TNull(), LLVMTPointer(target)) => CoerceNullLLVMPointer(target)
 
       case (CTArray(_, innerType), TArray(element)) if element == innerType =>
         CoerceCArrayPointer(element)
@@ -156,6 +158,14 @@ case object CoercionUtils {
         else {
           CoercionSequence(Seq(
             CoerceCArrayPointer(element),
+            getAnyCoercion(element, innerType).getOrElse(return None),
+          ))
+        }
+      case (CPPTArray(_, innerType), TPointer(element)) =>
+        if (element == innerType) { CoerceCPPArrayPointer(innerType) }
+        else {
+          CoercionSequence(Seq(
+            CoerceCPPArrayPointer(element),
             getAnyCoercion(element, innerType).getOrElse(return None),
           ))
         }

--- a/src/main/vct/main/stages/Parsing.scala
+++ b/src/main/vct/main/stages/Parsing.scala
@@ -122,7 +122,7 @@ case class Parsing[G <: Generation](
                 blameProvider,
                 ccpp,
                 cppSystemInclude,
-                readable.underlyingPath.map(_.getParent).toSeq ++
+                readable.underlyingPath.map(_.toAbsolutePath.getParent).toSeq ++
                   cppOtherIncludes,
                 cppDefines,
               )

--- a/src/rewrite/vct/rewrite/ClassToRef.scala
+++ b/src/rewrite/vct/rewrite/ClassToRef.scala
@@ -858,6 +858,8 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
             const(typeNumber(t.cls.decl))(e.o)
           // Keep pointer casts intact for the adtPointer stage
           case _: TPointer[Pre] | _: TNonNullPointer[Pre] => e.rewriteDefault()
+          // Keep integer casts intact for casting between integers and pointers
+          case _: TInt[Pre] => e.rewriteDefault()
           // Keep any casts intact for the adtAny stage
           case _: TAnyValue[Pre] => e.rewriteDefault()
           case other => ???

--- a/src/rewrite/vct/rewrite/ClassToRef.scala
+++ b/src/rewrite/vct/rewrite/ClassToRef.scala
@@ -858,8 +858,8 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
             const(typeNumber(t.cls.decl))(e.o)
           // Keep pointer casts intact for the adtPointer stage
           case _: TPointer[Pre] | _: TNonNullPointer[Pre] => e.rewriteDefault()
-          // Keep integer casts intact for casting between integers and pointers
-          case _: TInt[Pre] => e.rewriteDefault()
+          // Keep any casts intact for the adtAny stage
+          case _: TAnyValue[Pre] => e.rewriteDefault()
           case other => ???
         }
       case TypeOf(value) =>

--- a/src/rewrite/vct/rewrite/adt/ImportPointer.scala
+++ b/src/rewrite/vct/rewrite/adt/ImportPointer.scala
@@ -556,6 +556,8 @@ case class ImportPointer[Pre <: Generation](importer: ImportADTImporter)
             OptSome(applyAsTypeFunction(innerType, value, newValue))
           case (TNonNullPointer(innerType), TNonNullPointer(_)) =>
             applyAsTypeFunction(innerType, value, newValue)
+          // Other type of cast probably a cast to any
+          case (_, _) => super.postCoerce(e)
         }
       case IntegerPointerCast(value, typeValue, typeSize) =>
         val targetType = typeValue.t.asInstanceOf[TType[Pre]].t

--- a/test/main/vct/test/integration/examples/TechnicalSpec.scala
+++ b/test/main/vct/test/integration/examples/TechnicalSpec.scala
@@ -52,12 +52,10 @@ class TechnicalSpec extends VercorsSpec {
     void main(C arg);
   """
 
-  vercors should verify using anyBackend in
+  vercors should error withCode "resolutionError:type" in
     "example showing comparison of unrelated types" pvl """
     void test() {
-      /*[/expect assertFailed:false]*/
       assert 1 == false;
-      /*[/end]*/
     }
   """
 


### PR DESCRIPTION
# PR description

- Add error on (probably unintended) coercion to `any`
- Fix crash for CPP when using relative paths
- Add missing coercions from CPPTArray and TNull 
- Fix (always failing) comparison between Integer and int in JavaBIP casino examples. This includes an ugly added assumptions since I don't know how to add a precondition to a pure function in the JavaBIP context. If someone knows how to do that please let me know.