### PR TITLE
Vectors fix & xs->x works for array of structs

### DIFF
--- a/examples/concepts/c/structs.c
+++ b/examples/concepts/c/structs.c
@@ -33,6 +33,19 @@ void alter_struct(struct point *p){
 }
 
 /*@
+    context p != NULL ** Perm(p, write);
+    context Perm(&p->x, write);
+    context Perm(&p->y, write);
+    ensures p->x == 0;
+    ensures p->y == 0;
+    ensures \old(*p) == *p;
+@*/
+void alter_struct2(struct point p[]){
+    p->x = 0;
+    p->y = 0;
+}
+
+/*@
     context p != NULL ** Perm(p, write) ** Perm(*p, write);
     ensures p->x == \old(p->x + 1);
     ensures p->y == \old(p->y + 1);

--- a/res/universal/res/c/emmintrin.h
+++ b/res/universal/res/c/emmintrin.h
@@ -6,11 +6,13 @@
 // the vector. For example, _mm_add_epi32 tells us that the vector is composed of 32-bit integers.
 // In VerCors this is not useful, we want to know the size of the vector from the type, and not switch
 // between vector interpretations. So we defined __m128i to be a vector of 2 integers in VerCors.
+// Also see reference guide: https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html
 
 typedef double __v2df __attribute__ ((__vector_size__ (sizeof(double)*2)));
 typedef long long __v2di __attribute__ ((__vector_size__ (sizeof(long long)*2)));
 typedef unsigned long long __v2du __attribute__ ((__vector_size__ (sizeof(unsigned long long)*2)));
 typedef int __v4si __attribute__ ((__vector_size__ (sizeof(int)*4)));
+typedef float __v4sf __attribute__ ((__vector_size__ (sizeof(float)*4)));
 typedef unsigned int __v4su __attribute__ ((__vector_size__ (sizeof(unsigned int)*4)));
 typedef short __v8hi __attribute__ ((__vector_size__ (sizeof(short)*8)));
 typedef unsigned short __v8hu __attribute__ ((__vector_size__ (sizeof(unsigned short)*8)));
@@ -28,6 +30,16 @@ typedef float __m128 __attribute__ ((__vector_size__ (sizeof(float)*4)));
 typedef float __m128_u __attribute__ ((__vector_size__ (sizeof(float)*4)));
 typedef float __v4sf __attribute__ ((__vector_size__ (sizeof(float)*4)));
 
+
+typedef float __m256 __attribute__ ((__vector_size__ (sizeof(float)*8)));
+typedef long long __m256i __attribute__ ((__vector_size__ (sizeof(long long)*4)));
+typedef double __m256d __attribute__ ((__vector_size__ (sizeof(double)*4)));
+
+/* Unaligned version of the same types.  */
+typedef float __m256_u __attribute__ ((__vector_size__ (sizeof(float)*8)));
+typedef long long __m256i_u __attribute__ ((__vector_size__ (sizeof(long long)*4)));
+typedef double __m256d_u __attribute__ ((__vector_size__ (sizeof(double)*4)));
+
 //@ ensures \result[0] == __q0 && \result[1] == __q1;
 __m128i /*@ pure @*/ _mm_set_epi64x(long long __q1, long long __q0){
     __m128i res = {__q0, __q1};
@@ -38,6 +50,270 @@ __m128i /*@ pure @*/ _mm_set_epi64x(long long __q1, long long __q0){
 __m128i /*@ pure @*/ _mm_set1_epi64x (long long __A)
 {
   return _mm_set_epi64x (__A, __A);
+}
+
+/**** Loads ****/
+// SSE2
+
+/*@
+  requires __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<4; Perm(&__P[i], read));
+  ensures __P[0] == \result[0] && __P[1] == \result[1] && __P[2] == \result[2] && __P[3] == \result[3];
+@*/
+/*@ pure @*/ __m128 _mm_loadu_ps (float *__P);
+
+/*@
+  requires __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<4; Perm(&__P[i], read));
+  ensures __P[0] == \result[0] && __P[1] == \result[1] && __P[2] == \result[2] && __P[3] == \result[3];
+@*/
+/*@ pure @*/ __m128 _mm_load_ps (float *__P);
+
+/*@
+  requires __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<2; Perm(&__P[i], read));
+  ensures __P[0] == \result[0] && __P[1] == \result[1];
+@*/
+/*@ pure @*/ __m128d _mm_loadu_pd (double *__P);
+
+/*@
+  requires __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<2; Perm(&__P[i], read));
+  ensures __P[0] == \result[0] && __P[1] == \result[1];
+@*/
+/*@ pure @*/ __m128d _mm_load_pd (double *__P);
+
+/*@
+  requires __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<2; Perm((long long *)&__P[i], read));
+  ensures ((long long*)__P)[0] == \result[0] && ((long long*)__P)[1] == \result[1];
+@*/
+/*@ pure @*/ __m128i _mm_loadu_epi64 (void *__P);
+
+
+/*@
+  requires __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<2; Perm((long long *)&__P[i], read));
+  ensures ((long long*)__P)[0] == \result[0] && ((long long*)__P)[1] == \result[1];
+@*/
+/*@ pure @*/ __m128i _mm_load_epi64 (void *__P);
+
+/** AVX256 **/
+/*@
+  requires __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<8; Perm(&__P[i], read));
+  ensures __P[0] == \result[0] && __P[1] == \result[1] && __P[2] == \result[2] && __P[3] == \result[3] &&
+      __P[4] == \result[4] && __P[5] == \result[5] && __P[6] == \result[6] && __P[7] == \result[7];
+@*/
+/*@ pure @*/ __m256 _mm256_loadu_ps (float *__P);
+
+/*@
+  requires __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<8; Perm(&__P[i], read));
+  ensures __P[0] == \result[0] && __P[1] == \result[1] && __P[2] == \result[2] && __P[3] == \result[3] &&
+      __P[4] == \result[4] && __P[5] == \result[5] && __P[6] == \result[6] && __P[7] == \result[7];
+@*/
+/*@ pure @*/ __m256 _mm256_load_ps (float *__P);
+
+/*@
+  requires __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<4; Perm(&__P[i], read));
+  ensures __P[0] == \result[0] && __P[1] == \result[1] && __P[2] == \result[2] && __P[3] == \result[3];
+@*/
+/*@ pure @*/ __m256d _mm256_loadu_pd (double *__P);
+
+/*@
+  requires __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<4; Perm(&__P[i], read));
+  ensures __P[0] == \result[0] && __P[1] == \result[1] && __P[2] == \result[2] && __P[3] == \result[3];
+@*/
+/*@ pure @*/ __m256d _mm256_load_pd (double *__P);
+
+/*@
+  requires __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<4; Perm((long long *)&__P[i], read));
+  ensures ((long long*)__P)[0] == \result[0] && ((long long*)__P)[1] == \result[1] && ((long long*)__P)[2] == \result[2] && ((long long*)__P)[3] == \result[3];
+@*/
+/*@ pure @*/ __m256i _mm256_loadu_epi64 (void *__P);
+
+
+/*@
+  requires __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<4; Perm((long long *)&__P[i], read));
+  ensures ((long long*)__P)[0] == \result[0] && ((long long*)__P)[1] == \result[1] && ((long long*)__P)[2] == \result[2] && ((long long*)__P)[3] == \result[3];
+@*/
+/*@ pure @*/ __m256i _mm256_load_epi64 (void *__P);
+
+/**** Stores ****/
+// SSE2
+/*@
+  context __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<4; Perm(&__P[i], write));
+  ensures __P[0] == __A[0] && __P[1] == __A[1] && __P[2] == __A[2] && __P[3] == __A[3];
+@*/
+void _mm_store_ps (float *__P, __m128 __A);
+
+/*@
+  context __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<4; Perm(&__P[i], write));
+  ensures __P[0] == __A[0] && __P[1] == __A[1] && __P[2] == __A[2] && __P[3] == __A[3];
+@*/
+void _mm_storeu_ps (float *__P, __m128 __A);
+
+/*@
+  context __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<2; Perm(&__P[i], write));
+  ensures __P[0] == __A[0] && __P[1] == __A[1];
+@*/
+void _mm_store_pd (double *__P, __m128d __A);
+
+/*@
+  context __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<2; Perm(&__P[i], write));
+  ensures __P[0] == __A[0] && __P[1] == __A[1];
+@*/
+void _mm_storeu_pd (double *__P, __m128d __A);
+
+/*@
+  context __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<2; Perm((long long *)&__P[i], write));
+  ensures ((long long *) __P)[0] == __A[0] && ((long long *) __P)[1] == __A[1];
+@*/
+void _mm_storeu_epi64 (void *__P, __m128i __A);
+
+/*@
+  context __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<2; Perm((long long *)&__P[i], write));
+  ensures ((long long *) __P)[0] == __A[0] && ((long long *) __P)[1] == __A[1];
+@*/
+void _mm_store_epi64 (void *__P, __m128i __A);
+
+/** AVX256 **/
+/*@
+  context __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<8; Perm(&__P[i], write));
+  ensures __P[0] == __A[0] && __P[1] == __A[1] && __P[2] == __A[2] && __P[3] == __A[3] &&
+    __P[4] == __A[4] && __P[5] == __A[5] && __P[6] == __A[6] && __P[7] == __A[7];
+@*/
+void _mm256_store_ps (float *__P, __m256 __A);
+
+/*@
+  context __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<8; Perm(&__P[i], write));
+  ensures __P[0] == __A[0] && __P[1] == __A[1] && __P[2] == __A[2] && __P[3] == __A[3] &&
+    __P[4] == __A[4] && __P[5] == __A[5] && __P[6] == __A[6] && __P[7] == __A[7];
+@*/
+void _mm256_storeu_ps (float *__P, __m256 __A);
+
+/*@
+  context __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<4; Perm(&__P[i], write));
+  ensures __P[0] == __A[0] && __P[1] == __A[1] && __P[2] == __A[2] && __P[3] == __A[3];
+@*/
+void _mm256_store_pd (double *__P, __m256d __A);
+
+/*@
+  context __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<4; Perm(&__P[i], write));
+  ensures __P[0] == __A[0] && __P[1] == __A[1] && __P[2] == __A[2] && __P[3] == __A[3];
+@*/
+void _mm256_storeu_pd (double *__P, __m256d __A);
+
+/*@
+  context __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<4; Perm((long long *)&__P[i], write));
+  ensures ((long long *) __P)[0] == __A[0] && ((long long *) __P)[1] == __A[1] && ((long long *) __P)[2] == __A[2] && ((long long *) __P)[3] == __A[3];
+@*/
+void _mm256_storeu_epi64 (void *__P, __m256i __A);
+
+/*@
+  context __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<4; Perm((long long *)&__P[i], write));
+  ensures ((long long *) __P)[0] == __A[0] && ((long long *) __P)[1] == __A[1] && ((long long *) __P)[2] == __A[2] && ((long long *) __P)[3] == __A[3];
+@*/
+void _mm256_store_epi64 (void *__P, __m256i __A);
+
+/**** Some operators ****/
+// SSE2
+// __m128
+/*@ pure @*/ __m128 _mm_add_ps (__m128 __A, __m128 __B){
+    return __A + __B;
+}
+
+/*@ pure */ __m128 _mm_div_ps (__m128 __A, __m128 __B){
+    return __A / __B;
+}
+
+/*@ pure @*/ __m128 _mm_mul_ps (__m128 __A, __m128 __B){
+    return __A * __B;
+}
+
+/*@ pure @*/ __m128 _mm_sub_ps (__m128 __A, __m128 __B){
+    return __A - __B;
+}
+
+// __m128d
+/*@ pure @*/ __m128d _mm_add_pd (__m128d __A, __m128d __B){
+    return __A + __B;
+}
+
+/*@ pure */ __m128d _mm_div_pd (__m128d __A, __m128d __B){
+    return __A / __B;
+}
+
+/*@ pure @*/ __m128d _mm_mul_pd (__m128d __A, __m128d __B){
+    return __A * __B;
+}
+
+/*@ pure @*/ __m128d _mm_sub_pd (__m128d __A, __m128d __B){
+    return __A - __B;
+}
+
+// __m128i
+/*@ pure @*/ __m128i _mm_add_epi64(__m128i __A, __m128i __B){
+    return __A + __B;
+}
+
+//@ requires __B[0] != 0 ** __B[1] != 0;
+/*@ pure @*/ __m128i _mm_div_epi64(__m128i __A, __m128i __B){
+    return __A / __B;
+}
+
+/*@ pure @*/ __m128i _mm_mul_epi64(__m128i __A, __m128i __B){
+    return __A * __B;
+}
+
+/*@ pure @*/ __m128i _mm_sub_epi64(__m128i __A, __m128i __B){
+    return __A - __B;
+}
+
+// AVX2
+// __m256
+/*@ pure @*/ __m256 _mm256_add_ps (__m256 __A, __m256 __B){
+    return __A + __B;
+}
+
+/*@ pure */ __m256 _mm256_div_ps (__m256 __A, __m256 __B){
+    return __A / __B;
+}
+
+/*@ pure @*/ __m256 _mm256_mul_ps (__m256 __A, __m256 __B){
+    return __A * __B;
+}
+
+/*@ pure @*/ __m256 _mm256_sub_ps (__m256 __A, __m256 __B){
+    return __A - __B;
+}
+
+// __m256d
+/*@ pure @*/ __m256d _mm256_add_pd (__m256d __A, __m256d __B){
+    return __A + __B;
+}
+
+/*@ pure */ __m256d _mm256_div_pd (__m256d __A, __m256d __B){
+    return __A / __B;
+}
+
+/*@ pure @*/ __m256d _mm256_mul_pd (__m256d __A, __m256d __B){
+    return __A * __B;
+}
+
+/*@ pure @*/ __m256d _mm256_sub_pd (__m256d __A, __m256d __B){
+    return __A - __B;
+}
+
+// __m256i
+/*@ pure @*/ __m256i _mm256_add_epi64(__m256i __A, __m256i __B){
+    return __A + __B;
+}
+
+//@ requires __B[0] != 0 ** __B[1] != 0 ** __B[2] != 0 ** __B[3] != 0;
+/*@ pure @*/ __m256i _mm256_div_epi64(__m256i __A, __m256i __B){
+    return __A / __B;
+}
+
+/*@ pure @*/ __m256i _mm256_mul_epi64(__m256i __A, __m256i __B){
+    return __A * __B;
+}
+
+/*@ pure @*/ __m256i _mm256_sub_epi64(__m256i __A, __m256i __B){
+    return __A - __B;
 }
 
 

--- a/res/universal/res/c/math.h
+++ b/res/universal/res/c/math.h
@@ -3,6 +3,9 @@
 
 # define M_PI           3.14159265358979323846  /* pi */
 
+const double NAN = vercorsNAN;
+const double INFINITY = vercorsINFINITY;
+
 /*@
   decreases;
 pure double M_PI() = 3.14159265358979323846;

--- a/res/universal/res/c/stdio.h
+++ b/res/universal/res/c/stdio.h
@@ -1,6 +1,8 @@
 #ifndef STDIO_H
 #define STDIO_H
 
+#include <stddef.h>
+
 extern int printf(/*const*/ char *format, ...);
 
 #endif

--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -1261,6 +1261,7 @@ sealed trait Expr[G] extends NodeFamily[G] with ExprImpl[G]
 
 sealed trait Constant[G] extends Expr[G] with ConstantImpl[G]
 sealed trait ConstantInt[G] extends Constant[G] with ConstantIntImpl[G]
+sealed trait ConstantFloat[G] extends Constant[G]
 final case class CIntegerValue[G](value: BigInt, t: Type[G])(
     implicit val o: Origin
 ) extends ConstantInt[G] with Expr[G] with CIntegerValueImpl[G]
@@ -1270,7 +1271,11 @@ final case class BooleanValue[G](value: Boolean)(implicit val o: Origin)
     extends Constant[G] with BooleanValueImpl[G]
 final case class FloatValue[G](value: BigDecimal, t: Type[G] /* TFloat */ )(
     implicit val o: Origin
-) extends Constant[G] with FloatValueImpl[G]
+) extends ConstantFloat[G] with FloatValueImpl[G]
+final case class FloatNaN[G](t: Type[G] /* TFloat */ )(implicit val o: Origin)
+    extends ConstantFloat[G] with FloatNaNImpl[G]
+final case class FloatInf[G](t: Type[G] /* TFloat */ )(implicit val o: Origin)
+    extends ConstantFloat[G] with FloatInfImpl[G]
 final case class StringValue[G](value: String)(implicit val o: Origin)
     extends Constant[G] with StringValueImpl[G]
 final case class CharValue[G](value: Int)(implicit val o: Origin)

