### PR TITLE
Allow args of inlined function to be inlined

### DIFF
--- a/examples/concepts/basic/InlineFunctionsAsArg.pvl
+++ b/examples/concepts/basic/InlineFunctionsAsArg.pvl
@@ -1,0 +1,11 @@
+//:: cases InlineFunctions
+//:: tools silicon
+//:: verdict Pass
+
+class C {
+    inline pure int f(int x) = x + 1;
+
+    void m() {
+        assert f(f(f(0))) == 3;
+    }
+}

--- a/src/rewrite/vct/rewrite/InlineApplicables.scala
+++ b/src/rewrite/vct/rewrite/InlineApplicables.scala
@@ -305,64 +305,66 @@ case class InlineApplicables[Pre <: Generation]()
       case apply: ApplyInlineable[Pre] if apply.ref.decl.inline =>
         implicit val o: Origin = apply.o
 
-        checkCycle(apply, apply.ref.decl) {
-          lazy val obj = {
-            val instanceApply = apply.asInstanceOf[InstanceApply[Pre]]
-            val cls = classOwner(instanceApply.ref.decl)
-            Replacement(ThisObject[Pre](cls.ref), instanceApply.obj)(
-              InlineLetThisOrigin
-            )
-          }
-
-          lazy val args = Replacements(
-            for ((arg, v) <- apply.args.zip(apply.ref.decl.args))
-              yield Replacement(v.get, arg)(v.o)
+        lazy val obj = {
+          val instanceApply = apply.asInstanceOf[InstanceApply[Pre]]
+          val cls = classOwner(instanceApply.ref.decl)
+          Replacement(ThisObject[Pre](cls.ref), instanceApply.obj)(
+            InlineLetThisOrigin
           )
+        }
 
-          lazy val givenArgs = Replacements(
-            for (
-              (Ref(v), arg) <- apply.asInstanceOf[InvokingNode[Pre]].givenMap
-            )
-              yield Replacement(v.get, arg)(v.o)
-          )
+        lazy val args = Replacements(
+          for ((arg, v) <- apply.args.zip(apply.ref.decl.args))
+            yield Replacement(v.get, arg)(v.o)
+        )
 
-          lazy val outArgs = {
-            val inv = apply.asInstanceOf[AnyMethodInvocation[Pre]]
-            Replacements(
-              for ((out, v) <- inv.outArgs.zip(inv.ref.decl.outArgs))
-                yield Replacement(v.get, out)(v.o)
-            )
-          }
+        lazy val givenArgs = Replacements(
+          for ((Ref(v), arg) <- apply.asInstanceOf[InvokingNode[Pre]].givenMap)
+            yield Replacement(v.get, arg)(v.o)
+        )
 
-          lazy val yields = Replacements(
-            for ((out, Ref(v)) <- apply.asInstanceOf[InvokingNode[Pre]].yields)
+        lazy val outArgs = {
+          val inv = apply.asInstanceOf[AnyMethodInvocation[Pre]]
+          Replacements(
+            for ((out, v) <- inv.outArgs.zip(inv.ref.decl.outArgs))
               yield Replacement(v.get, out)(v.o)
           )
+        }
 
-          // TODO: consider type arguments
-          apply match {
-            case ProcedureInvocation(Ref(proc), _, _, typeArgs, _, _) =>
-              dispatch((args + givenArgs).stat(
-                apply.t,
-                proc.body.getOrElse(throw AbstractInlineable(apply, proc)),
-                outArgs + yields,
-              ))
-            case FunctionInvocation(Ref(func), _, typeArgs, _, _) =>
-              dispatch((args + givenArgs).expr(
+        lazy val yields = Replacements(
+          for ((out, Ref(v)) <- apply.asInstanceOf[InvokingNode[Pre]].yields)
+            yield Replacement(v.get, out)(v.o)
+        )
+
+        // TODO: consider type arguments
+        apply match {
+          case ProcedureInvocation(Ref(proc), _, _, typeArgs, _, _) =>
+            dispatch((args + givenArgs).stat(
+              apply.t,
+              checkCycle(apply, apply.ref.decl) {
+                proc.body.getOrElse(throw AbstractInlineable(apply, proc))
+              },
+              outArgs + yields,
+            ))
+          case FunctionInvocation(Ref(func), _, typeArgs, _, _) =>
+            dispatch((args + givenArgs).expr(checkCycle(apply, apply.ref.decl) {
+              func.body.getOrElse(throw AbstractInlineable(apply, func))
+            }))
+
+          case MethodInvocation(_, Ref(method), _, _, typeArgs, _, _) =>
+            dispatch((obj + args + givenArgs).stat(
+              apply.t,
+              checkCycle(apply, apply.ref.decl) {
+                method.body.getOrElse(throw AbstractInlineable(apply, method))
+              },
+              outArgs + yields,
+            ))
+          case InstanceFunctionInvocation(_, Ref(func), _, typeArgs, _, _) =>
+            dispatch(
+              (obj + args + givenArgs).expr(checkCycle(apply, apply.ref.decl) {
                 func.body.getOrElse(throw AbstractInlineable(apply, func))
-              ))
-
-            case MethodInvocation(_, Ref(method), _, _, typeArgs, _, _) =>
-              dispatch((obj + args + givenArgs).stat(
-                apply.t,
-                method.body.getOrElse(throw AbstractInlineable(apply, method)),
-                outArgs + yields,
-              ))
-            case InstanceFunctionInvocation(_, Ref(func), _, typeArgs, _, _) =>
-              dispatch((obj + args + givenArgs).expr(func.body.getOrElse(
-                throw AbstractInlineable(apply, func)
-              )))
-          }
+              })
+            )
         }
 
       case Unfolding(

--- a/test/main/vct/test/integration/examples/BasicExamplesSpec.scala
+++ b/test/main/vct/test/integration/examples/BasicExamplesSpec.scala
@@ -22,6 +22,7 @@ class BasicExamplesSpec extends VercorsSpec {
   vercors should verify using anyBackend example "concepts/basic/frac2.pvl"
   vercors should verify using anyBackend example "concepts/basic/fraction-comparison.pvl"
   vercors should verify using anyBackend example "concepts/basic/InlineFunctions.pvl"
+  vercors should verify using anyBackend example "concepts/basic/InlineFunctionsAsArg.pvl"
   vercors should verify using silicon example "concepts/basic/MultiDimArray.java"
   vercors should verify using anyBackend example "concepts/basic/NewClassGhost.java"
   // https://github.com/utwente-fmt/vercors/issues/921


### PR DESCRIPTION
- [x] The wiki is updated in accordance with the changes in this PR. For example: syntax changes, semantics changes, VerCors flags changes, etc.

# PR description
I think it should be allowed to inline a function, were in the argument the inlined function is used.

Thus with this the following verifies:
```java
class C {
    inline pure int f(int x) = x + 1;

    void m() {
        assert f(f(f(0))) == 3;
    }
} 
```