### PR TITLE
Can now take sizeof typedef again

### DIFF
--- a/src/parsers/antlr4/LangCParser.g4
+++ b/src/parsers/antlr4/LangCParser.g4
@@ -90,8 +90,8 @@ unaryExpression
     :   '++' unaryExpression
     |   '--' unaryExpression
     |   unaryOperator castExpression
-    |   'sizeof' unaryExpression
     |   'sizeof' '(' typeName ')'
+    |   'sizeof' unaryExpression
     |   '_Alignof' '(' typeName ')'
     |   '&&'  clangIdentifier // GCC extension address of label
     |   postfixExpression

--- a/src/parsers/vct/parsers/transform/CToCol.scala
+++ b/src/parsers/vct/parsers/transform/CToCol.scala
@@ -890,8 +890,8 @@ case class CToCol[G](
           case "~" => BitNot(convert(arg), 0, signed = true)(blame(expr))
           case "!" => col.Not(convert(arg))
         }
-      case UnaryExpression3(_, _) => ??(expr)
-      case UnaryExpression4(_, _, tname, _) => SizeOf(convert(tname))
+      case UnaryExpression4(_, _) => ??(expr)
+      case UnaryExpression3(_, _, tname, _) => SizeOf(convert(tname))
       case UnaryExpression5(_, _, _, _) => ??(expr)
       case UnaryExpression6(_, _) => ??(expr)
       case UnaryExpression7(inner) => convert(inner)

--- a/test/main/vct/test/integration/examples/CSpec.scala
+++ b/test/main/vct/test/integration/examples/CSpec.scala
@@ -640,4 +640,14 @@ class CSpec extends VercorsSpec {
         //@ assert a0 + sizeof(int) == a1;
     }
     """
+
+  vercors should verify using silicon in "Taking sizeof of typedef" c
+    """
+    #include <stdlib.h>
+    typedef int test;
+    int main(){
+        test* x = (test *) malloc(sizeof ( test ) );
+        int y = (test) 5.0;
+    }
+    """
 }


### PR DESCRIPTION
- [x] The wiki is updated in accordance with the changes in this PR. For example: syntax changes, semantics changes, VerCors flags changes, etc.

# PR description
The following program crashed before:
```c
#include <stdlib.h>

typedef int test;

int main(){
    test* x = (test *) malloc(sizeof ( test ) );
    int y = (test) 5.0;
}
```
Because it could not parse `test` in the `sizeof`. Now it works.