--- a/src/col/vct/col/ast/expr/literal/constant/FloatInfImpl.scala
+++ b/src/col/vct/col/ast/expr/literal/constant/FloatInfImpl.scala
@@ -1,0 +1,11 @@
+package vct.col.ast.expr.literal.constant
+
+import vct.col.ast.FloatInf
+import vct.col.ast.ops.FloatInfOps
+import vct.col.print._
+
+trait FloatInfImpl[G] extends FloatInfOps[G] {
+  this: FloatInf[G] =>
+  val value: Double = Double.PositiveInfinity
+  override def layout(implicit ctx: Ctx): Doc = Text("inf")
+}

--- a/src/col/vct/col/ast/expr/literal/constant/FloatNaNImpl.scala
+++ b/src/col/vct/col/ast/expr/literal/constant/FloatNaNImpl.scala
@@ -1,0 +1,12 @@
+package vct.col.ast.expr.literal.constant
+
+import vct.col.ast.{FloatNaN}
+import vct.col.ast.`type`.typeclass.TFloats
+import vct.col.ast.ops.FloatNaNOps
+import vct.col.print._
+
+trait FloatNaNImpl[G] extends FloatNaNOps[G] {
+  this: FloatNaN[G] =>
+  def value: Double = Double.NaN
+  override def layout(implicit ctx: Ctx): Doc = Text("NaN")
+}

--- a/src/col/vct/col/ast/lang/c/CFunctionTypeExtensionModifierImpl.scala
+++ b/src/col/vct/col/ast/lang/c/CFunctionTypeExtensionModifierImpl.scala
@@ -1,4 +1,4 @@
-package vct.col.ast.unsorted
+package vct.col.ast.lang.c
 
 import vct.col.ast.{CFunctionTypeExtensionModifier, CTypeAttribute}
 import vct.col.ast.ops.CFunctionTypeExtensionModifierOps

--- a/src/col/vct/col/typerules/CoercingRewriter.scala
+++ b/src/col/vct/col/typerules/CoercingRewriter.scala
@@ -622,25 +622,6 @@ abstract class CoercingRewriter[Pre <: Generation]()
       )
     f(left._1, right._1)
   }
-  def vectorFloatRatOp2[T](
-      e: BinExpr[Pre],
-      f: (Expr[Pre], Expr[Pre]) => T,
-  ): T = {
-    implicit val o: Origin = e.o
-    val (left, right) = firstOk(
-      e,
-      s"Expected both operands to be of type vector[float or rational], but got ${e
-          .left.t} and ${e.right.t}.",
-      (vectorFloat(e.left), vectorFloat(e.right)),
-      (vectorRational(e.left), vectorRational(e.right)),
-    )
-    if (left._2.size != right._2.size)
-      throw IncoercibleText(
-        e,
-        "This expression does not have a matching vector lengths",
-      )
-    f(left._1, right._1)
-  }
   def vectorOp2[T](e: BinExpr[Pre], f: (Expr[Pre], Expr[Pre]) => T): T = {
     implicit val o: Origin = e.o
     val (left, right) = firstOk(
@@ -2086,6 +2067,8 @@ abstract class CoercingRewriter[Pre <: Generation]()
       case value: CIntegerValue[Pre] => e
       case value: IntegerValue[Pre] => e
       case value: FloatValue[Pre] => e
+      case value: FloatNaN[Pre] => e
+      case value: FloatInf[Pre] => e
       case value @ Value(loc) => Value(loc)
       case value @ AutoValue(loc) => value
       case values @ Values(arr, from, to) =>
@@ -2116,7 +2099,7 @@ abstract class CoercingRewriter[Pre <: Generation]()
         val vectorType = TVector(leftType.size, sharedType)
         VectorEq(coerce(left, vectorType), coerce(right, vectorType))
       case div @ VectorFloatDiv(_, _) =>
-        vectorFloatRatOp2(div, (l, r) => VectorFloatDiv(l, r)(div.blame))
+        vectorFloatOp2(div, (l, r) => VectorFloatDiv(l, r)(div.blame))
       case div @ VectorFloorDiv(_, _) =>
         vectorIntOp2(div, (l, r) => VectorFloorDiv(l, r)(div.blame))
       case minus @ VectorMinus(_, _) =>

--- a/src/col/vct/col/typerules/CoercingRewriter.scala
+++ b/src/col/vct/col/typerules/CoercingRewriter.scala
@@ -622,6 +622,25 @@ abstract class CoercingRewriter[Pre <: Generation]()
       )
     f(left._1, right._1)
   }
+  def vectorFloatRatOp2[T](
+      e: BinExpr[Pre],
+      f: (Expr[Pre], Expr[Pre]) => T,
+  ): T = {
+    implicit val o: Origin = e.o
+    val (left, right) = firstOk(
+      e,
+      s"Expected both operands to be of type vector[float or rational], but got ${e
+          .left.t} and ${e.right.t}.",
+      (vectorFloat(e.left), vectorFloat(e.right)),
+      (vectorRational(e.left), vectorRational(e.right)),
+    )
+    if (left._2.size != right._2.size)
+      throw IncoercibleText(
+        e,
+        "This expression does not have a matching vector lengths",
+      )
+    f(left._1, right._1)
+  }
   def vectorOp2[T](e: BinExpr[Pre], f: (Expr[Pre], Expr[Pre]) => T): T = {
     implicit val o: Origin = e.o
     val (left, right) = firstOk(
@@ -2097,7 +2116,7 @@ abstract class CoercingRewriter[Pre <: Generation]()
         val vectorType = TVector(leftType.size, sharedType)
         VectorEq(coerce(left, vectorType), coerce(right, vectorType))
       case div @ VectorFloatDiv(_, _) =>
-        vectorFloatOp2(div, (l, r) => VectorFloatDiv(l, r)(div.blame))
+        vectorFloatRatOp2(div, (l, r) => VectorFloatDiv(l, r)(div.blame))
       case div @ VectorFloorDiv(_, _) =>
         vectorIntOp2(div, (l, r) => VectorFloorDiv(l, r)(div.blame))
       case minus @ VectorMinus(_, _) =>

--- a/src/main/vct/main/stages/Transformation.scala
+++ b/src/main/vct/main/stages/Transformation.scala
@@ -476,13 +476,14 @@ case class SilverTransformation(
         ExtractInlineQuantifierPatterns,
         EncodeBitVectors.withArg(opaqueBitwiseOperators),
         // Translate internal types to domains
+        ImportVector.withArg(adtImporter),
+        // After ImportVector, but before SmtlibToProverTypes
         FloatToRat,
         SmtlibToProverTypes,
         EnumToDomain,
         ImportArray.withArg(adtImporter),
         ImportConstPointer.withArg(adtImporter),
         ImportPointer.withArg(adtImporter),
-        ImportVector.withArg(adtImporter),
         ImportMapCompat.withArg(adtImporter),
         ImportEither.withArg(adtImporter),
         ImportTuple.withArg(adtImporter),

--- a/src/parsers/antlr4/LangCLexer.g4
+++ b/src/parsers/antlr4/LangCLexer.g4
@@ -124,6 +124,9 @@ Arrow : '->';
 Dot : '.';
 Ellipsis : '...';
 
+NAN: 'vercorsNAN';
+INFINITY: 'vercorsINFINITY';
+
 fragment
 IdentifierNondigit
     :   Nondigit

--- a/src/parsers/antlr4/LangCParser.g4
+++ b/src/parsers/antlr4/LangCParser.g4
@@ -41,6 +41,8 @@ primaryExpression
     |   '__builtin_va_arg' '(' unaryExpression ',' typeName ')'
     |   '__builtin_offsetof' '(' typeName ',' unaryExpression ')'
     |   'NULL'
+    |   'vercorsNAN'
+    |   'vercorsINFINITY'
     ;
 
 annotatedPrimaryExpression

--- a/src/parsers/vct/parsers/transform/CToCol.scala
+++ b/src/parsers/vct/parsers/transform/CToCol.scala
@@ -1014,6 +1014,8 @@ case class CToCol[G](
       case PrimaryExpression7(_, _, _, _, _, _) => ??(expr)
       case PrimaryExpression8(_, _, _, _, _, _) => ??(expr)
       case PrimaryExpression9(_) => col.Null()
+      case PrimaryExpression10(_) => FloatNaN(TFloats.C_ieee754_64bit)
+      case PrimaryExpression11(_) => FloatInf(TFloats.C_ieee754_64bit)
     }
 
   def convert(implicit ids: IdentifierListContext): Seq[String] =

--- a/src/rewrite/vct/rewrite/CFloatIntCoercion.scala
+++ b/src/rewrite/vct/rewrite/CFloatIntCoercion.scala
@@ -1,24 +1,7 @@
 package vct.col.rewrite
 
 import vct.col.ast.`type`.typeclass.TFloats
-import vct.col.ast.{
-  BinExpr,
-  CIntegerValue,
-  Cast,
-  CastFloat,
-  CoerceCFloatCInt,
-  CoerceCIntCFloat,
-  CoerceDecreasePrecision,
-  Coercion,
-  Expr,
-  IntegerValue,
-  TCFloat,
-  TCInt,
-  TFloat,
-  TInt,
-  Type,
-  TypeValue,
-}
+import vct.col.ast._
 import vct.col.origin.Origin
 import vct.col.rewrite.{Generation, RewriterBuilder}
 import vct.col.typerules.CoercingRewriter
@@ -38,7 +21,30 @@ case class CFloatIntCoercion[Pre <: Generation]()
       case CoerceCFloatCInt(_) => CastFloat(e, TInt())
       case CoerceCIntCFloat(target) => CastFloat(e, dispatch(target))
       case CoerceDecreasePrecision(_, target) => CastFloat(e, dispatch(target))
+      case c if ignoreMappedCoercion(c) => e
       case other => super.applyCoercion(e, other)
+    }
+
+  def isIgnoredCoercion(c: Coercion[_]): Boolean =
+    c match {
+      case CoerceCFloatFloat(_, _) => true
+      case CoerceCIntInt(_) => true
+      case CoerceIncreasePrecision(_, _) => true
+      case CoerceIncreasePrecision(_, _) => true
+      case _ => false
+    }
+
+  def ignoreMappedCoercion(c: Coercion[_]): Boolean =
+    c match {
+      case CoerceMapSeq(inner, _, _) if isIgnoredCoercion(inner) => true
+      case CoerceMapSet(inner, _, _) if isIgnoredCoercion(inner) => true
+      case CoerceMapBag(inner, _, _) if isIgnoredCoercion(inner) => true
+      case CoerceMapMap(inner, _, _) if isIgnoredCoercion(inner) => true
+      case CoerceMapTuple(inner, _, _) if inner.forall(isIgnoredCoercion) =>
+        true
+      case CoerceMapVector(inner, _, _, _) if isIgnoredCoercion(inner) => true
+      case CoerceMapOption(inner, _, _) if isIgnoredCoercion(inner) => true
+      case _ => false
     }
 
   override def postCoerce(t: Type[Pre]): Type[Post] =
@@ -49,7 +55,7 @@ case class CFloatIntCoercion[Pre <: Generation]()
       // to an arbitrary big float.
       case TCFloat(e, m) => TFloats.ieee754_32bit
       case TFloat(e, m) => TFloats.ieee754_32bit
-      case other => super.postCoerce(other)
+      case other => other.rewriteDefault() // super.postCoerce(other)
     }
 
   override def postCoerce(e: Expr[Pre]): Expr[Post] =
@@ -58,6 +64,6 @@ case class CFloatIntCoercion[Pre <: Generation]()
       case Cast(e, TypeValue(TCInt())) if e.t.isInstanceOf[TCInt[Pre]] =>
         dispatch(e)
       case CIntegerValue(v, _) => IntegerValue(v)(e.o)
-      case other => super.postCoerce(other)
+      case other => other.rewriteDefault() // super.postCoerce(other)
     }
 }

--- a/src/rewrite/vct/rewrite/CFloatIntCoercion.scala
+++ b/src/rewrite/vct/rewrite/CFloatIntCoercion.scala
@@ -53,9 +53,9 @@ case class CFloatIntCoercion[Pre <: Generation]()
       // This is wrong, but since we translate to rationals anyways, this does not matter.
       // Getting everything to type check otherwise is a pain, since in "coerce" we always coerce
       // to an arbitrary big float.
-      case TCFloat(e, m) => TFloats.ieee754_32bit
-      case TFloat(e, m) => TFloats.ieee754_32bit
-      case other => other.rewriteDefault() // super.postCoerce(other)
+      case TCFloat(_, _) => TFloats.ieee754_32bit
+      case TFloat(_, _) => TFloats.ieee754_32bit
+      case other => other.rewriteDefault()
     }
 
   override def postCoerce(e: Expr[Pre]): Expr[Post] =
@@ -64,6 +64,6 @@ case class CFloatIntCoercion[Pre <: Generation]()
       case Cast(e, TypeValue(TCInt())) if e.t.isInstanceOf[TCInt[Pre]] =>
         dispatch(e)
       case CIntegerValue(v, _) => IntegerValue(v)(e.o)
-      case other => other.rewriteDefault() // super.postCoerce(other)
+      case other => other.rewriteDefault()
     }
 }

--- a/src/rewrite/vct/rewrite/FloatToRat.scala
+++ b/src/rewrite/vct/rewrite/FloatToRat.scala
@@ -32,28 +32,102 @@ case class FloatToRat[Pre <: Generation]() extends Rewriter[Pre] {
       case TFloat(e, m) => s"f${e}_$m"
     }
 
-  private val nonDetFloatOrigin: Origin = Origin(
+  private val floatOrigin: Origin = Origin(
     Seq(LabelContext("float to rational conversion"))
   )
 
-  val nonDetFloat: mutable.Map[Unit, Function[Post]] = mutable.Map()
+  val specialFloats: mutable.Map[String, Function[Post]] = mutable.Map()
+  val floatDiv: mutable.Map[Unit, Function[Post]] = mutable.Map()
 
-  def getNonDetFloat(): Expr[Post] = {
-    val nondetFunc = nonDetFloat.getOrElseUpdate((), makeNondetFloatFunc())
+  def NaN(implicit o: Origin): Expr[Post] = makeSpecialFloatInv("NaN")
+  def posInf(implicit o: Origin): Expr[Post] = makeSpecialFloatInv("PosInf")
+  def negInf(implicit o: Origin): Expr[Post] = UMinus(posInf)
+
+  def makeSpecialFloatInv(
+      name: String
+  )(implicit o: Origin): FunctionInvocation[Post] = {
+    val nondetFunc = specialFloats.getOrElseUpdate(name, makeSpecialFloat(name))
     FunctionInvocation[Post](nondetFunc.ref, Seq(), Nil, Nil, Nil)(
       TrueSatisfiable
-    )(nonDetFloatOrigin)
+    )(o)
   }
 
-  def makeNondetFloatFunc(): Function[Post] = {
+  def getFloatDiv(a: Expr[Post], b: Expr[Post])(
+      implicit o: Origin
+  ): FunctionInvocation[Post] = {
+    val nondetFunc = floatDiv.getOrElseUpdate((), makeFloatDiv())
+    FunctionInvocation[Post](nondetFunc.ref, Seq(a, b), Nil, Nil, Nil)(
+      TrueSatisfiable
+    )(o)
+  }
+
+  def isInf(a: Expr[Post]): Expr[Post] = {
+    implicit val o: Origin = floatOrigin
+    a === posInf || a === negInf
+  }
+
+  def z: Expr[Post] = {
+    implicit val o: Origin = floatOrigin
+    const[Post](0) /:/ const(1)
+  }
+
+  def makeFloatOp(
+      body: (Expr[Post], Expr[Post]) => Expr[Post],
+      name: String,
+  ): Function[Post] = {
+    implicit val o: Origin = floatOrigin
+    val new_t = TRational[Post]()
+    val a_var = new Variable[Post](new_t)(floatOrigin.where(name = "a"))
+    val b_var = new Variable[Post](new_t)(floatOrigin.where(name = "b"))
+
+    val a = Local[Post](a_var.ref)
+    val b = Local[Post](b_var.ref)
+
     globalDeclarations.declare(
-      withResult((result: Result[Post]) =>
-        function[Post](
-          blame = AbstractApplicable,
-          contractBlame = TrueSatisfiable,
-          returnType = TRational(),
-        )(nonDetFloatOrigin.where(name = "nonDetFloat"))
-      )(nonDetFloatOrigin)
+      function[Post](
+        blame = AbstractApplicable,
+        contractBlame = TrueSatisfiable,
+        returnType = TRational(),
+        args = Seq(a_var, b_var),
+        body = Some(body(a, b)),
+      )(floatOrigin.where(name = name))
+    )
+  }
+
+  // Normally floats don't fail on division by zero, they get the `inf` value.
+  // Thus we use this function for division
+  def makeFloatDiv(): Function[Post] = {
+    val body =
+      (a: Expr[Post], b: Expr[Post]) => {
+        implicit val o: Origin = floatOrigin
+        // If we want to support NaN, this would look like the following:
+        // Select((b === z && a === z) || (isInf(b) && isInf(a)) || a === NaN || b === NaN, NaN,
+        // Anyway I think this complicates stuff atm, since you can never really check calculations anymore, since
+        // something could be NaN and then NaN keeps propagating. To properly do this we need an ADT for floats
+
+        // +/-a/0=+/-inf (also if a is inf, see:
+        Select(
+          b === z,
+          Select(a > z, posInf, negInf),
+          Select(
+            isInf(b),
+            z, // This should be +/- zero, but we only have regular zero
+            // Otherwise, standard def
+            a /:/ b,
+          ),
+        )
+      }
+
+    makeFloatOp(body, "floatDiv")
+  }
+
+  def makeSpecialFloat(name: String): Function[Post] = {
+    globalDeclarations.declare(
+      function[Post](
+        blame = AbstractApplicable,
+        contractBlame = TrueSatisfiable,
+        returnType = TRational(),
+      )(floatOrigin.where(name = name))
     )
   }
 
@@ -78,21 +152,29 @@ case class FloatToRat[Pre <: Generation]() extends Rewriter[Pre] {
           denominator = denominator * 10
         }
         const[Post](numerator.toBigIntExact.get) /:/ const(denominator)
+      /* We should define for all operators working on floats (+, -, *, /, <, >, <=, >= !=, ==) how they interact with
+       * inf and NaN. But we do not atm. This should be based on the IEEE754 standard
+       * However, C/C++ programs only work with this, when the hardware actually adheres to this standard.
+       * This can be checked with `#ifdef NAN`
+       * So it depends on the hardware we run on. This is something we should then implement as well
+       *
+       * This was the best reference I could find so far:
+       * https://www.gnu.org/software/libc/manual/html_node/Infinity-and-NaN.html
+       *
+       * To really properly address this I think float should be encoded in a ADT, and then we have separate values for
+       * quiet NaN, signaling NaN , +Inf, -Inf, -Zero and Value, were value contains a rational value
+       */
       case div @ FloatDiv(left, right) =>
-        // Normally floats don't fail on division by zero, they get the `inf` value. Rewriting this to not fail on division by zero.
         implicit val o: Origin = div.o
-        val newRight = dispatch(right)
-        Select(
-          newRight !== const[Post](0) /:/ const(1),
-          RatDiv(dispatch(left), newRight)(div.blame)(div.o),
-          getNonDetFloat(),
-        )(div.o)
-      case e => rewriteDefault(e)
+        getFloatDiv(dispatch(left), dispatch(right))
+      case FloatNaN(_) => NaN(expr.o)
+      case FloatInf(_) => posInf(expr.o)
+      case e => e.rewriteDefault()
     }
 
   override def dispatch(t: Type[Pre]): Type[Post] =
     t match {
       case TFloat(_, _) => TRational()(t.o)
-      case t => rewriteDefault(t)
+      case t => t.rewriteDefault()
     }
 }

--- a/src/rewrite/vct/rewrite/FloatToRat.scala
+++ b/src/rewrite/vct/rewrite/FloatToRat.scala
@@ -104,18 +104,11 @@ case class FloatToRat[Pre <: Generation]() extends Rewriter[Pre] {
         // Select((b === z && a === z) || (isInf(b) && isInf(a)) || a === NaN || b === NaN, NaN,
         // Anyway I think this complicates stuff atm, since you can never really check calculations anymore, since
         // something could be NaN and then NaN keeps propagating. To properly do this we need an ADT for floats
+        // Strictly speaking we need 1/inf == 0, but if we add that here, you'd always have to say that a certain value
+        // is not inf. Even 5/1 does not work, since the prover thinks that 5 could be inf.
 
         // +/-a/0=+/-inf (also if a is inf, see:
-        Select(
-          b === z,
-          Select(a > z, posInf, negInf),
-          Select(
-            isInf(b),
-            z, // This should be +/- zero, but we only have regular zero
-            // Otherwise, standard def
-            a /:/ b,
-          ),
-        )
+        Select(b === z, Select(a > z, posInf, negInf), a /:/ b)
       }
 
     makeFloatOp(body, "floatDiv")

--- a/src/rewrite/vct/rewrite/adt/ImportVector.scala
+++ b/src/rewrite/vct/rewrite/adt/ImportVector.scala
@@ -277,31 +277,6 @@ case class ImportVector[Pre <: Generation](importer: ImportADTImporter)
     )(blame)(o)
   }
 
-  private val nonDetFloatOrigin: Origin = Origin(
-    Seq(LabelContext("float to rational conversion"))
-  )
-
-  val nonDetFloat: mutable.Map[Unit, Function[Post]] = mutable.Map()
-
-  def getNonDetFloat(): Expr[Post] = {
-    val nondetFunc = nonDetFloat.getOrElseUpdate((), makeNondetFloatFunc())
-    FunctionInvocation[Post](nondetFunc.ref, Seq(), Nil, Nil, Nil)(
-      TrueSatisfiable
-    )(nonDetFloatOrigin)
-  }
-
-  def makeNondetFloatFunc(): Function[Post] = {
-    globalDeclarations.declare(
-      withResult((result: Result[Post]) =>
-        function[Post](
-          blame = AbstractApplicable,
-          contractBlame = TrueSatisfiable,
-          returnType = TRational(),
-        )(nonDetFloatOrigin.where(name = "nonDetFloat"))
-      )(nonDetFloatOrigin)
-    )
-  }
-
   override def postCoerce(e: Expr[Pre]): Expr[Post] =
     e match {
       case LiteralVector(element, xs) =>
@@ -446,16 +421,10 @@ case class ImportVector[Pre <: Generation](importer: ImportADTImporter)
                 makeVectorOp(
                   size,
                   elementT,
-                  // We do not want to check for non zeroness
+                  // We do not want to check for non zeroness for floats
                   isDivOp = false,
                   isCompareOp = false,
-                  // Floats are turned into rationals, and floats don't care about division by zero per se
-                  (l, r) =>
-                    Select(
-                      Neq(r, const[Post](0)),
-                      RatDiv[Post](l, r)(div.blame)(o),
-                      getNonDetFloat(),
-                    ),
+                  (l, r) => FloatDiv[Post](l, r)(div.blame)(o),
                   "div",
                 ),
               )

--- a/src/rewrite/vct/rewrite/adt/ImportVector.scala
+++ b/src/rewrite/vct/rewrite/adt/ImportVector.scala
@@ -277,6 +277,31 @@ case class ImportVector[Pre <: Generation](importer: ImportADTImporter)
     )(blame)(o)
   }
 
+  private val nonDetFloatOrigin: Origin = Origin(
+    Seq(LabelContext("float to rational conversion"))
+  )
+
+  val nonDetFloat: mutable.Map[Unit, Function[Post]] = mutable.Map()
+
+  def getNonDetFloat(): Expr[Post] = {
+    val nondetFunc = nonDetFloat.getOrElseUpdate((), makeNondetFloatFunc())
+    FunctionInvocation[Post](nondetFunc.ref, Seq(), Nil, Nil, Nil)(
+      TrueSatisfiable
+    )(nonDetFloatOrigin)
+  }
+
+  def makeNondetFloatFunc(): Function[Post] = {
+    globalDeclarations.declare(
+      withResult((result: Result[Post]) =>
+        function[Post](
+          blame = AbstractApplicable,
+          contractBlame = TrueSatisfiable,
+          returnType = TRational(),
+        )(nonDetFloatOrigin.where(name = "nonDetFloat"))
+      )(nonDetFloatOrigin)
+    )
+  }
+
   override def postCoerce(e: Expr[Pre]): Expr[Post] =
     e match {
       case LiteralVector(element, xs) =>
@@ -413,15 +438,24 @@ case class ImportVector[Pre <: Generation](importer: ImportADTImporter)
                 ),
               )
             case div: VectorFloatDiv[Pre] =>
-              val o: Origin = Origin(Seq(LabelContext("vector div method")))
+              implicit val o: Origin = Origin(
+                Seq(LabelContext("vector div method"))
+              )
               vectorOpsMethods.getOrElseUpdate(
                 (size, "floatDiv", elementT),
                 makeVectorOp(
                   size,
                   elementT,
-                  isDivOp = divOp,
+                  // We do not want to check for non zeroness
+                  isDivOp = false,
                   isCompareOp = false,
-                  (l, r) => FloatDiv[Post](l, r)(div.blame)(o),
+                  // Floats are turned into rationals, and floats don't care about division by zero per se
+                  (l, r) =>
+                    Select(
+                      Neq(r, const[Post](0)),
+                      RatDiv[Post](l, r)(div.blame)(o),
+                      getNonDetFloat(),
+                    ),
                   "div",
                 ),
               )

--- a/src/rewrite/vct/rewrite/lang/LangCToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangCToCol.scala
@@ -1666,6 +1666,9 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
             case CTPointer(struct) =>
               getBaseStructTypeWithUnique(struct).map({ case (t, _) => t.ref })
                 .getOrElse(throw WrongStructType(deref.struct.t))
+            case CTArray(_, struct) =>
+              getBaseStructTypeWithUnique(struct).map({ case (t, _) => t.ref })
+                .getOrElse(throw WrongStructType(deref.struct.t))
             case t => throw WrongStructType(t)
           }
         Deref[Post](

--- a/test/main/vct/test/integration/examples/TechnicalFloatSpec.scala
+++ b/test/main/vct/test/integration/examples/TechnicalFloatSpec.scala
@@ -117,6 +117,14 @@ class TechnicalFloatSpec extends VercorsSpec {
       }
   """
 
+  vercors should verify using silicon in "division of float" c """
+      #include <math.h>
+
+      void m() {
+        //@ assert(1.0/0.0 == INFINITY);
+      }
+  """
+
   vercors should verify using silicon in "inequality of floats c" c """
       #include "stdbool.h"
       bool m() {


### PR DESCRIPTION
- [ ] The wiki is updated in accordance with the changes in this PR. For example: syntax changes, semantics changes, VerCors flags changes, etc.

# PR description
Vectors:
* For vectors, the division operator was not working properly (since float went to rats, and it didn't type check anymore)
* I removed some spurious coercionmap functions to appear after Cint to int coercions
* I've added a bunch of AVX and AVX2 functions in the header file.

xs->x works for array of structs:
* I now allow `struct v xs[1]; xs->x` to work (it complained about not valid vector type before) 