### PR TITLE
Remove permissions to struct values

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -61,7 +61,7 @@ object external extends Module {
 object viper extends ScalaModule {
   object silverGit extends GitModule {
     def url = T { "https://github.com/viperproject/silver.git" }
-    def commitish = T { "08c001b33decce0b16e698be862d7904c7282a99" }
+    def commitish = T { "8d76b10ad5a99965ec2a15530bef65c223682163" }
     def filteredRepo = T {
       val workspace = repo()
       os.remove.all(workspace / "src" / "test")
@@ -70,8 +70,8 @@ object viper extends ScalaModule {
   }
 
   object siliconGit extends GitModule {
-    def url = T { "https://github.com/viperproject/silicon.git" }
-    def commitish = T { "2257d9c029d368629ed1f831c3c959713b1d1d10" }
+    def url = T { "https://github.com/superaxander/silicon.git" }
+    def commitish = T { "c53d4ddd38b2652a03e712c157f1619bd6af6f42" }
     def filteredRepo = T {
       val workspace = repo()
       os.remove.all(workspace / "src" / "test")
@@ -82,7 +82,7 @@ object viper extends ScalaModule {
 
   object carbonGit extends GitModule {
     def url = T { "https://github.com/viperproject/carbon.git" }
-    def commitish = T { "2da52018ead6e1f17fb1c67adc65ecdd4ff6c155" }
+    def commitish = T { "30d8949751330ee7120972d9846af49b5a74f040" }
     def filteredRepo = T {
       val workspace = repo()
       os.remove.all(workspace / "src" / "test")

--- a/build.sc
+++ b/build.sc
@@ -61,7 +61,7 @@ object external extends Module {
 object viper extends ScalaModule {
   object silverGit extends GitModule {
     def url = T { "https://github.com/viperproject/silver.git" }
-    def commitish = T { "8d76b10ad5a99965ec2a15530bef65c223682163" }
+    def commitish = T { "7807892feadbf777121ee2c32b19ff17c89689e1" }
     def filteredRepo = T {
       val workspace = repo()
       os.remove.all(workspace / "src" / "test")
@@ -70,8 +70,8 @@ object viper extends ScalaModule {
   }
 
   object siliconGit extends GitModule {
-    def url = T { "https://github.com/superaxander/silicon.git" }
-    def commitish = T { "d281a0463b25f35d81b675f673f6a6c19dac6b23" }
+    def url = T { "https://github.com/viperproject/silicon.git" }
+    def commitish = T { "2139dd1bf093e407831e3d79e2406c21ff4743cb" }
     def filteredRepo = T {
       val workspace = repo()
       os.remove.all(workspace / "src" / "test")
@@ -82,7 +82,7 @@ object viper extends ScalaModule {
 
   object carbonGit extends GitModule {
     def url = T { "https://github.com/viperproject/carbon.git" }
-    def commitish = T { "30d8949751330ee7120972d9846af49b5a74f040" }
+    def commitish = T { "b2964f738137645967ad86d57f9b6d52e66f5710" }
     def filteredRepo = T {
       val workspace = repo()
       os.remove.all(workspace / "src" / "test")

--- a/build.sc
+++ b/build.sc
@@ -71,7 +71,7 @@ object viper extends ScalaModule {
 
   object siliconGit extends GitModule {
     def url = T { "https://github.com/superaxander/silicon.git" }
-    def commitish = T { "c53d4ddd38b2652a03e712c157f1619bd6af6f42" }
+    def commitish = T { "8ba5c7bc933073a6db849cc0de8e30d575397baa" }
     def filteredRepo = T {
       val workspace = repo()
       os.remove.all(workspace / "src" / "test")

--- a/build.sc
+++ b/build.sc
@@ -71,7 +71,7 @@ object viper extends ScalaModule {
 
   object siliconGit extends GitModule {
     def url = T { "https://github.com/superaxander/silicon.git" }
-    def commitish = T { "8ba5c7bc933073a6db849cc0de8e30d575397baa" }
+    def commitish = T { "d281a0463b25f35d81b675f673f6a6c19dac6b23" }
     def filteredRepo = T {
       val workspace = repo()
       os.remove.all(workspace / "src" / "test")

--- a/examples/concepts/c/pointer_casts.c
+++ b/examples/concepts/c/pointer_casts.c
@@ -31,7 +31,6 @@ void castRemainsValidInLoop() {
     int *pointer_to_integer = (int *)&struct_b;
 
     //@ loop_invariant 0 <= i && i <= 10;
-    //@ loop_invariant Perm(&struct_b, write);
     //@ loop_invariant Perm(struct_b, write);
     //@ loop_invariant pointer_to_integer == (int *)&struct_b;
     //@ loop_invariant *pointer_to_integer == 10 - i;

--- a/examples/concepts/c/structs.c
+++ b/examples/concepts/c/structs.c
@@ -20,7 +20,7 @@ struct linked_list{
 };
 
 /*@
-    context p != NULL ** Perm(p, write);
+    context p != NULL;
     context Perm(&p->x, write);
     context Perm(&p->y, write);
     ensures p->x == 0;
@@ -33,7 +33,7 @@ void alter_struct(struct point *p){
 }
 
 /*@
-    context p != NULL ** Perm(p, write);
+    context p != NULL;
     context Perm(&p->x, write);
     context Perm(&p->y, write);
     ensures p->x == 0;
@@ -46,7 +46,7 @@ void alter_struct2(struct point p[]){
 }
 
 /*@
-    context p != NULL ** Perm(p, write) ** Perm(*p, write);
+    context p != NULL ** Perm(*p, write);
     ensures p->x == \old(p->x + 1);
     ensures p->y == \old(p->y + 1);
     ensures \old(*p) == *p;
@@ -75,7 +75,7 @@ void alter_copy_struct_2(struct point p){
 }
 
 /*@
-  context r != NULL ** Perm(r, 1\2) ** Perm(*r, 1\2);
+  context r != NULL ** Perm(*r, 1\2);
   ensures \result == (r->p1.x + r->p2.x + r->p3.x)/3;
 @*/
 int avr_x(struct triangle *r){
@@ -87,7 +87,6 @@ int avr_x(struct triangle *r){
  //decreases n;
  requires n >= 0;
  requires inp != NULL && \pointer_length(inp) >= n;
- requires (\forall* int i; 0 <= i && i < n; Perm(&inp[i], 1\10));
  requires (\forall int i, int j; 0<=i && i<n && 0<=j && j<n; i != j ==> {:inp[i]:} != {:inp[j]:});
  requires (\forall* int i; 0 <= i && i < n; Perm(&inp[i].x, 1\10));
  ensures |\result| == n;
@@ -104,9 +103,8 @@ pure int sum_seq(seq<int> xs) = |xs| == 0 ? 0 : sum_seq(xs[.. (|xs|-1)]) + xs[ |
 
 /*@
   requires len > 0;
-  context p != NULL ** Perm(p, 1\2) ** Perm(*p, 1\2);
+  context p != NULL ** Perm(*p, 1\2);
   context p->ps != NULL && \pointer_length(p->ps) >= len;
-  context (\forall* int i; 0<=i && i<len; Perm(&p->ps[i], 1\2));
   context (\forall int i, int j; 0<=i && i<len && 0<=j && j<len; i != j ==> {:p->ps[i]:} != {:p->ps[j]:});
   context (\forall* int i; 0<=i && i<len; Perm(p->ps[i], 1\2));
   // This hangs for bigger numbers than 3, and is incredibly slow for 3, so we leave it out for now
@@ -118,9 +116,8 @@ int avr_x_pol(struct polygon *p, int len){
     // ghost seq<int> xs = inp_to_seq(p->ps, len);
     /*@
       loop_invariant 0<=i && i<=len;
-      loop_invariant p != NULL ** Perm(p, 1\2) ** Perm(*p, 1\2);
+      loop_invariant p != NULL ** Perm(*p, 1\2);
       loop_invariant p->ps != NULL && \pointer_length(p->ps) >= len;
-      loop_invariant (\forall* int i; 0<=i && i<len; Perm(&p->ps[i], 1\2));
       loop_invariant (\forall int i, int j; 0<=i && i<len && 0<=j && j<len; i != j ==> {:p->ps[i]:} != {:p->ps[j]:});
       loop_invariant (\forall* int i; 0<=i && i<len; Perm(p->ps[i], 1\2));
       //loop_invariant (\forall int i; 0<=i && i<len; p->ps[i].x == xs[i]);

--- a/examples/concepts/c/tagged_struct.c
+++ b/examples/concepts/c/tagged_struct.c
@@ -23,11 +23,9 @@ void baz() {
     //@ loop_invariant 0 <= i && i <= 2;
     //@ loop_invariant elems != NULL;
     //@ loop_invariant \pointer(elems, 2, write);
-    //@ loop_invariant Perm(&e1, write);
     //@ loop_invariant Perm(e1, write);
     //@ loop_invariant e1.d != NULL;
     //@ loop_invariant Perm(e1.d, write);
-    //@ loop_invariant Perm(&e2, write);
     //@ loop_invariant Perm(e2, write);
     //@ loop_invariant e2.d != NULL;
     //@ loop_invariant Perm(e2.d, write);

--- a/examples/concepts/llvm/pallas/pallas_c_perm.c
+++ b/examples/concepts/llvm/pallas/pallas_c_perm.c
@@ -2,8 +2,8 @@
 // Test that the permission-annotations of Pallas work as expected.
 
 /*@
-requires ptr != NULL && Perm(ptr, fracOf(1, 2));
-ensures Perm(ptr, fracOf(1, 2));
+requires ptr != NULL && _Perm(ptr, _fracOf(1, 2));
+ensures _Perm(ptr, _fracOf(1, 2));
 @*/
 int foo(int *ptr) {
     return *ptr + 5;
@@ -14,10 +14,9 @@ typedef struct S {
 } BigStruct;
 
 /*@
-requires s != NULL && Perm(s, fracOf(1, 2));
-requires sep(Perm(&s->a, fracOf(1, 1)), Perm(&s->b, fracOf(1, 1)));
-ensures Perm(s, fracOf(1, 2));
-ensures sep(Perm(&s->a, fracOf(1, 1)), Perm(&s->b, fracOf(1, 1)));
+requires s != NULL;
+requires _sep(_Perm(&s->a, _write), _Perm(&s->b, _write));
+ensures _sep(_Perm(&s->a, _write), _Perm(&s->b, _write));
 ensures s->a == 0 && s->b == 0;
 @*/
 void bar(BigStruct *s) {

--- a/examples/concepts/llvm/pallas/pallas_c_perm.ll
+++ b/examples/concepts/llvm/pallas/pallas_c_perm.ll
@@ -6,7 +6,7 @@ target triple = "x86_64-unknown-linux-gnu"
 %struct.S = type { i64, i64, i64, i64, i64, i64, i64 }
 %pallas.fracT = type { i64, i64, i64, i64 }
 
-@llvm.used = appending global [7 x ptr] [ptr @PALLAS_SPEC_0, ptr @PALLAS_SPEC_1, ptr @PALLAS_SPEC_2, ptr @PALLAS_SPEC_3, ptr @PALLAS_SPEC_4, ptr @PALLAS_SPEC_5, ptr @PALLAS_SPEC_6], section "llvm.metadata"
+@llvm.used = appending global [6 x ptr] [ptr @PALLAS_SPEC_0, ptr @PALLAS_SPEC_1, ptr @PALLAS_SPEC_2, ptr @PALLAS_SPEC_3, ptr @PALLAS_SPEC_4, ptr @PALLAS_SPEC_5], section "llvm.metadata"
 
 ; Function Attrs: noinline nounwind uwtable
 define dso_local i32 @foo(ptr noundef %0) #0 !dbg !14 !pallas.fcontract !20 {
@@ -26,125 +26,106 @@ declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
 define dso_local void @bar(ptr noundef %0) #0 !dbg !32 !pallas.fcontract !51 {
   %2 = alloca ptr, align 8
   store ptr %0, ptr %2, align 8
-  call void @llvm.dbg.declare(metadata ptr %2, metadata !55, metadata !DIExpression()), !dbg !64
-  %3 = load ptr, ptr %2, align 8, !dbg !65
-  %4 = getelementptr inbounds %struct.S, ptr %3, i32 0, i32 0, !dbg !66
-  store i64 0, ptr %4, align 8, !dbg !67
-  %5 = load ptr, ptr %2, align 8, !dbg !68
-  %6 = getelementptr inbounds %struct.S, ptr %5, i32 0, i32 1, !dbg !69
-  store i64 0, ptr %6, align 8, !dbg !70
-  ret void, !dbg !71
+  call void @llvm.dbg.declare(metadata ptr %2, metadata !55, metadata !DIExpression()), !dbg !62
+  %3 = load ptr, ptr %2, align 8, !dbg !63
+  %4 = getelementptr inbounds %struct.S, ptr %3, i32 0, i32 0, !dbg !64
+  store i64 0, ptr %4, align 8, !dbg !65
+  %5 = load ptr, ptr %2, align 8, !dbg !66
+  %6 = getelementptr inbounds %struct.S, ptr %5, i32 0, i32 1, !dbg !67
+  store i64 0, ptr %6, align 8, !dbg !68
+  ret void, !dbg !69
 }
 
 ; Function Attrs: noinline nounwind uwtable
-define dso_local zeroext i1 @PALLAS_SPEC_0(ptr noundef %0) #0 !dbg !72 !pallas.exprWrapper !76 {
+define dso_local zeroext i1 @PALLAS_SPEC_0(ptr noundef %0) #0 !dbg !70 !pallas.exprWrapper !74 {
   %2 = alloca %pallas.fracT, align 8
-  call void @llvm.dbg.value(metadata ptr %0, metadata !77, metadata !DIExpression()), !dbg !78
-  %3 = icmp ne ptr %0, null, !dbg !79
-  br i1 %3, label %4, label %6, !dbg !80
+  call void @llvm.dbg.value(metadata ptr %0, metadata !75, metadata !DIExpression()), !dbg !76
+  %3 = icmp ne ptr %0, null, !dbg !77
+  br i1 %3, label %4, label %6, !dbg !78
 
 4:                                                ; preds = %1
-  call void @pallas.fracOf(ptr sret(%pallas.fracT) %2, i32 noundef 1, i32 noundef 2), !dbg !81
-  %5 = call i1 @pallas.perm(ptr noundef %0, ptr noundef byval(%pallas.fracT) %2), !dbg !82
+  call void @pallas.fracOf(ptr sret(%pallas.fracT) %2, i32 noundef 1, i32 noundef 2), !dbg !79
+  %5 = call i1 @pallas.perm(ptr noundef %0, ptr noundef byval(%pallas.fracT) %2), !dbg !80
   br label %6
 
 6:                                                ; preds = %4, %1
-  %7 = phi i1 [ false, %1 ], [ %5, %4 ], !dbg !78
-  ret i1 %7, !dbg !78
+  %7 = phi i1 [ false, %1 ], [ %5, %4 ], !dbg !76
+  ret i1 %7, !dbg !76
 }
 
 ; Function Attrs: noinline nounwind uwtable
-define dso_local zeroext i1 @PALLAS_SPEC_1(ptr noundef %0) #0 !dbg !83 !pallas.exprWrapper !76 {
+define dso_local zeroext i1 @PALLAS_SPEC_1(ptr noundef %0) #0 !dbg !81 !pallas.exprWrapper !74 {
   %2 = alloca %pallas.fracT, align 8
-  call void @llvm.dbg.value(metadata ptr %0, metadata !84, metadata !DIExpression()), !dbg !85
-  call void @pallas.fracOf(ptr sret(%pallas.fracT) %2, i32 noundef 1, i32 noundef 2), !dbg !86
-  %3 = call i1 @pallas.perm(ptr noundef %0, ptr noundef byval(%pallas.fracT) %2), !dbg !87
-  ret i1 %3, !dbg !85
+  call void @llvm.dbg.value(metadata ptr %0, metadata !82, metadata !DIExpression()), !dbg !83
+  call void @pallas.fracOf(ptr sret(%pallas.fracT) %2, i32 noundef 1, i32 noundef 2), !dbg !84
+  %3 = call i1 @pallas.perm(ptr noundef %0, ptr noundef byval(%pallas.fracT) %2), !dbg !85
+  ret i1 %3, !dbg !83
 }
 
 ; Function Attrs: noinline nounwind uwtable
-define dso_local zeroext i1 @PALLAS_SPEC_2(ptr noundef %0) #0 !dbg !88 !pallas.exprWrapper !76 {
-  %2 = alloca %pallas.fracT, align 8
-  call void @llvm.dbg.value(metadata ptr %0, metadata !103, metadata !DIExpression()), !dbg !104
-  %3 = icmp ne ptr %0, null, !dbg !105
-  br i1 %3, label %4, label %6, !dbg !106
-
-4:                                                ; preds = %1
-  call void @pallas.fracOf(ptr sret(%pallas.fracT) %2, i32 noundef 1, i32 noundef 2), !dbg !107
-  %5 = call i1 @pallas.perm(ptr noundef %0, ptr noundef byval(%pallas.fracT) %2), !dbg !108
-  br label %6
-
-6:                                                ; preds = %4, %1
-  %7 = phi i1 [ false, %1 ], [ %5, %4 ], !dbg !104
-  ret i1 %7, !dbg !104
+define dso_local zeroext i1 @PALLAS_SPEC_2(ptr noundef %0) #0 !dbg !86 !pallas.exprWrapper !74 {
+  call void @llvm.dbg.value(metadata ptr %0, metadata !101, metadata !DIExpression()), !dbg !102
+  %2 = icmp ne ptr %0, null, !dbg !103
+  ret i1 %2, !dbg !102
 }
 
 ; Function Attrs: noinline nounwind uwtable
-define dso_local zeroext i1 @PALLAS_SPEC_3(ptr noundef %0) #0 !dbg !109 !pallas.exprWrapper !76 {
+define dso_local zeroext i1 @PALLAS_SPEC_3(ptr noundef %0) #0 !dbg !104 !pallas.exprWrapper !74 {
   %2 = alloca %pallas.fracT, align 8
   %3 = alloca %pallas.fracT, align 8
-  call void @llvm.dbg.value(metadata ptr %0, metadata !110, metadata !DIExpression()), !dbg !111
-  %4 = getelementptr inbounds %struct.S, ptr %0, i32 0, i32 0, !dbg !112
-  call void @pallas.fracOf(ptr sret(%pallas.fracT) %2, i32 noundef 1, i32 noundef 1), !dbg !113
-  %5 = call i1 @pallas.perm(ptr noundef %4, ptr noundef byval(%pallas.fracT) %2), !dbg !114
-  %6 = getelementptr inbounds %struct.S, ptr %0, i32 0, i32 1, !dbg !115
-  call void @pallas.fracOf(ptr sret(%pallas.fracT) %3, i32 noundef 1, i32 noundef 1), !dbg !116
-  %7 = call i1 @pallas.perm(ptr noundef %6, ptr noundef byval(%pallas.fracT) %3), !dbg !117
-  %8 = call i1 @pallas.sepConj(i1 %5, i1 %7), !dbg !118
-  ret i1 %8, !dbg !111
+  call void @llvm.dbg.value(metadata ptr %0, metadata !105, metadata !DIExpression()), !dbg !106
+  %4 = getelementptr inbounds %struct.S, ptr %0, i32 0, i32 0, !dbg !107
+  call void @pallas.fracOf(ptr sret(%pallas.fracT) %2, i32 noundef 1, i32 noundef 1), !dbg !108
+  %5 = call i1 @pallas.perm(ptr noundef %4, ptr noundef byval(%pallas.fracT) %2), !dbg !109
+  %6 = getelementptr inbounds %struct.S, ptr %0, i32 0, i32 1, !dbg !110
+  call void @pallas.fracOf(ptr sret(%pallas.fracT) %3, i32 noundef 1, i32 noundef 1), !dbg !111
+  %7 = call i1 @pallas.perm(ptr noundef %6, ptr noundef byval(%pallas.fracT) %3), !dbg !112
+  %8 = call i1 @pallas.sepConj(i1 %5, i1 %7), !dbg !113
+  ret i1 %8, !dbg !106
 }
 
 ; Function Attrs: noinline nounwind uwtable
-define dso_local zeroext i1 @PALLAS_SPEC_4(ptr noundef %0) #0 !dbg !119 !pallas.exprWrapper !76 {
-  %2 = alloca %pallas.fracT, align 8
-  call void @llvm.dbg.value(metadata ptr %0, metadata !120, metadata !DIExpression()), !dbg !121
-  call void @pallas.fracOf(ptr sret(%pallas.fracT) %2, i32 noundef 1, i32 noundef 2), !dbg !122
-  %3 = call i1 @pallas.perm(ptr noundef %0, ptr noundef byval(%pallas.fracT) %2), !dbg !123
-  ret i1 %3, !dbg !121
-}
-
-; Function Attrs: noinline nounwind uwtable
-define dso_local zeroext i1 @PALLAS_SPEC_5(ptr noundef %0) #0 !dbg !124 !pallas.exprWrapper !76 {
+define dso_local zeroext i1 @PALLAS_SPEC_4(ptr noundef %0) #0 !dbg !114 !pallas.exprWrapper !74 {
   %2 = alloca %pallas.fracT, align 8
   %3 = alloca %pallas.fracT, align 8
+  call void @llvm.dbg.value(metadata ptr %0, metadata !115, metadata !DIExpression()), !dbg !116
+  %4 = getelementptr inbounds %struct.S, ptr %0, i32 0, i32 0, !dbg !117
+  call void @pallas.fracOf(ptr sret(%pallas.fracT) %2, i32 noundef 1, i32 noundef 1), !dbg !118
+  %5 = call i1 @pallas.perm(ptr noundef %4, ptr noundef byval(%pallas.fracT) %2), !dbg !119
+  %6 = getelementptr inbounds %struct.S, ptr %0, i32 0, i32 1, !dbg !120
+  call void @pallas.fracOf(ptr sret(%pallas.fracT) %3, i32 noundef 1, i32 noundef 1), !dbg !121
+  %7 = call i1 @pallas.perm(ptr noundef %6, ptr noundef byval(%pallas.fracT) %3), !dbg !122
+  %8 = call i1 @pallas.sepConj(i1 %5, i1 %7), !dbg !123
+  ret i1 %8, !dbg !116
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_5(ptr noundef %0) #0 !dbg !124 !pallas.exprWrapper !74 {
   call void @llvm.dbg.value(metadata ptr %0, metadata !125, metadata !DIExpression()), !dbg !126
-  %4 = getelementptr inbounds %struct.S, ptr %0, i32 0, i32 0, !dbg !127
-  call void @pallas.fracOf(ptr sret(%pallas.fracT) %2, i32 noundef 1, i32 noundef 1), !dbg !128
-  %5 = call i1 @pallas.perm(ptr noundef %4, ptr noundef byval(%pallas.fracT) %2), !dbg !129
-  %6 = getelementptr inbounds %struct.S, ptr %0, i32 0, i32 1, !dbg !130
-  call void @pallas.fracOf(ptr sret(%pallas.fracT) %3, i32 noundef 1, i32 noundef 1), !dbg !131
-  %7 = call i1 @pallas.perm(ptr noundef %6, ptr noundef byval(%pallas.fracT) %3), !dbg !132
-  %8 = call i1 @pallas.sepConj(i1 %5, i1 %7), !dbg !133
-  ret i1 %8, !dbg !126
-}
-
-; Function Attrs: noinline nounwind uwtable
-define dso_local zeroext i1 @PALLAS_SPEC_6(ptr noundef %0) #0 !dbg !134 !pallas.exprWrapper !76 {
-  call void @llvm.dbg.value(metadata ptr %0, metadata !135, metadata !DIExpression()), !dbg !136
-  %2 = getelementptr inbounds %struct.S, ptr %0, i32 0, i32 0, !dbg !137
-  %3 = load i64, ptr %2, align 8, !dbg !137
-  %4 = icmp eq i64 %3, 0, !dbg !138
-  br i1 %4, label %5, label %9, !dbg !139
+  %2 = getelementptr inbounds %struct.S, ptr %0, i32 0, i32 0, !dbg !127
+  %3 = load i64, ptr %2, align 8, !dbg !127
+  %4 = icmp eq i64 %3, 0, !dbg !128
+  br i1 %4, label %5, label %9, !dbg !129
 
 5:                                                ; preds = %1
-  %6 = getelementptr inbounds %struct.S, ptr %0, i32 0, i32 1, !dbg !140
-  %7 = load i64, ptr %6, align 8, !dbg !140
-  %8 = icmp eq i64 %7, 0, !dbg !141
+  %6 = getelementptr inbounds %struct.S, ptr %0, i32 0, i32 1, !dbg !130
+  %7 = load i64, ptr %6, align 8, !dbg !130
+  %8 = icmp eq i64 %7, 0, !dbg !131
   br label %9
 
 9:                                                ; preds = %5, %1
-  %10 = phi i1 [ false, %1 ], [ %8, %5 ], !dbg !136
-  ret i1 %10, !dbg !136
+  %10 = phi i1 [ false, %1 ], [ %8, %5 ], !dbg !126
+  ret i1 %10, !dbg !126
 }
 
 ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare void @llvm.dbg.value(metadata, metadata, metadata) #1
 
-declare !pallas.specLib !142 i1 @pallas.sepConj(i1, i1)
+declare !pallas.specLib !132 i1 @pallas.sepConj(i1, i1)
 
-declare !pallas.specLib !143 i1 @pallas.perm(ptr noundef, ptr noundef byval(%pallas.fracT))
+declare !pallas.specLib !133 i1 @pallas.perm(ptr noundef, ptr noundef byval(%pallas.fracT))
 
-declare !pallas.specLib !144 void @pallas.fracOf(ptr sret(%pallas.fracT), i32 noundef, i32 noundef)
+declare !pallas.specLib !134 void @pallas.fracOf(ptr sret(%pallas.fracT), i32 noundef, i32 noundef)
 
 attributes #0 = { noinline nounwind uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
@@ -154,9 +135,9 @@ attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memo
 !llvm.ident = !{!13, !13}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang version 17.0.0 (https://github.com/swiftlang/llvm-project.git 73500bf55acff5fa97b56dcdeb013f288efd084f)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
-!1 = !DIFile(filename: "examples/concepts/llvm/pallas/pallas_c_perm.c", directory: ".", checksumkind: CSK_MD5, checksum: "d2aa0438a967aa071e1ca93950bffbb7")
+!1 = !DIFile(filename: "examples/concepts/llvm/pallas/pallas_c_perm.c", directory: ".", checksumkind: CSK_MD5, checksum: "06af036f7ddb85158b950fc5ea26d4e8")
 !2 = distinct !DICompileUnit(language: DW_LANG_C11, file: !3, producer: "clang version 17.0.0 (https://github.com/swiftlang/llvm-project.git 73500bf55acff5fa97b56dcdeb013f288efd084f)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, retainedTypes: !4, splitDebugInlining: false, nameTableKind: None)
-!3 = !DIFile(filename: "tmp/source_wrappers.c", directory: ".", checksumkind: CSK_MD5, checksum: "0b69c1a1190a7c9aa30f22854b9e1f7f")
+!3 = !DIFile(filename: "tmp/source_wrappers.c", directory: ".", checksumkind: CSK_MD5, checksum: "eaeeec9d4bf512a82bce8d9cf1299077")
 !4 = !{!5}
 !5 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
 !6 = !{i32 7, !"Dwarf Version", i32 5}
@@ -176,16 +157,16 @@ attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memo
 !20 = !{!21, i1 false, !22, !25}
 !21 = !{!"pallas.srcLoc", i64 4, i64 1, i64 7, i64 1}
 !22 = !{!"pallas.requires", !23, ptr @PALLAS_SPEC_0, !24}
-!23 = !{!"pallas.srcLoc", i64 5, i64 1, i64 5, i64 48}
+!23 = !{!"pallas.srcLoc", i64 5, i64 1, i64 5, i64 50}
 !24 = !DILocalVariable(name: "ptr", arg: 1, scope: !14, file: !1, line: 8, type: !18)
 !25 = !{!"pallas.ensures", !26, ptr @PALLAS_SPEC_1, !24}
-!26 = !{!"pallas.srcLoc", i64 6, i64 1, i64 6, i64 32}
+!26 = !{!"pallas.srcLoc", i64 6, i64 1, i64 6, i64 34}
 !27 = !DILocation(line: 8, column: 14, scope: !14)
 !28 = !DILocation(line: 9, column: 13, scope: !14)
 !29 = !DILocation(line: 9, column: 12, scope: !14)
 !30 = !DILocation(line: 9, column: 17, scope: !14)
 !31 = !DILocation(line: 9, column: 5, scope: !14)
-!32 = distinct !DISubprogram(name: "bar", scope: !1, file: !1, line: 23, type: !33, scopeLine: 23, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !19)
+!32 = distinct !DISubprogram(name: "bar", scope: !1, file: !1, line: 22, type: !33, scopeLine: 22, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !19)
 !33 = !DISubroutineType(types: !34)
 !34 = !{null, !35}
 !35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
@@ -204,97 +185,87 @@ attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memo
 !48 = !DIDerivedType(tag: DW_TAG_member, name: "e", scope: !37, file: !1, line: 13, baseType: !40, size: 64, offset: 256)
 !49 = !DIDerivedType(tag: DW_TAG_member, name: "f", scope: !37, file: !1, line: 13, baseType: !40, size: 64, offset: 320)
 !50 = !DIDerivedType(tag: DW_TAG_member, name: "g", scope: !37, file: !1, line: 13, baseType: !40, size: 64, offset: 384)
-!51 = !{!52, i1 false, !53, !56, !58, !60, !62}
-!52 = !{!"pallas.srcLoc", i64 16, i64 1, i64 22, i64 1}
+!51 = !{!52, i1 false, !53, !56, !58, !60}
+!52 = !{!"pallas.srcLoc", i64 16, i64 1, i64 21, i64 1}
 !53 = !{!"pallas.requires", !54, ptr @PALLAS_SPEC_2, !55}
-!54 = !{!"pallas.srcLoc", i64 17, i64 1, i64 17, i64 44}
-!55 = !DILocalVariable(name: "s", arg: 1, scope: !32, file: !1, line: 23, type: !35)
+!54 = !{!"pallas.srcLoc", i64 17, i64 1, i64 17, i64 19}
+!55 = !DILocalVariable(name: "s", arg: 1, scope: !32, file: !1, line: 22, type: !35)
 !56 = !{!"pallas.requires", !57, ptr @PALLAS_SPEC_3, !55}
-!57 = !{!"pallas.srcLoc", i64 18, i64 1, i64 18, i64 67}
+!57 = !{!"pallas.srcLoc", i64 18, i64 1, i64 18, i64 58}
 !58 = !{!"pallas.ensures", !59, ptr @PALLAS_SPEC_4, !55}
-!59 = !{!"pallas.srcLoc", i64 19, i64 1, i64 19, i64 30}
+!59 = !{!"pallas.srcLoc", i64 19, i64 1, i64 19, i64 57}
 !60 = !{!"pallas.ensures", !61, ptr @PALLAS_SPEC_5, !55}
-!61 = !{!"pallas.srcLoc", i64 20, i64 1, i64 20, i64 66}
-!62 = !{!"pallas.ensures", !63, ptr @PALLAS_SPEC_6, !55}
-!63 = !{!"pallas.srcLoc", i64 21, i64 1, i64 21, i64 31}
-!64 = !DILocation(line: 23, column: 21, scope: !32)
-!65 = !DILocation(line: 24, column: 5, scope: !32)
-!66 = !DILocation(line: 24, column: 8, scope: !32)
-!67 = !DILocation(line: 24, column: 10, scope: !32)
-!68 = !DILocation(line: 25, column: 5, scope: !32)
-!69 = !DILocation(line: 25, column: 8, scope: !32)
-!70 = !DILocation(line: 25, column: 10, scope: !32)
-!71 = !DILocation(line: 26, column: 1, scope: !32)
-!72 = distinct !DISubprogram(name: "PALLAS_SPEC_0", scope: !1, file: !1, line: 5, type: !73, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !19)
-!73 = !DISubroutineType(types: !74)
-!74 = !{!75, !18}
-!75 = !DIBasicType(name: "_Bool", size: 8, encoding: DW_ATE_boolean)
-!76 = !{!""}
-!77 = !DILocalVariable(name: "ptr", arg: 1, scope: !72, file: !1, line: 5, type: !18)
-!78 = !DILocation(line: 0, scope: !72)
-!79 = !DILocation(line: 5, column: 14, scope: !72)
-!80 = !DILocation(line: 5, column: 22, scope: !72)
-!81 = !DILocation(line: 5, column: 35, scope: !72)
-!82 = !DILocation(line: 5, column: 25, scope: !72)
-!83 = distinct !DISubprogram(name: "PALLAS_SPEC_1", scope: !1, file: !1, line: 6, type: !73, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !19)
-!84 = !DILocalVariable(name: "ptr", arg: 1, scope: !83, file: !1, line: 6, type: !18)
-!85 = !DILocation(line: 0, scope: !83)
-!86 = !DILocation(line: 6, column: 19, scope: !83)
-!87 = !DILocation(line: 6, column: 9, scope: !83)
-!88 = distinct !DISubprogram(name: "PALLAS_SPEC_2", scope: !1, file: !1, line: 17, type: !89, scopeLine: 17, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !19)
-!89 = !DISubroutineType(types: !90)
-!90 = !{!75, !91}
-!91 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !92, size: 64)
-!92 = !DIDerivedType(tag: DW_TAG_typedef, name: "BigStruct", file: !93, line: 29, baseType: !94)
-!93 = !DIFile(filename: "./tmp/source_wrappers.c", directory: ".", checksumkind: CSK_MD5, checksum: "0b69c1a1190a7c9aa30f22854b9e1f7f")
-!94 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "S", file: !93, line: 27, size: 448, elements: !95)
-!95 = !{!96, !97, !98, !99, !100, !101, !102}
-!96 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !94, file: !93, line: 28, baseType: !40, size: 64)
-!97 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !94, file: !93, line: 28, baseType: !40, size: 64, offset: 64)
-!98 = !DIDerivedType(tag: DW_TAG_member, name: "c", scope: !94, file: !93, line: 28, baseType: !40, size: 64, offset: 128)
-!99 = !DIDerivedType(tag: DW_TAG_member, name: "d", scope: !94, file: !93, line: 28, baseType: !40, size: 64, offset: 192)
-!100 = !DIDerivedType(tag: DW_TAG_member, name: "e", scope: !94, file: !93, line: 28, baseType: !40, size: 64, offset: 256)
-!101 = !DIDerivedType(tag: DW_TAG_member, name: "f", scope: !94, file: !93, line: 28, baseType: !40, size: 64, offset: 320)
-!102 = !DIDerivedType(tag: DW_TAG_member, name: "g", scope: !94, file: !93, line: 28, baseType: !40, size: 64, offset: 384)
-!103 = !DILocalVariable(name: "s", arg: 1, scope: !88, file: !1, line: 17, type: !91)
-!104 = !DILocation(line: 0, scope: !88)
-!105 = !DILocation(line: 17, column: 12, scope: !88)
-!106 = !DILocation(line: 17, column: 20, scope: !88)
-!107 = !DILocation(line: 17, column: 31, scope: !88)
-!108 = !DILocation(line: 17, column: 23, scope: !88)
-!109 = distinct !DISubprogram(name: "PALLAS_SPEC_3", scope: !1, file: !1, line: 18, type: !89, scopeLine: 18, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !19)
-!110 = !DILocalVariable(name: "s", arg: 1, scope: !109, file: !1, line: 18, type: !91)
-!111 = !DILocation(line: 0, scope: !109)
-!112 = !DILocation(line: 18, column: 23, scope: !109)
-!113 = !DILocation(line: 18, column: 26, scope: !109)
-!114 = !DILocation(line: 18, column: 14, scope: !109)
-!115 = !DILocation(line: 18, column: 50, scope: !109)
-!116 = !DILocation(line: 18, column: 53, scope: !109)
-!117 = !DILocation(line: 18, column: 41, scope: !109)
-!118 = !DILocation(line: 18, column: 10, scope: !109)
-!119 = distinct !DISubprogram(name: "PALLAS_SPEC_4", scope: !1, file: !1, line: 19, type: !89, scopeLine: 19, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !19)
-!120 = !DILocalVariable(name: "s", arg: 1, scope: !119, file: !1, line: 19, type: !91)
-!121 = !DILocation(line: 0, scope: !119)
-!122 = !DILocation(line: 19, column: 17, scope: !119)
-!123 = !DILocation(line: 19, column: 9, scope: !119)
-!124 = distinct !DISubprogram(name: "PALLAS_SPEC_5", scope: !1, file: !1, line: 20, type: !89, scopeLine: 20, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !19)
-!125 = !DILocalVariable(name: "s", arg: 1, scope: !124, file: !1, line: 20, type: !91)
+!61 = !{!"pallas.srcLoc", i64 20, i64 1, i64 20, i64 31}
+!62 = !DILocation(line: 22, column: 21, scope: !32)
+!63 = !DILocation(line: 23, column: 5, scope: !32)
+!64 = !DILocation(line: 23, column: 8, scope: !32)
+!65 = !DILocation(line: 23, column: 10, scope: !32)
+!66 = !DILocation(line: 24, column: 5, scope: !32)
+!67 = !DILocation(line: 24, column: 8, scope: !32)
+!68 = !DILocation(line: 24, column: 10, scope: !32)
+!69 = !DILocation(line: 25, column: 1, scope: !32)
+!70 = distinct !DISubprogram(name: "PALLAS_SPEC_0", scope: !1, file: !1, line: 5, type: !71, scopeLine: 5, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !19)
+!71 = !DISubroutineType(types: !72)
+!72 = !{!73, !18}
+!73 = !DIBasicType(name: "_Bool", size: 8, encoding: DW_ATE_boolean)
+!74 = !{!""}
+!75 = !DILocalVariable(name: "ptr", arg: 1, scope: !70, file: !1, line: 5, type: !18)
+!76 = !DILocation(line: 0, scope: !70)
+!77 = !DILocation(line: 5, column: 14, scope: !70)
+!78 = !DILocation(line: 5, column: 22, scope: !70)
+!79 = !DILocation(line: 5, column: 36, scope: !70)
+!80 = !DILocation(line: 5, column: 25, scope: !70)
+!81 = distinct !DISubprogram(name: "PALLAS_SPEC_1", scope: !1, file: !1, line: 6, type: !71, scopeLine: 6, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !19)
+!82 = !DILocalVariable(name: "ptr", arg: 1, scope: !81, file: !1, line: 6, type: !18)
+!83 = !DILocation(line: 0, scope: !81)
+!84 = !DILocation(line: 6, column: 20, scope: !81)
+!85 = !DILocation(line: 6, column: 9, scope: !81)
+!86 = distinct !DISubprogram(name: "PALLAS_SPEC_2", scope: !1, file: !1, line: 17, type: !87, scopeLine: 17, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !19)
+!87 = !DISubroutineType(types: !88)
+!88 = !{!73, !89}
+!89 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !90, size: 64)
+!90 = !DIDerivedType(tag: DW_TAG_typedef, name: "BigStruct", file: !91, line: 29, baseType: !92)
+!91 = !DIFile(filename: "./tmp/source_wrappers.c", directory: ".", checksumkind: CSK_MD5, checksum: "eaeeec9d4bf512a82bce8d9cf1299077")
+!92 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "S", file: !91, line: 27, size: 448, elements: !93)
+!93 = !{!94, !95, !96, !97, !98, !99, !100}
+!94 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !92, file: !91, line: 28, baseType: !40, size: 64)
+!95 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !92, file: !91, line: 28, baseType: !40, size: 64, offset: 64)
+!96 = !DIDerivedType(tag: DW_TAG_member, name: "c", scope: !92, file: !91, line: 28, baseType: !40, size: 64, offset: 128)
+!97 = !DIDerivedType(tag: DW_TAG_member, name: "d", scope: !92, file: !91, line: 28, baseType: !40, size: 64, offset: 192)
+!98 = !DIDerivedType(tag: DW_TAG_member, name: "e", scope: !92, file: !91, line: 28, baseType: !40, size: 64, offset: 256)
+!99 = !DIDerivedType(tag: DW_TAG_member, name: "f", scope: !92, file: !91, line: 28, baseType: !40, size: 64, offset: 320)
+!100 = !DIDerivedType(tag: DW_TAG_member, name: "g", scope: !92, file: !91, line: 28, baseType: !40, size: 64, offset: 384)
+!101 = !DILocalVariable(name: "s", arg: 1, scope: !86, file: !1, line: 17, type: !89)
+!102 = !DILocation(line: 0, scope: !86)
+!103 = !DILocation(line: 17, column: 12, scope: !86)
+!104 = distinct !DISubprogram(name: "PALLAS_SPEC_3", scope: !1, file: !1, line: 18, type: !87, scopeLine: 18, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !19)
+!105 = !DILocalVariable(name: "s", arg: 1, scope: !104, file: !1, line: 18, type: !89)
+!106 = !DILocation(line: 0, scope: !104)
+!107 = !DILocation(line: 18, column: 25, scope: !104)
+!108 = !DILocation(line: 18, column: 28, scope: !104)
+!109 = !DILocation(line: 18, column: 15, scope: !104)
+!110 = !DILocation(line: 18, column: 47, scope: !104)
+!111 = !DILocation(line: 18, column: 50, scope: !104)
+!112 = !DILocation(line: 18, column: 37, scope: !104)
+!113 = !DILocation(line: 18, column: 10, scope: !104)
+!114 = distinct !DISubprogram(name: "PALLAS_SPEC_4", scope: !1, file: !1, line: 19, type: !87, scopeLine: 19, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !19)
+!115 = !DILocalVariable(name: "s", arg: 1, scope: !114, file: !1, line: 19, type: !89)
+!116 = !DILocation(line: 0, scope: !114)
+!117 = !DILocation(line: 19, column: 24, scope: !114)
+!118 = !DILocation(line: 19, column: 27, scope: !114)
+!119 = !DILocation(line: 19, column: 14, scope: !114)
+!120 = !DILocation(line: 19, column: 46, scope: !114)
+!121 = !DILocation(line: 19, column: 49, scope: !114)
+!122 = !DILocation(line: 19, column: 36, scope: !114)
+!123 = !DILocation(line: 19, column: 9, scope: !114)
+!124 = distinct !DISubprogram(name: "PALLAS_SPEC_5", scope: !1, file: !1, line: 20, type: !87, scopeLine: 20, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !19)
+!125 = !DILocalVariable(name: "s", arg: 1, scope: !124, file: !1, line: 20, type: !89)
 !126 = !DILocation(line: 0, scope: !124)
-!127 = !DILocation(line: 20, column: 22, scope: !124)
-!128 = !DILocation(line: 20, column: 25, scope: !124)
-!129 = !DILocation(line: 20, column: 13, scope: !124)
-!130 = !DILocation(line: 20, column: 49, scope: !124)
-!131 = !DILocation(line: 20, column: 52, scope: !124)
-!132 = !DILocation(line: 20, column: 40, scope: !124)
-!133 = !DILocation(line: 20, column: 9, scope: !124)
-!134 = distinct !DISubprogram(name: "PALLAS_SPEC_6", scope: !1, file: !1, line: 21, type: !89, scopeLine: 21, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !19)
-!135 = !DILocalVariable(name: "s", arg: 1, scope: !134, file: !1, line: 21, type: !91)
-!136 = !DILocation(line: 0, scope: !134)
-!137 = !DILocation(line: 21, column: 12, scope: !134)
-!138 = !DILocation(line: 21, column: 14, scope: !134)
-!139 = !DILocation(line: 21, column: 19, scope: !134)
-!140 = !DILocation(line: 21, column: 25, scope: !134)
-!141 = !DILocation(line: 21, column: 27, scope: !134)
-!142 = !{!"pallas.sepConj"}
-!143 = !{!"pallas.perm"}
-!144 = !{!"pallas.fracOf"}
+!127 = !DILocation(line: 20, column: 12, scope: !124)
+!128 = !DILocation(line: 20, column: 14, scope: !124)
+!129 = !DILocation(line: 20, column: 19, scope: !124)
+!130 = !DILocation(line: 20, column: 25, scope: !124)
+!131 = !DILocation(line: 20, column: 27, scope: !124)
+!132 = !{!"pallas.sepConj"}
+!133 = !{!"pallas.perm"}
+!134 = !{!"pallas.fracOf"}

--- a/examples/concepts/llvm/pallas/pallas_c_perm_fail_2.c
+++ b/examples/concepts/llvm/pallas/pallas_c_perm_fail_2.c
@@ -7,8 +7,7 @@ typedef struct S {
 } BigStruct;
 
 /*@
-requires s != NULL && Perm(s, fracOf(1, 2));
-ensures Perm(s, fracOf(1, 2));
+requires s != NULL;
 ensures s->a == 0;
 @*/
 void bar(BigStruct *s) {

--- a/examples/concepts/llvm/pallas/pallas_c_perm_fail_2.ll
+++ b/examples/concepts/llvm/pallas/pallas_c_perm_fail_2.ll
@@ -4,65 +4,41 @@ target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16
 target triple = "x86_64-unknown-linux-gnu"
 
 %struct.S = type { i64, i64, i64, i64, i64, i64, i64 }
-%pallas.fracT = type { i64, i64, i64, i64 }
 
-@llvm.used = appending global [3 x ptr] [ptr @PALLAS_SPEC_2, ptr @PALLAS_SPEC_0, ptr @PALLAS_SPEC_1], section "llvm.metadata"
+@llvm.used = appending global [2 x ptr] [ptr @PALLAS_SPEC_0, ptr @PALLAS_SPEC_1], section "llvm.metadata"
 
 ; Function Attrs: noinline nounwind uwtable
 define dso_local void @bar(ptr noundef %0) #0 !dbg !14 !pallas.fcontract !34 {
   %2 = alloca ptr, align 8
   store ptr %0, ptr %2, align 8
-  call void @llvm.dbg.declare(metadata ptr %2, metadata !38, metadata !DIExpression()), !dbg !43
-  %3 = load ptr, ptr %2, align 8, !dbg !44
-  %4 = getelementptr inbounds %struct.S, ptr %3, i32 0, i32 0, !dbg !45
-  store i64 0, ptr %4, align 8, !dbg !46
-  ret void, !dbg !47
+  call void @llvm.dbg.declare(metadata ptr %2, metadata !38, metadata !DIExpression()), !dbg !41
+  %3 = load ptr, ptr %2, align 8, !dbg !42
+  %4 = getelementptr inbounds %struct.S, ptr %3, i32 0, i32 0, !dbg !43
+  store i64 0, ptr %4, align 8, !dbg !44
+  ret void, !dbg !45
 }
 
 ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
 
 ; Function Attrs: noinline nounwind uwtable
-define dso_local zeroext i1 @PALLAS_SPEC_2(ptr noundef %0) #0 !dbg !48 !pallas.exprWrapper !64 {
-  call void @llvm.dbg.value(metadata ptr %0, metadata !65, metadata !DIExpression()), !dbg !66
-  %2 = getelementptr inbounds %struct.S, ptr %0, i32 0, i32 0, !dbg !67
-  %3 = load i64, ptr %2, align 8, !dbg !67
-  %4 = icmp eq i64 %3, 0, !dbg !68
-  ret i1 %4, !dbg !66
+define dso_local zeroext i1 @PALLAS_SPEC_0(ptr noundef %0) #0 !dbg !46 !pallas.exprWrapper !62 {
+  call void @llvm.dbg.value(metadata ptr %0, metadata !63, metadata !DIExpression()), !dbg !64
+  %2 = icmp ne ptr %0, null, !dbg !65
+  ret i1 %2, !dbg !64
 }
 
 ; Function Attrs: noinline nounwind uwtable
-define dso_local zeroext i1 @PALLAS_SPEC_0(ptr noundef %0) #0 !dbg !69 !pallas.exprWrapper !64 {
-  %2 = alloca %pallas.fracT, align 8
-  call void @llvm.dbg.value(metadata ptr %0, metadata !70, metadata !DIExpression()), !dbg !71
-  %3 = icmp ne ptr %0, null, !dbg !72
-  br i1 %3, label %4, label %6, !dbg !73
-
-4:                                                ; preds = %1
-  call void @pallas.fracOf(ptr sret(%pallas.fracT) %2, i32 noundef 1, i32 noundef 2), !dbg !74
-  %5 = call i1 @pallas.perm(ptr noundef %0, ptr noundef byval(%pallas.fracT) %2), !dbg !75
-  br label %6
-
-6:                                                ; preds = %4, %1
-  %7 = phi i1 [ false, %1 ], [ %5, %4 ], !dbg !71
-  ret i1 %7, !dbg !71
-}
-
-; Function Attrs: noinline nounwind uwtable
-define dso_local zeroext i1 @PALLAS_SPEC_1(ptr noundef %0) #0 !dbg !76 !pallas.exprWrapper !64 {
-  %2 = alloca %pallas.fracT, align 8
-  call void @llvm.dbg.value(metadata ptr %0, metadata !77, metadata !DIExpression()), !dbg !78
-  call void @pallas.fracOf(ptr sret(%pallas.fracT) %2, i32 noundef 1, i32 noundef 2), !dbg !79
-  %3 = call i1 @pallas.perm(ptr noundef %0, ptr noundef byval(%pallas.fracT) %2), !dbg !80
-  ret i1 %3, !dbg !78
+define dso_local zeroext i1 @PALLAS_SPEC_1(ptr noundef %0) #0 !dbg !66 !pallas.exprWrapper !62 {
+  call void @llvm.dbg.value(metadata ptr %0, metadata !67, metadata !DIExpression()), !dbg !68
+  %2 = getelementptr inbounds %struct.S, ptr %0, i32 0, i32 0, !dbg !69
+  %3 = load i64, ptr %2, align 8, !dbg !69
+  %4 = icmp eq i64 %3, 0, !dbg !70
+  ret i1 %4, !dbg !68
 }
 
 ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare void @llvm.dbg.value(metadata, metadata, metadata) #1
-
-declare !pallas.specLib !81 i1 @pallas.perm(ptr noundef, ptr noundef byval(%pallas.fracT))
-
-declare !pallas.specLib !82 void @pallas.fracOf(ptr sret(%pallas.fracT), i32 noundef, i32 noundef)
 
 attributes #0 = { noinline nounwind uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
@@ -72,9 +48,9 @@ attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memo
 !llvm.ident = !{!13, !13}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang version 17.0.0 (https://github.com/swiftlang/llvm-project.git 73500bf55acff5fa97b56dcdeb013f288efd084f)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
-!1 = !DIFile(filename: "examples/concepts/llvm/pallas/pallas_c_perm_fail_2.c", directory: ".", checksumkind: CSK_MD5, checksum: "a1fc853c50100ff6c9de9d333db797b7")
+!1 = !DIFile(filename: "examples/concepts/llvm/pallas/pallas_c_perm_fail_2.c", directory: ".", checksumkind: CSK_MD5, checksum: "6e88c295299820f9e6cdc988aadaa1d0")
 !2 = distinct !DICompileUnit(language: DW_LANG_C11, file: !3, producer: "clang version 17.0.0 (https://github.com/swiftlang/llvm-project.git 73500bf55acff5fa97b56dcdeb013f288efd084f)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, retainedTypes: !4, splitDebugInlining: false, nameTableKind: None)
-!3 = !DIFile(filename: "tmp/source_wrappers.c", directory: ".", checksumkind: CSK_MD5, checksum: "3ecacb47795eb31d75b75313e691d298")
+!3 = !DIFile(filename: "tmp/source_wrappers.c", directory: ".", checksumkind: CSK_MD5, checksum: "b0e0828c26c7850eec017e1ce77b1789")
 !4 = !{!5}
 !5 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
 !6 = !{i32 7, !"Dwarf Version", i32 5}
@@ -85,7 +61,7 @@ attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memo
 !11 = !{i32 7, !"uwtable", i32 2}
 !12 = !{i32 7, !"frame-pointer", i32 2}
 !13 = !{!"clang version 17.0.0 (https://github.com/swiftlang/llvm-project.git 73500bf55acff5fa97b56dcdeb013f288efd084f)"}
-!14 = distinct !DISubprogram(name: "bar", scope: !1, file: !1, line: 14, type: !15, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !33)
+!14 = distinct !DISubprogram(name: "bar", scope: !1, file: !1, line: 13, type: !15, scopeLine: 13, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !33)
 !15 = !DISubroutineType(types: !16)
 !16 = !{null, !17}
 !17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
@@ -105,52 +81,40 @@ attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memo
 !31 = !DIDerivedType(tag: DW_TAG_member, name: "f", scope: !19, file: !1, line: 6, baseType: !22, size: 64, offset: 320)
 !32 = !DIDerivedType(tag: DW_TAG_member, name: "g", scope: !19, file: !1, line: 6, baseType: !22, size: 64, offset: 384)
 !33 = !{}
-!34 = !{!35, i1 false, !36, !39, !41}
-!35 = !{!"pallas.srcLoc", i64 9, i64 1, i64 13, i64 1}
+!34 = !{!35, i1 false, !36, !39}
+!35 = !{!"pallas.srcLoc", i64 9, i64 1, i64 12, i64 1}
 !36 = !{!"pallas.requires", !37, ptr @PALLAS_SPEC_0, !38}
-!37 = !{!"pallas.srcLoc", i64 10, i64 1, i64 10, i64 44}
-!38 = !DILocalVariable(name: "s", arg: 1, scope: !14, file: !1, line: 14, type: !17)
+!37 = !{!"pallas.srcLoc", i64 10, i64 1, i64 10, i64 19}
+!38 = !DILocalVariable(name: "s", arg: 1, scope: !14, file: !1, line: 13, type: !17)
 !39 = !{!"pallas.ensures", !40, ptr @PALLAS_SPEC_1, !38}
-!40 = !{!"pallas.srcLoc", i64 11, i64 1, i64 11, i64 30}
-!41 = !{!"pallas.ensures", !42, ptr @PALLAS_SPEC_2, !38}
-!42 = !{!"pallas.srcLoc", i64 12, i64 1, i64 12, i64 18}
-!43 = !DILocation(line: 14, column: 21, scope: !14)
-!44 = !DILocation(line: 15, column: 5, scope: !14)
-!45 = !DILocation(line: 15, column: 8, scope: !14)
-!46 = !DILocation(line: 15, column: 10, scope: !14)
-!47 = !DILocation(line: 16, column: 1, scope: !14)
-!48 = distinct !DISubprogram(name: "PALLAS_SPEC_2", scope: !1, file: !1, line: 12, type: !49, scopeLine: 12, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !33)
-!49 = !DISubroutineType(types: !50)
-!50 = !{!51, !52}
-!51 = !DIBasicType(name: "_Bool", size: 8, encoding: DW_ATE_boolean)
-!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !53, size: 64)
-!53 = !DIDerivedType(tag: DW_TAG_typedef, name: "BigStruct", file: !54, line: 8, baseType: !55)
-!54 = !DIFile(filename: "./tmp/source_wrappers.c", directory: ".", checksumkind: CSK_MD5, checksum: "3ecacb47795eb31d75b75313e691d298")
-!55 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "S", file: !54, line: 6, size: 448, elements: !56)
-!56 = !{!57, !58, !59, !60, !61, !62, !63}
-!57 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !55, file: !54, line: 7, baseType: !22, size: 64)
-!58 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !55, file: !54, line: 7, baseType: !22, size: 64, offset: 64)
-!59 = !DIDerivedType(tag: DW_TAG_member, name: "c", scope: !55, file: !54, line: 7, baseType: !22, size: 64, offset: 128)
-!60 = !DIDerivedType(tag: DW_TAG_member, name: "d", scope: !55, file: !54, line: 7, baseType: !22, size: 64, offset: 192)
-!61 = !DIDerivedType(tag: DW_TAG_member, name: "e", scope: !55, file: !54, line: 7, baseType: !22, size: 64, offset: 256)
-!62 = !DIDerivedType(tag: DW_TAG_member, name: "f", scope: !55, file: !54, line: 7, baseType: !22, size: 64, offset: 320)
-!63 = !DIDerivedType(tag: DW_TAG_member, name: "g", scope: !55, file: !54, line: 7, baseType: !22, size: 64, offset: 384)
-!64 = !{!""}
-!65 = !DILocalVariable(name: "s", arg: 1, scope: !48, file: !1, line: 12, type: !52)
-!66 = !DILocation(line: 0, scope: !48)
-!67 = !DILocation(line: 12, column: 12, scope: !48)
-!68 = !DILocation(line: 12, column: 14, scope: !48)
-!69 = distinct !DISubprogram(name: "PALLAS_SPEC_0", scope: !1, file: !1, line: 10, type: !49, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !33)
-!70 = !DILocalVariable(name: "s", arg: 1, scope: !69, file: !1, line: 10, type: !52)
-!71 = !DILocation(line: 0, scope: !69)
-!72 = !DILocation(line: 10, column: 12, scope: !69)
-!73 = !DILocation(line: 10, column: 20, scope: !69)
-!74 = !DILocation(line: 10, column: 31, scope: !69)
-!75 = !DILocation(line: 10, column: 23, scope: !69)
-!76 = distinct !DISubprogram(name: "PALLAS_SPEC_1", scope: !1, file: !1, line: 11, type: !49, scopeLine: 11, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !33)
-!77 = !DILocalVariable(name: "s", arg: 1, scope: !76, file: !1, line: 11, type: !52)
-!78 = !DILocation(line: 0, scope: !76)
-!79 = !DILocation(line: 11, column: 17, scope: !76)
-!80 = !DILocation(line: 11, column: 9, scope: !76)
-!81 = !{!"pallas.perm"}
-!82 = !{!"pallas.fracOf"}
+!40 = !{!"pallas.srcLoc", i64 11, i64 1, i64 11, i64 18}
+!41 = !DILocation(line: 13, column: 21, scope: !14)
+!42 = !DILocation(line: 14, column: 5, scope: !14)
+!43 = !DILocation(line: 14, column: 8, scope: !14)
+!44 = !DILocation(line: 14, column: 10, scope: !14)
+!45 = !DILocation(line: 15, column: 1, scope: !14)
+!46 = distinct !DISubprogram(name: "PALLAS_SPEC_0", scope: !1, file: !1, line: 10, type: !47, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !33)
+!47 = !DISubroutineType(types: !48)
+!48 = !{!49, !50}
+!49 = !DIBasicType(name: "_Bool", size: 8, encoding: DW_ATE_boolean)
+!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
+!51 = !DIDerivedType(tag: DW_TAG_typedef, name: "BigStruct", file: !52, line: 8, baseType: !53)
+!52 = !DIFile(filename: "./tmp/source_wrappers.c", directory: ".", checksumkind: CSK_MD5, checksum: "b0e0828c26c7850eec017e1ce77b1789")
+!53 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "S", file: !52, line: 6, size: 448, elements: !54)
+!54 = !{!55, !56, !57, !58, !59, !60, !61}
+!55 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !53, file: !52, line: 7, baseType: !22, size: 64)
+!56 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !53, file: !52, line: 7, baseType: !22, size: 64, offset: 64)
+!57 = !DIDerivedType(tag: DW_TAG_member, name: "c", scope: !53, file: !52, line: 7, baseType: !22, size: 64, offset: 128)
+!58 = !DIDerivedType(tag: DW_TAG_member, name: "d", scope: !53, file: !52, line: 7, baseType: !22, size: 64, offset: 192)
+!59 = !DIDerivedType(tag: DW_TAG_member, name: "e", scope: !53, file: !52, line: 7, baseType: !22, size: 64, offset: 256)
+!60 = !DIDerivedType(tag: DW_TAG_member, name: "f", scope: !53, file: !52, line: 7, baseType: !22, size: 64, offset: 320)
+!61 = !DIDerivedType(tag: DW_TAG_member, name: "g", scope: !53, file: !52, line: 7, baseType: !22, size: 64, offset: 384)
+!62 = !{!""}
+!63 = !DILocalVariable(name: "s", arg: 1, scope: !46, file: !1, line: 10, type: !50)
+!64 = !DILocation(line: 0, scope: !46)
+!65 = !DILocation(line: 10, column: 12, scope: !46)
+!66 = distinct !DISubprogram(name: "PALLAS_SPEC_1", scope: !1, file: !1, line: 11, type: !47, scopeLine: 11, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !33)
+!67 = !DILocalVariable(name: "s", arg: 1, scope: !66, file: !1, line: 11, type: !50)
+!68 = !DILocation(line: 0, scope: !66)
+!69 = !DILocation(line: 11, column: 12, scope: !66)
+!70 = !DILocation(line: 11, column: 14, scope: !66)

--- a/res/universal/res/adt/pointer.pvl
+++ b/res/universal/res/adt/pointer.pvl
@@ -40,8 +40,6 @@ adt `pointer` {
 
   axiom (∀ `pointer` p1, `pointer` p2, int stride; stride > 0 && ({:ptr_address(p1, stride):} == {:ptr_address(p2, stride):} && {:pointer_block(p1):} == {:pointer_block(p2):}) ==> p1 == p2);
 
-  axiom (∀ `pointer` p1, `pointer` p2; {:pointer_offset(p1):} == {:pointer_offset(p2):} && {:pointer_block(p1):} == {:pointer_block(p2):} ==> p1 == p2);
-
   axiom ptr_add_axiom();
 
   axiom ptr_add_axiom2();

--- a/res/universal/res/adt/pointer.pvl
+++ b/res/universal/res/adt/pointer.pvl
@@ -19,7 +19,6 @@ adt `block` {
 }
 
 adt `pointer` {
-  /* pure `pointer` pointer_of(`block` b, int offset); */
   pure `block` pointer_block(`pointer` p);
   pure int pointer_offset(`pointer` p);
   pure `pointer` pointer_inv(ref r);
@@ -60,12 +59,12 @@ ensures `pointer`.pointer_block(\result) == `pointer`.pointer_block(p);
 pure `pointer` ptr_add(`pointer` p, int offset);
 
 decreases;
-ensures (\forall `pointer` p1, int offset, int i;
-    0 <= `pointer`.pointer_offset(p1) + offset &&
-    `pointer`.pointer_offset(p1) + offset < `block`.block_length(`pointer`.pointer_block(p1)) &&
-    0 <= i &&
-    i < `block`.block_length(`pointer`.pointer_block(p1)) - `pointer`.pointer_offset(p1) - offset;
-    {:ptr_add(ptr_add(p1, offset), i):} == ptr_add(p1, offset + i));
+ensures (\forall `pointer` p, int offset, int i;
+    0 <= `pointer`.pointer_offset(p) + offset &&
+    `pointer`.pointer_offset(p) + offset < `block`.block_length(`pointer`.pointer_block(p)) &&
+    0 <= `pointer`.pointer_offset(p) + offset + i &&
+    `pointer`.pointer_offset(p) + offset + i < `block`.block_length(`pointer`.pointer_block(p));
+    {:ptr_add(ptr_add(p, offset), i):} == ptr_add(p, offset + i));
 pure boolean ptr_add_axiom() = true;
 
 decreases;
@@ -80,3 +79,4 @@ decreases;
 requires stride > 0;
 ensures `pointer`.ptr_address(\result, stride) == address;
 pure `pointer` ptr_from_address(int address, int stride);
+

--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -1496,6 +1496,10 @@ final case class PointerAdd[G](pointer: Expr[G], offset: Expr[G])(
     val blame: Blame[PointerAddError]
 )(implicit val o: Origin)
     extends Expr[G] with PointerAddImpl[G]
+final case class PointerToAdt[G](pointer: Expr[G], t: Type[G])(
+    val blame: Blame[PointerNull]
+)(implicit val o: Origin)
+    extends Expr[G] with PointerToAdtImpl[G]
 final case class AddrOf[G](e: Expr[G])(implicit val o: Origin)
     extends Expr[G] with AddrOfImpl[G]
 final case class AddrOfConstCast[G](e: Expr[G])(implicit val o: Origin)

--- a/src/col/vct/col/ast/expr/heap/read/PointerToAdtImpl.scala
+++ b/src/col/vct/col/ast/expr/heap/read/PointerToAdtImpl.scala
@@ -1,0 +1,14 @@
+package vct.col.ast.expr.heap.read
+
+import vct.col.ast.ops.PointerToAdtOps
+import vct.col.ast.{PointerToAdt, TAxiomatic}
+import vct.col.print._
+
+trait PointerToAdtImpl[G] extends PointerToAdtOps[G] {
+  this: PointerToAdt[G] =>
+
+  require(t.isInstanceOf[TAxiomatic[_]])
+
+  override def layout(implicit ctx: Ctx): Doc =
+    Group(Text("to_") <> t <> "(" <> pointer <> ")")
+}

--- a/src/col/vct/col/origin/Blame.scala
+++ b/src/col/vct/col/origin/Blame.scala
@@ -159,7 +159,9 @@ case class AssignFieldFailed(node: SilverFieldAssign[_])
 }
 
 case class CopyClassFailed(node: Node[_], clazz: ByValueClass[_], field: String)
-    extends PointerDerefError with NodeVerificationFailure {
+    extends PointerDerefError
+    with InvocationFailure
+    with NodeVerificationFailure {
   override def code: String = "copyClassFailed"
   override def descInContext: String =
     s"Insufficient read permission for field '$field' to copy ${clazz.o
@@ -362,9 +364,8 @@ case class DecreaseTerminationMeasureFailed(
     s"${apply.o.inlineContextText} may not terminate, since `${measure.o.inlineContextText}` is not decreased or not bounded"
 }
 
-case class DecreaseTerminationMeasureFailedDueToWhile(
-                                             node: Loop[_],
-                                           ) extends LoopInvariantFailure with NodeVerificationFailure {
+case class DecreaseTerminationMeasureFailedDueToWhile(node: Loop[_])
+    extends LoopInvariantFailure with NodeVerificationFailure {
   override def code: String = "loopTerminationFailed"
   override def position: String = node.o.shortPositionText
   override def descInContext: String =
@@ -373,9 +374,10 @@ case class DecreaseTerminationMeasureFailedDueToWhile(
     s"Loop may not terminate, since ${node.o.inlineContextText} is not proven to be decreasing with a decrease clause"
 }
 
-case class CallTerminationMeasureFailed(apply: InvokingNode[_],
-  calledMethod: ContractApplicable[_],
-  ) extends TerminationMeasureFailed {
+case class CallTerminationMeasureFailed(
+    apply: InvokingNode[_],
+    calledMethod: ContractApplicable[_],
+) extends TerminationMeasureFailed {
   override def code: String = "callDecreasesFailed"
   override def position: String = calledMethod.o.shortPositionText
   override def desc: String =

--- a/src/col/vct/col/typerules/CoercingRewriter.scala
+++ b/src/col/vct/col/typerules/CoercingRewriter.scala
@@ -1656,6 +1656,7 @@ abstract class CoercingRewriter[Pre <: Generation]()
         )
       case add @ PointerAdd(p, offset) =>
         PointerAdd(pointer(p)._1, int(offset))(add.blame)
+      case to @ PointerToAdt(p, t) => PointerToAdt(pointer(p)._1, t)(to.blame)
       case blck @ PointerBlock(p) => PointerBlock(pointer(p)._1)(blck.blame)
       case addr @ PointerAddress(p, elementSize) =>
         PointerAddress(pointer(p)._1, elementSize)(addr.blame)

--- a/src/rewrite/vct/rewrite/ClassToRef.scala
+++ b/src/rewrite/vct/rewrite/ClassToRef.scala
@@ -119,13 +119,12 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
   val valueAdt: SuccessionMap[Unit, AxiomaticDataType[Post]] = SuccessionMap()
   val valueAdtTypeArgument: Variable[Post] =
     new Variable(TType(TAnyValue()))(ValueAdtOrigin.where(name = "V"))
-  val valueAsFunctions
-      : mutable.Map[(Type[Pre], Option[BigInt]), ADTFunction[Post]] = mutable
+  val valueAsFunctions: mutable.Map[Type[Pre], ADTFunction[Post]] = mutable
     .Map()
 
-  val castHelpers: SuccessionMap[(Type[Pre], Option[BigInt]), Procedure[Post]] =
-    SuccessionMap()
-  val requiredCastHelpers: ScopedStack[mutable.Set[Type[Pre]]] = ScopedStack()
+//  val castHelpers: SuccessionMap[(Type[Pre], Option[BigInt]), Procedure[Post]] =
+//    SuccessionMap()
+//  val requiredCastHelpers: ScopedStack[mutable.Set[Type[Pre]]] = ScopedStack()
 
   def typeNumber(cls: Class[Pre]): Int =
     typeNumberStore.getOrElseUpdate(cls, typeNumberStore.size + 1)
@@ -185,13 +184,12 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
   private def makeValueAsFunction(
       typeName: String,
       t: Type[Post],
-      unique: Option[BigInt],
   ): ADTFunction[Post] = {
     new ADTFunction[Post](
       Seq(new Variable(TVar[Post](valueAdtTypeArgument.ref))(
         ValueAdtOrigin.where(name = "v")
       )),
-      TNonNullPointer(t, unique),
+      TNonNullPointer(t, None),
     )(ValueAdtOrigin.where(name = "value_as_" + typeName))
   }
 
@@ -220,10 +218,9 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
       axiomType,
       body = { a =>
         InlinePattern(adtFunctionInvocation[Post](
-          valueAsFunctions.getOrElseUpdate(
-            (oldT, unique),
-            makeValueAsFunction(oldT.toString, newT, unique),
-          ).ref,
+          valueAsFunctions
+            .getOrElseUpdate(oldT, makeValueAsFunction(oldT.toString, newT))
+            .ref,
           typeArgs = Some((valueAdt.ref(()), Seq(axiomType))),
           args = Seq(a),
         )) === Cast(
@@ -430,8 +427,8 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
               body = { a =>
                 InlinePattern(adtFunctionInvocation[Post](
                   valueAsFunctions.getOrElseUpdate(
-                    (field.t, unique),
-                    makeValueAsFunction(field.t.toString, newT, unique),
+                    field.t,
+                    makeValueAsFunction(field.t.toString, newT),
                   ).ref,
                   typeArgs = Some((valueAdt.ref(()), Seq(axiomType))),
                   args = Seq(a),
@@ -502,33 +499,6 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
             "index_" + cls.o.find[SourceName].map(_.name).getOrElse("unknown")
           )
       )
-//    val fromPointer = new ADTFunction[Post](
-//      Seq(new Variable(TNonNullPointer(TVoid(), None))(Origin(Seq(PreferredName(Seq("pointer")), LabelContext("classToRef"))))),
-//      axiomType
-//    )(cls.o.copy(cls.o.originContents.filterNot(_.isInstanceOf[SourceName])).where(name = "from_pointer_"+cls.o.find[SourceName].map(_.name).getOrElse("unknown")));
-    val injectivityAxiom =
-      new ADTAxiom[Post](foralls(
-        Seq(axiomType, axiomType),
-        body = { case Seq(a0, a1) =>
-          foldAnd(fieldFunctions.map { f =>
-            Implies(
-              Eq(
-                adtFunctionInvocation[Post](f.ref, args = Seq(a0)),
-                adtFunctionInvocation[Post](f.ref, args = Seq(a1)),
-              ),
-              a0 === a1,
-            )
-          })
-        },
-        triggers = { case Seq(a0, a1) =>
-          fieldFunctions.map { f =>
-            Seq(
-              adtFunctionInvocation[Post](f.ref, None, args = Seq(a0)),
-              adtFunctionInvocation[Post](f.ref, None, args = Seq(a1)),
-            )
-          }
-        },
-      ))
     val destructorAxioms = fieldFunctions.zip(fieldInverses).map {
       case (f, inv) =>
         new ADTAxiom[Post](forall(
@@ -566,7 +536,8 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
     byValClassSucc(cls) =
       new AxiomaticDataType[Post](
         Seq(indexFunction) ++ destructorAxioms ++ indexAxioms ++
-          fieldFunctions ++ fieldInverses ++ valueAsAxioms,
+          fieldFunctions ++ fieldInverses ++ valueAsAxioms ++
+          unwrapCastConstraintAxioms(axiomType, TByValueClass(cls.ref, Nil)),
         Nil,
       )(o.withContent(LabelContext(ByValueClassADTLabel)))
     globalDeclarations.succeed(cls, byValClassSucc(cls))
@@ -598,41 +569,33 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
     }
   }
 
-  private def addCastConstraints(
-      expr: Expr[Pre],
-      totalHelpers: mutable.Set[Type[Pre]],
-  ): Expr[Post] = {
-    val helpers: mutable.Set[Type[Pre]] = mutable.Set()
-    var result: Seq[Expr[Post]] = Nil
-    for (clause <- expr.unfoldStar) {
-      val newClause = requiredCastHelpers.having(helpers) { dispatch(clause) }
-      if (helpers.nonEmpty) {
-        result ++= helpers.map { case t =>
-          unwrapCastConstraints(dispatch(t), t, None)(CastHelperOrigin)
-        }.toSeq
-        totalHelpers.addAll(helpers)
-        helpers.clear()
-      }
-      result = result :+ newClause
-    }
-    foldStar(result)(expr.o)
-  }
+//  private def addCastConstraints(
+//      expr: Expr[Pre],
+//      totalHelpers: mutable.Set[Type[Pre]],
+//  ): Expr[Post] = {
+//    var result: Seq[Expr[Post]] = Nil
+//    for (clause <- expr.unfoldStar) {
+//      val newClause = dispatch(clause)
+//      result = result :+ newClause
+//    }
+//    foldStar(result)(expr.o)
+//  }
 
   // For loops add cast helpers before and as an invariant (since otherwise the contract might not be well-formed)
-  override def dispatch(node: LoopContract[Pre]): LoopContract[Post] = {
-    val helpers: mutable.Set[Type[Pre]] = mutable.Set()
-    node match {
-      case inv @ LoopInvariant(invariant, decreases) => {
-        val result =
-          LoopInvariant(
-            addCastConstraints(invariant, helpers),
-            decreases.map(dispatch),
-          )(inv.blame)(node.o)
-        if (requiredCastHelpers.nonEmpty) {
-          requiredCastHelpers.top.addAll(helpers)
-        }
-        result
-      }
+//  override def dispatch(node: LoopContract[Pre]): LoopContract[Post] = {
+//    val helpers: mutable.Set[Type[Pre]] = mutable.Set()
+//    node match {
+//      case inv @ LoopInvariant(invariant, decreases) => {
+//        val result =
+//          LoopInvariant(
+//            addCastConstraints(invariant, helpers),
+//            decreases.map(dispatch),
+//          )(inv.blame)(node.o)
+//        if (requiredCastHelpers.nonEmpty) {
+//          requiredCastHelpers.top.addAll(helpers)
+//        }
+//        result
+//      }
 //      case contract @ IterationContract(
 //            requires,
 //            ensures,
@@ -649,76 +612,65 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
 //        }
 //        result
 //      }
-      case _: IterationContract[Pre] => throw ExtraNode
-    }
-  }
+//      case _: IterationContract[Pre] => throw ExtraNode
+//    }
+//  }
 
   override def dispatch(stat: Statement[Pre]): Statement[Post] = {
-    val helpers: mutable.Set[Type[Pre]] = mutable.Set()
+//    val helpers: mutable.Set[Type[Pre]] = mutable.Set()
     val result =
-      requiredCastHelpers.having(helpers) {
-        stat match {
-          case Instantiate(Ref(cls), Local(Ref(v))) =>
-            instantiate(cls, succ(v))(stat.o)
-          case inv @ InvokeMethod(
-                obj,
-                Ref(method),
-                args,
-                outArgs,
-                typeArgs,
-                givenMap,
-                yields,
-              ) =>
-            InvokeProcedure[Post](
-              ref = methodSucc.ref(method),
-              args = dispatch(obj) +: args.map(dispatch),
-              outArgs = outArgs.map(dispatch),
-              typeArgs = typeArgs.map(dispatch),
-              givenMap = givenMap.map { case (Ref(v), e) =>
-                (succ(v), dispatch(e))
-              },
-              yields = yields.map { case (e, Ref(v)) => (dispatch(e), succ(v)) },
-            )(PreBlameSplit.left(
-              InstanceNullPreconditionFailed(inv.blame, inv),
-              PreBlameSplit
-                .left(PanicBlame("incorrect instance method type?"), inv.blame),
-            ))(inv.o)
-          case inv @ InvokeConstructor(
-                Ref(cons),
-                _,
-                out,
-                args,
-                outArgs,
-                typeArgs,
-                givenMap,
-                yields,
-              ) =>
-            InvokeProcedure[Post](
-              ref = consSucc.ref(cons),
-              args = args.map(dispatch),
-              outArgs = dispatch(out) +: outArgs.map(dispatch),
-              typeArgs = typeArgs.map(dispatch),
-              givenMap = givenMap.map { case (Ref(v), e) =>
-                (succ(v), dispatch(e))
-              },
-              yields = yields.map { case (e, Ref(v)) => (dispatch(e), succ(v)) },
-            )(inv.blame)(inv.o)
-          case other => super.dispatch(other)
-        }
+//      requiredCastHelpers.having(helpers) {
+      stat match {
+        case Instantiate(Ref(cls), Local(Ref(v))) =>
+          instantiate(cls, succ(v))(stat.o)
+        case inv @ InvokeMethod(
+              obj,
+              Ref(method),
+              args,
+              outArgs,
+              typeArgs,
+              givenMap,
+              yields,
+            ) =>
+          InvokeProcedure[Post](
+            ref = methodSucc.ref(method),
+            args = dispatch(obj) +: args.map(dispatch),
+            outArgs = outArgs.map(dispatch),
+            typeArgs = typeArgs.map(dispatch),
+            givenMap = givenMap.map { case (Ref(v), e) =>
+              (succ(v), dispatch(e))
+            },
+            yields = yields.map { case (e, Ref(v)) => (dispatch(e), succ(v)) },
+          )(PreBlameSplit.left(
+            InstanceNullPreconditionFailed(inv.blame, inv),
+            PreBlameSplit
+              .left(PanicBlame("incorrect instance method type?"), inv.blame),
+          ))(inv.o)
+        case inv @ InvokeConstructor(
+              Ref(cons),
+              _,
+              out,
+              args,
+              outArgs,
+              typeArgs,
+              givenMap,
+              yields,
+            ) =>
+          InvokeProcedure[Post](
+            ref = consSucc.ref(cons),
+            args = args.map(dispatch),
+            outArgs = dispatch(out) +: outArgs.map(dispatch),
+            typeArgs = typeArgs.map(dispatch),
+            givenMap = givenMap.map { case (Ref(v), e) =>
+              (succ(v), dispatch(e))
+            },
+            yields = yields.map { case (e, Ref(v)) => (dispatch(e), succ(v)) },
+          )(inv.blame)(inv.o)
+        case other => super.dispatch(other)
       }
+//      }
 
-    if (helpers.nonEmpty) {
-      Block(helpers.map { t =>
-        InvokeProcedure[Post](
-          castHelpers.getOrElseUpdate((t, None), makeCastHelper(t)).ref,
-          Nil,
-          Nil,
-          Nil,
-          Nil,
-          Nil,
-        )(TrueSatisfiable)(CastHelperOrigin)
-      }.toSeq :+ result)(stat.o)
-    } else { result }
+    result
   }
 
   override def dispatch(node: ApplyAnyPredicate[Pre]): ApplyAnyPredicate[Post] =
@@ -749,10 +701,8 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
 //          ) ==>
         (InlinePattern(Cast(p, TypeValue(TNonNullPointer(newT, unique)))) ===
           adtFunctionInvocation(
-            valueAsFunctions.getOrElseUpdate(
-              (t, unique),
-              makeValueAsFunction(t.toString, newT, unique),
-            ).ref,
+            valueAsFunctions
+              .getOrElseUpdate(t, makeValueAsFunction(t.toString, newT)).ref,
             typeArgs = Some((valueAdt.ref(()), Seq(outerType))),
             args = Seq(PointerToAdt(p, outerType)(RequiresExhaleModeBlame())),
           )) /*,*/
@@ -773,32 +723,60 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
     }
   }
 
-  private def makeCastHelper(t: Type[Pre]): Procedure[Post] = {
-    implicit val o: Origin = CastHelperOrigin
-      .where(name = "constraints_" + t.toString)
-    globalDeclarations.declare(procedure(
-      AbstractApplicable,
-      TrueSatisfiable,
-      ensures = UnitAccountedPredicate(
-        unwrapCastConstraints(dispatch(t), t, None)
-      ),
-    ))
-  }
-
-  private def addCastHelpers(
+  private def unwrapCastConstraintAxioms(
+      outerType: Type[Post],
       t: Type[Pre],
-      helpers: mutable.Set[Type[Pre]],
-  ): Unit = {
+  ): Seq[ADTAxiom[Post]] = {
+    implicit val o: Origin = CastHelperOrigin
+    val newT = dispatch(t)
+    val constraint =
+      new ADTAxiom(forall[Post](
+        TNonNullPointer(outerType, None),
+        body = { p =>
+          InlinePattern(Cast(p, TypeValue(TNonNullPointer(newT, None)))) ===
+            adtFunctionInvocation(
+              valueAsFunctions
+                .getOrElseUpdate(t, makeValueAsFunction(t.toString, newT)).ref,
+              typeArgs = Some((valueAdt.ref(()), Seq(outerType))),
+              args = Seq(PointerToAdt(p, outerType)(RequiresExhaleModeBlame())),
+            )
+        },
+      ))
     t match {
-      case cls: TByValueClass[Pre] => {
-        helpers.add(t)
-        cls.cls.decl.decls.collectFirst { case field: InstanceField[Pre] =>
-          addCastHelpers(field.t, helpers)
-        }
-      }
-      case _ =>
+      case TByValueClass(Ref(cls), _) =>
+        constraint +: cls.decls.collectFirst { case field: InstanceField[Pre] =>
+          unwrapCastConstraintAxioms(outerType, field.t)
+        }.getOrElse(Nil)
+      case _ => Seq(constraint)
     }
   }
+
+//  private def makeCastHelper(t: Type[Pre]): Procedure[Post] = {
+//    implicit val o: Origin = CastHelperOrigin
+//      .where(name = "constraints_" + t.toString)
+//    globalDeclarations.declare(procedure(
+//      AbstractApplicable,
+//      TrueSatisfiable,
+//      ensures = UnitAccountedPredicate(
+//        unwrapCastConstraints(dispatch(t), t, None)
+//      ),
+//    ))
+//  }
+//
+//  private def addCastHelpers(
+//      t: Type[Pre],
+//      helpers: mutable.Set[Type[Pre]],
+//  ): Unit = {
+//    t match {
+//      case cls: TByValueClass[Pre] => {
+//        helpers.add(t)
+//        cls.cls.decl.decls.collectFirst { case field: InstanceField[Pre] =>
+//          addCastHelpers(field.t, helpers)
+//        }
+//      }
+//      case _ =>
+//    }
+//  }
 
   override def dispatch(e: Expr[Pre]): Expr[Post] =
     e match {
@@ -936,9 +914,9 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
         )(PanicBlame("instanceOf requires nothing"))(e.o)
       case Cast(value, typeValue) if value.t.asPointer.isDefined => {
         // Keep pointer casts and add extra annotations
-        if (requiredCastHelpers.nonEmpty) {
-          addCastHelpers(value.t.asPointer.get.element, requiredCastHelpers.top)
-        }
+//        if (requiredCastHelpers.nonEmpty) {
+//          addCastHelpers(value.t.asPointer.get.element, requiredCastHelpers.top)
+//        }
 
         e.rewriteDefault()
       }

--- a/src/rewrite/vct/rewrite/ClassToRef.scala
+++ b/src/rewrite/vct/rewrite/ClassToRef.scala
@@ -549,8 +549,8 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
     byValConsSucc(cls) = constructor
     byValClassSucc(cls) =
       new AxiomaticDataType[Post](
-        Seq(indexFunction, injectivityAxiom) ++ destructorAxioms ++
-          indexAxioms ++ fieldFunctions ++ fieldInverses ++ valueAsAxioms,
+        Seq(indexFunction) ++ destructorAxioms ++ indexAxioms ++
+          fieldFunctions ++ fieldInverses ++ valueAsAxioms,
         Nil,
       )
     globalDeclarations.succeed(cls, byValClassSucc(cls))

--- a/src/rewrite/vct/rewrite/ClassToRef.scala
+++ b/src/rewrite/vct/rewrite/ClassToRef.scala
@@ -949,6 +949,45 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
       case v @ Value(PredicateLocation(inv: InstancePredicateApply[Pre])) =>
         implicit val o: Origin = e.o
         Star[Post](v.rewrite(), dispatch(inv.obj) !== Null())
+      case starall @ Starall(bindings, _, body) => {
+        implicit val o: Origin = starall.o
+        val dereferencedClasses = body.flatCollect {
+          case Value(body) => body.flatCollect {
+            case FieldLocation(cls, _) if cls.t.asByValueClass.isDefined =>
+              cls.collect {
+                case DerefPointer(ptr) if ptr.t.asPointer.get.element == cls.t && ptr.exists { case Local(Ref(v)) => bindings.contains(v) } =>
+                  ptr.t
+              }
+            case Deref(cls, _) if cls.t.asByValueClass.isDefined =>
+              cls.collect {
+                case DerefPointer(ptr) if ptr.t.asPointer.get.element == cls.t && ptr.exists { case Local(Ref(v)) => bindings.contains(v) } =>
+                  ptr.t
+              }
+          }
+          case Perm(body, _) => body.flatCollect {
+            // TODO: This could be inlinepattern!
+            case FieldLocation(cls, _) if cls.t.asByValueClass.isDefined =>
+              cls.collect {
+                case DerefPointer(ptr) if ptr.t.asPointer.get.element == cls.t && ptr.exists { case Local(Ref(v)) => bindings.contains(v) } =>
+                  ptr.t
+              }
+            case Deref(cls, _) if cls.t.asByValueClass.isDefined =>
+              cls.collect {
+                case DerefPointer(ptr) if ptr.t.asPointer.get.element == cls.t && ptr.exists { case Local(Ref(v)) => bindings.contains(v) } =>
+                  ptr.t
+              }
+          }
+        }
+
+        foldStar(dereferencedClasses.toSet.map({c: Type[Pre] =>
+          val newPointer = dispatch(c) match {
+            case TPointer(inner, unique) => TNonNullPointer(inner, unique)
+            case t@TNonNullPointer(_, _) => t
+          }
+          PolarityDependent(foralls[Post](Seq(newPointer, newPointer), {case Seq(p, q) => ((p !== q) && CurPerm(PointerLocation(p)(NonNullPointerNull)) > NoPerm() && CurPerm(PointerLocation(q)(NonNullPointerNull)) > NoPerm()) ==> (DerefPointer(p)(NonNullPointerNull) !== DerefPointer(q)(NonNullPointerNull))}, {case Seq(p, q) => Seq(Seq(DerefPointer(p)(NonNullPointerNull), DerefPointer(q)(NonNullPointerNull)))}), tt)
+        }).toSeq :+ super.dispatch(starall))
+
+      }
       case _ => super.dispatch(e)
     }
 

--- a/src/rewrite/vct/rewrite/ClassToRef.scala
+++ b/src/rewrite/vct/rewrite/ClassToRef.scala
@@ -31,6 +31,8 @@ case object ClassToRef extends RewriterBuilder {
   private def CastHelperOrigin: Origin =
     Origin(Seq(LabelContext("classToRef cast helpers")))
 
+  val ByValueClassADTLabel = "ByValueClassADT"
+
   private case class InstanceNullPreconditionFailed(
       inner: Blame[InstanceNull],
       inv: InvokingNode[_],
@@ -69,6 +71,16 @@ case object ClassToRef extends RewriterBuilder {
             s"Permission should be framed, did not expect: ${error.desc}"
           )
         case _: PointerInsufficientPermission => throw RequiresExhaleModeError()
+      }
+    }
+  }
+
+  private case class SubscriptToAddBlame(blame: Blame[PointerSubscriptError])
+      extends Blame[PointerAddError] {
+    override def blame(error: PointerAddError): Unit = {
+      error match {
+        case e @ PointerNull(_) => blame.blame(e)
+        case e @ PointerBounds(_) => blame.blame(e)
       }
     }
   }
@@ -477,7 +489,7 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
             "new_" + cls.o.find[SourceName].map(_.name).getOrElse("unknown")
           )
       )
-    // TAnyValue is a placeholder the pointer adt doesn't have type parameters
+    // TVoid is a placeholder the pointer adt doesn't have type parameters
     val indexFunction =
       new ADTFunction[Post](
         Seq(new Variable(TNonNullPointer(TVoid(), None))(Origin(
@@ -490,6 +502,10 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
             "index_" + cls.o.find[SourceName].map(_.name).getOrElse("unknown")
           )
       )
+//    val fromPointer = new ADTFunction[Post](
+//      Seq(new Variable(TNonNullPointer(TVoid(), None))(Origin(Seq(PreferredName(Seq("pointer")), LabelContext("classToRef"))))),
+//      axiomType
+//    )(cls.o.copy(cls.o.originContents.filterNot(_.isInstanceOf[SourceName])).where(name = "from_pointer_"+cls.o.find[SourceName].map(_.name).getOrElse("unknown")));
     val injectivityAxiom =
       new ADTAxiom[Post](foralls(
         Seq(axiomType, axiomType),
@@ -552,7 +568,7 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
         Seq(indexFunction) ++ destructorAxioms ++ indexAxioms ++
           fieldFunctions ++ fieldInverses ++ valueAsAxioms,
         Nil,
-      )
+      )(o.withContent(LabelContext(ByValueClassADTLabel)))
     globalDeclarations.succeed(cls, byValClassSucc(cls))
   }
 
@@ -724,25 +740,24 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
     val constraint = forall[Post](
       TNonNullPointer(outerType, None),
       body = { p =>
-        PolarityDependent(
-          Greater(
-            CurPerm(PointerLocation(p)(PanicBlame(
-              "Referring to a non-null pointer should not cause any verification failures"
-            ))),
-            NoPerm(),
-          ) ==>
-            (InlinePattern(
-              Cast(p, TypeValue(TNonNullPointer(newT, unique)))
-            ) === adtFunctionInvocation(
-              valueAsFunctions.getOrElseUpdate(
-                (t, unique),
-                makeValueAsFunction(t.toString, newT, unique),
-              ).ref,
-              typeArgs = Some((valueAdt.ref(()), Seq(outerType))),
-              args = Seq(DerefPointer(p)(RequiresExhaleModeBlame())),
-            )),
-          tt,
-        )
+//        PolarityDependent(
+//          Greater(
+//            CurPerm(PointerLocation(p)(PanicBlame(
+//              "Referring to a non-null pointer should not cause any verification failures"
+//            ))),
+//            NoPerm(),
+//          ) ==>
+        (InlinePattern(Cast(p, TypeValue(TNonNullPointer(newT, unique)))) ===
+          adtFunctionInvocation(
+            valueAsFunctions.getOrElseUpdate(
+              (t, unique),
+              makeValueAsFunction(t.toString, newT, unique),
+            ).ref,
+            typeArgs = Some((valueAdt.ref(()), Seq(outerType))),
+            args = Seq(PointerToAdt(p, outerType)(RequiresExhaleModeBlame())),
+          )) /*,*/
+//          tt,
+//        )
       },
     )
     t match {
@@ -845,17 +860,32 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
               deref.blame
             )(deref.o)
           case t: TByValueClass[Pre] =>
-            DerefPointer(
-              adtFunctionInvocation[Post](
-                byValFieldSucc.ref(field),
-                args = Seq(dispatch(obj)),
-              )(deref.o)
-            )(DerefFieldPointerBlame(
-              deref.blame,
-              deref,
-              t.cls.decl.asInstanceOf[ByValueClass[Pre]],
-              Referrable.originNameOrEmpty(field),
-            ))(deref.o)
+            if (field.t.asByValueClass.isDefined) {
+              PointerToAdt(
+                adtFunctionInvocation[Post](
+                  byValFieldSucc.ref(field),
+                  args = Seq(dispatch(obj)),
+                )(deref.o),
+                dispatch(field.t),
+              )(DerefFieldPointerBlame(
+                deref.blame,
+                deref,
+                t.cls.decl.asInstanceOf[ByValueClass[Pre]],
+                Referrable.originNameOrEmpty(field),
+              ))(deref.o)
+            } else {
+              DerefPointer(
+                adtFunctionInvocation[Post](
+                  byValFieldSucc.ref(field),
+                  args = Seq(dispatch(obj)),
+                )(deref.o)
+              )(DerefFieldPointerBlame(
+                deref.blame,
+                deref,
+                t.cls.decl.asInstanceOf[ByValueClass[Pre]],
+                Referrable.originNameOrEmpty(field),
+              ))(deref.o)
+            }
         }
       case TypeValue(t) =>
         t match {
@@ -949,45 +979,54 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
       case v @ Value(PredicateLocation(inv: InstancePredicateApply[Pre])) =>
         implicit val o: Origin = e.o
         Star[Post](v.rewrite(), dispatch(inv.obj) !== Null())
-      case starall @ Starall(bindings, _, body) => {
-        implicit val o: Origin = starall.o
-        val dereferencedClasses = body.flatCollect {
-          case Value(body) => body.flatCollect {
-            case FieldLocation(cls, _) if cls.t.asByValueClass.isDefined =>
-              cls.collect {
-                case DerefPointer(ptr) if ptr.t.asPointer.get.element == cls.t && ptr.exists { case Local(Ref(v)) => bindings.contains(v) } =>
-                  ptr.t
-              }
-            case Deref(cls, _) if cls.t.asByValueClass.isDefined =>
-              cls.collect {
-                case DerefPointer(ptr) if ptr.t.asPointer.get.element == cls.t && ptr.exists { case Local(Ref(v)) => bindings.contains(v) } =>
-                  ptr.t
-              }
-          }
-          case Perm(body, _) => body.flatCollect {
-            // TODO: This could be inlinepattern!
-            case FieldLocation(cls, _) if cls.t.asByValueClass.isDefined =>
-              cls.collect {
-                case DerefPointer(ptr) if ptr.t.asPointer.get.element == cls.t && ptr.exists { case Local(Ref(v)) => bindings.contains(v) } =>
-                  ptr.t
-              }
-            case Deref(cls, _) if cls.t.asByValueClass.isDefined =>
-              cls.collect {
-                case DerefPointer(ptr) if ptr.t.asPointer.get.element == cls.t && ptr.exists { case Local(Ref(v)) => bindings.contains(v) } =>
-                  ptr.t
-              }
-          }
-        }
-
-        foldStar(dereferencedClasses.toSet.map({c: Type[Pre] =>
-          val newPointer = dispatch(c) match {
-            case TPointer(inner, unique) => TNonNullPointer(inner, unique)
-            case t@TNonNullPointer(_, _) => t
-          }
-          PolarityDependent(foralls[Post](Seq(newPointer, newPointer), {case Seq(p, q) => ((p !== q) && CurPerm(PointerLocation(p)(NonNullPointerNull)) > NoPerm() && CurPerm(PointerLocation(q)(NonNullPointerNull)) > NoPerm()) ==> (DerefPointer(p)(NonNullPointerNull) !== DerefPointer(q)(NonNullPointerNull))}, {case Seq(p, q) => Seq(Seq(DerefPointer(p)(NonNullPointerNull), DerefPointer(q)(NonNullPointerNull)))}), tt)
-        }).toSeq :+ super.dispatch(starall))
-
-      }
+//      case starall @ Starall(bindings, _, body) => {
+//        implicit val o: Origin = starall.o
+//        val dereferencedClasses = body.flatCollect {
+//          case Value(body) => body.flatCollect {
+//            case FieldLocation(cls, _) if cls.t.asByValueClass.isDefined =>
+//              cls.collect {
+//                case DerefPointer(ptr) if ptr.t.asPointer.get.element == cls.t && ptr.exists { case Local(Ref(v)) => bindings.contains(v) } =>
+//                  ptr.t
+//              }
+//            case Deref(cls, _) if cls.t.asByValueClass.isDefined =>
+//              cls.collect {
+//                case DerefPointer(ptr) if ptr.t.asPointer.get.element == cls.t && ptr.exists { case Local(Ref(v)) => bindings.contains(v) } =>
+//                  ptr.t
+//              }
+//          }
+//          case Perm(body, _) => body.flatCollect {
+//            // TODO: This could be inlinepattern!
+//            case FieldLocation(cls, _) if cls.t.asByValueClass.isDefined =>
+//              cls.collect {
+//                case DerefPointer(ptr) if ptr.t.asPointer.get.element == cls.t && ptr.exists { case Local(Ref(v)) => bindings.contains(v) } =>
+//                  ptr.t
+//              }
+//            case Deref(cls, _) if cls.t.asByValueClass.isDefined =>
+//              cls.collect {
+//                case DerefPointer(ptr) if ptr.t.asPointer.get.element == cls.t && ptr.exists { case Local(Ref(v)) => bindings.contains(v) } =>
+//                  ptr.t
+//              }
+//          }
+//        }
+//
+//        foldStar(dereferencedClasses.toSet.map({c: Type[Pre] =>
+//          val newPointer = dispatch(c) match {
+//            case TPointer(inner, unique) => TNonNullPointer(inner, unique)
+//            case t@TNonNullPointer(_, _) => t
+//          }
+//          PolarityDependent(foralls[Post](Seq(newPointer, newPointer), {case Seq(p, q) => ((p !== q) && CurPerm(PointerLocation(p)(NonNullPointerNull)) > NoPerm() && CurPerm(PointerLocation(q)(NonNullPointerNull)) > NoPerm()) ==> (DerefPointer(p)(NonNullPointerNull) !== DerefPointer(q)(NonNullPointerNull))}, {case Seq(p, q) => Seq(Seq(DerefPointer(p)(NonNullPointerNull), DerefPointer(q)(NonNullPointerNull)))}), tt)
+//        }).toSeq :+ super.dispatch(starall))
+//
+//      }
+      case dp @ DerefPointer(ptr) if dp.t.asByValueClass.isDefined =>
+        PointerToAdt(dispatch(ptr), dispatch(dp.t))(dp.blame)(dp.o)
+      case ps @ PointerSubscript(ptr, index) if ps.t.asByValueClass.isDefined =>
+        PointerToAdt(
+          PointerAdd(dispatch(ptr), dispatch(index))(SubscriptToAddBlame(
+            ps.blame
+          ))(ps.o),
+          dispatch(ps.t),
+        )(ps.blame)(ps.o)
       case _ => super.dispatch(e)
     }
 

--- a/src/rewrite/vct/rewrite/ClassToRef.scala
+++ b/src/rewrite/vct/rewrite/ClassToRef.scala
@@ -119,12 +119,9 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
   val valueAdt: SuccessionMap[Unit, AxiomaticDataType[Post]] = SuccessionMap()
   val valueAdtTypeArgument: Variable[Post] =
     new Variable(TType(TAnyValue()))(ValueAdtOrigin.where(name = "V"))
-  val valueAsFunctions: mutable.Map[Type[Pre], ADTFunction[Post]] = mutable
+  val valueAsFunctions
+      : mutable.Map[(Type[Pre], Option[BigInt]), ADTFunction[Post]] = mutable
     .Map()
-
-//  val castHelpers: SuccessionMap[(Type[Pre], Option[BigInt]), Procedure[Post]] =
-//    SuccessionMap()
-//  val requiredCastHelpers: ScopedStack[mutable.Set[Type[Pre]]] = ScopedStack()
 
   def typeNumber(cls: Class[Pre]): Int =
     typeNumberStore.getOrElseUpdate(cls, typeNumberStore.size + 1)
@@ -184,12 +181,13 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
   private def makeValueAsFunction(
       typeName: String,
       t: Type[Post],
+      unique: Option[BigInt],
   ): ADTFunction[Post] = {
     new ADTFunction[Post](
       Seq(new Variable(TVar[Post](valueAdtTypeArgument.ref))(
         ValueAdtOrigin.where(name = "v")
       )),
-      TNonNullPointer(t, None),
+      TNonNullPointer(t, unique),
     )(ValueAdtOrigin.where(name = "value_as_" + typeName))
   }
 
@@ -218,9 +216,10 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
       axiomType,
       body = { a =>
         InlinePattern(adtFunctionInvocation[Post](
-          valueAsFunctions
-            .getOrElseUpdate(oldT, makeValueAsFunction(oldT.toString, newT))
-            .ref,
+          valueAsFunctions.getOrElseUpdate(
+            (oldT, unique),
+            makeValueAsFunction(oldT.toString, newT, unique),
+          ).ref,
           typeArgs = Some((valueAdt.ref(()), Seq(axiomType))),
           args = Seq(a),
         )) === Cast(
@@ -427,8 +426,8 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
               body = { a =>
                 InlinePattern(adtFunctionInvocation[Post](
                   valueAsFunctions.getOrElseUpdate(
-                    field.t,
-                    makeValueAsFunction(field.t.toString, newT),
+                    (field.t, unique),
+                    makeValueAsFunction(field.t.toString, newT, unique),
                   ).ref,
                   typeArgs = Some((valueAdt.ref(()), Seq(axiomType))),
                   args = Seq(a),
@@ -537,7 +536,11 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
       new AxiomaticDataType[Post](
         Seq(indexFunction) ++ destructorAxioms ++ indexAxioms ++
           fieldFunctions ++ fieldInverses ++ valueAsAxioms ++
-          unwrapCastConstraintAxioms(axiomType, TByValueClass(cls.ref, Nil)),
+          unwrapCastConstraintAxioms(
+            axiomType,
+            TByValueClass(cls.ref, Nil),
+            None,
+          ),
         Nil,
       )(o.withContent(LabelContext(ByValueClassADTLabel)))
     globalDeclarations.succeed(cls, byValClassSucc(cls))
@@ -569,109 +572,55 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
     }
   }
 
-//  private def addCastConstraints(
-//      expr: Expr[Pre],
-//      totalHelpers: mutable.Set[Type[Pre]],
-//  ): Expr[Post] = {
-//    var result: Seq[Expr[Post]] = Nil
-//    for (clause <- expr.unfoldStar) {
-//      val newClause = dispatch(clause)
-//      result = result :+ newClause
-//    }
-//    foldStar(result)(expr.o)
-//  }
-
-  // For loops add cast helpers before and as an invariant (since otherwise the contract might not be well-formed)
-//  override def dispatch(node: LoopContract[Pre]): LoopContract[Post] = {
-//    val helpers: mutable.Set[Type[Pre]] = mutable.Set()
-//    node match {
-//      case inv @ LoopInvariant(invariant, decreases) => {
-//        val result =
-//          LoopInvariant(
-//            addCastConstraints(invariant, helpers),
-//            decreases.map(dispatch),
-//          )(inv.blame)(node.o)
-//        if (requiredCastHelpers.nonEmpty) {
-//          requiredCastHelpers.top.addAll(helpers)
-//        }
-//        result
-//      }
-//      case contract @ IterationContract(
-//            requires,
-//            ensures,
-//            context_everywhere,
-//          ) => {
-//        val result =
-//          IterationContract(
-//            addCastConstraints(requires, helpers),
-//            addCastConstraints(ensures, helpers),
-//            addCastConstraints(context_everywhere, helpers),
-//          )(contract.blame)(node.o)
-//        if (requiredCastHelpers.nonEmpty) {
-//          requiredCastHelpers.top.addAll(helpers)
-//        }
-//        result
-//      }
-//      case _: IterationContract[Pre] => throw ExtraNode
-//    }
-//  }
-
-  override def dispatch(stat: Statement[Pre]): Statement[Post] = {
-//    val helpers: mutable.Set[Type[Pre]] = mutable.Set()
-    val result =
-//      requiredCastHelpers.having(helpers) {
-      stat match {
-        case Instantiate(Ref(cls), Local(Ref(v))) =>
-          instantiate(cls, succ(v))(stat.o)
-        case inv @ InvokeMethod(
-              obj,
-              Ref(method),
-              args,
-              outArgs,
-              typeArgs,
-              givenMap,
-              yields,
-            ) =>
-          InvokeProcedure[Post](
-            ref = methodSucc.ref(method),
-            args = dispatch(obj) +: args.map(dispatch),
-            outArgs = outArgs.map(dispatch),
-            typeArgs = typeArgs.map(dispatch),
-            givenMap = givenMap.map { case (Ref(v), e) =>
-              (succ(v), dispatch(e))
-            },
-            yields = yields.map { case (e, Ref(v)) => (dispatch(e), succ(v)) },
-          )(PreBlameSplit.left(
-            InstanceNullPreconditionFailed(inv.blame, inv),
-            PreBlameSplit
-              .left(PanicBlame("incorrect instance method type?"), inv.blame),
-          ))(inv.o)
-        case inv @ InvokeConstructor(
-              Ref(cons),
-              _,
-              out,
-              args,
-              outArgs,
-              typeArgs,
-              givenMap,
-              yields,
-            ) =>
-          InvokeProcedure[Post](
-            ref = consSucc.ref(cons),
-            args = args.map(dispatch),
-            outArgs = dispatch(out) +: outArgs.map(dispatch),
-            typeArgs = typeArgs.map(dispatch),
-            givenMap = givenMap.map { case (Ref(v), e) =>
-              (succ(v), dispatch(e))
-            },
-            yields = yields.map { case (e, Ref(v)) => (dispatch(e), succ(v)) },
-          )(inv.blame)(inv.o)
-        case other => super.dispatch(other)
-      }
-//      }
-
-    result
-  }
+  override def dispatch(stat: Statement[Pre]): Statement[Post] =
+    stat match {
+      case Instantiate(Ref(cls), Local(Ref(v))) =>
+        instantiate(cls, succ(v))(stat.o)
+      case inv @ InvokeMethod(
+            obj,
+            Ref(method),
+            args,
+            outArgs,
+            typeArgs,
+            givenMap,
+            yields,
+          ) =>
+        InvokeProcedure[Post](
+          ref = methodSucc.ref(method),
+          args = dispatch(obj) +: args.map(dispatch),
+          outArgs = outArgs.map(dispatch),
+          typeArgs = typeArgs.map(dispatch),
+          givenMap = givenMap.map { case (Ref(v), e) =>
+            (succ(v), dispatch(e))
+          },
+          yields = yields.map { case (e, Ref(v)) => (dispatch(e), succ(v)) },
+        )(PreBlameSplit.left(
+          InstanceNullPreconditionFailed(inv.blame, inv),
+          PreBlameSplit
+            .left(PanicBlame("incorrect instance method type?"), inv.blame),
+        ))(inv.o)
+      case inv @ InvokeConstructor(
+            Ref(cons),
+            _,
+            out,
+            args,
+            outArgs,
+            typeArgs,
+            givenMap,
+            yields,
+          ) =>
+        InvokeProcedure[Post](
+          ref = consSucc.ref(cons),
+          args = args.map(dispatch),
+          outArgs = dispatch(out) +: outArgs.map(dispatch),
+          typeArgs = typeArgs.map(dispatch),
+          givenMap = givenMap.map { case (Ref(v), e) =>
+            (succ(v), dispatch(e))
+          },
+          yields = yields.map { case (e, Ref(v)) => (dispatch(e), succ(v)) },
+        )(inv.blame)(inv.o)
+      case other => super.dispatch(other)
+    }
 
   override def dispatch(node: ApplyAnyPredicate[Pre]): ApplyAnyPredicate[Post] =
     node match {
@@ -683,49 +632,10 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
       case other => other.rewriteDefault()
     }
 
-  private def unwrapCastConstraints(
-      outerType: Type[Post],
-      t: Type[Pre],
-      unique: Option[BigInt],
-  )(implicit o: Origin): Expr[Post] = {
-    val newT = dispatch(t)
-    val constraint = forall[Post](
-      TNonNullPointer(outerType, None),
-      body = { p =>
-//        PolarityDependent(
-//          Greater(
-//            CurPerm(PointerLocation(p)(PanicBlame(
-//              "Referring to a non-null pointer should not cause any verification failures"
-//            ))),
-//            NoPerm(),
-//          ) ==>
-        (InlinePattern(Cast(p, TypeValue(TNonNullPointer(newT, unique)))) ===
-          adtFunctionInvocation(
-            valueAsFunctions
-              .getOrElseUpdate(t, makeValueAsFunction(t.toString, newT)).ref,
-            typeArgs = Some((valueAdt.ref(()), Seq(outerType))),
-            args = Seq(PointerToAdt(p, outerType)(RequiresExhaleModeBlame())),
-          )) /*,*/
-//          tt,
-//        )
-      },
-    )
-    t match {
-      case TByValueClass(Ref(cls), _) =>
-        constraint &* cls.decls.collectFirst { case field: InstanceField[Pre] =>
-          unwrapCastConstraints(
-            outerType,
-            field.t,
-            field.flags.collectFirst { case Unique(unique) => unique },
-          )
-        }.getOrElse(tt)
-      case _ => constraint
-    }
-  }
-
   private def unwrapCastConstraintAxioms(
       outerType: Type[Post],
       t: Type[Pre],
+      unique: Option[BigInt],
   ): Seq[ADTAxiom[Post]] = {
     implicit val o: Origin = CastHelperOrigin
     val newT = dispatch(t)
@@ -733,10 +643,12 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
       new ADTAxiom(forall[Post](
         TNonNullPointer(outerType, None),
         body = { p =>
-          InlinePattern(Cast(p, TypeValue(TNonNullPointer(newT, None)))) ===
+          InlinePattern(Cast(p, TypeValue(TNonNullPointer(newT, unique)))) ===
             adtFunctionInvocation(
-              valueAsFunctions
-                .getOrElseUpdate(t, makeValueAsFunction(t.toString, newT)).ref,
+              valueAsFunctions.getOrElseUpdate(
+                (t, unique),
+                makeValueAsFunction(t.toString, newT, unique),
+              ).ref,
               typeArgs = Some((valueAdt.ref(()), Seq(outerType))),
               args = Seq(PointerToAdt(p, outerType)(RequiresExhaleModeBlame())),
             )
@@ -745,38 +657,15 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
     t match {
       case TByValueClass(Ref(cls), _) =>
         constraint +: cls.decls.collectFirst { case field: InstanceField[Pre] =>
-          unwrapCastConstraintAxioms(outerType, field.t)
+          unwrapCastConstraintAxioms(
+            outerType,
+            field.t,
+            field.flags.collectFirst { case Unique(unique) => unique },
+          )
         }.getOrElse(Nil)
       case _ => Seq(constraint)
     }
   }
-
-//  private def makeCastHelper(t: Type[Pre]): Procedure[Post] = {
-//    implicit val o: Origin = CastHelperOrigin
-//      .where(name = "constraints_" + t.toString)
-//    globalDeclarations.declare(procedure(
-//      AbstractApplicable,
-//      TrueSatisfiable,
-//      ensures = UnitAccountedPredicate(
-//        unwrapCastConstraints(dispatch(t), t, None)
-//      ),
-//    ))
-//  }
-//
-//  private def addCastHelpers(
-//      t: Type[Pre],
-//      helpers: mutable.Set[Type[Pre]],
-//  ): Unit = {
-//    t match {
-//      case cls: TByValueClass[Pre] => {
-//        helpers.add(t)
-//        cls.cls.decl.decls.collectFirst { case field: InstanceField[Pre] =>
-//          addCastHelpers(field.t, helpers)
-//        }
-//      }
-//      case _ =>
-//    }
-//  }
 
   override def dispatch(e: Expr[Pre]): Expr[Post] =
     e match {
@@ -914,10 +803,6 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
         )(PanicBlame("instanceOf requires nothing"))(e.o)
       case Cast(value, typeValue) if value.t.asPointer.isDefined => {
         // Keep pointer casts and add extra annotations
-//        if (requiredCastHelpers.nonEmpty) {
-//          addCastHelpers(value.t.asPointer.get.element, requiredCastHelpers.top)
-//        }
-
         e.rewriteDefault()
       }
       case Cast(value, typeValue)
@@ -957,45 +842,6 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
       case v @ Value(PredicateLocation(inv: InstancePredicateApply[Pre])) =>
         implicit val o: Origin = e.o
         Star[Post](v.rewrite(), dispatch(inv.obj) !== Null())
-//      case starall @ Starall(bindings, _, body) => {
-//        implicit val o: Origin = starall.o
-//        val dereferencedClasses = body.flatCollect {
-//          case Value(body) => body.flatCollect {
-//            case FieldLocation(cls, _) if cls.t.asByValueClass.isDefined =>
-//              cls.collect {
-//                case DerefPointer(ptr) if ptr.t.asPointer.get.element == cls.t && ptr.exists { case Local(Ref(v)) => bindings.contains(v) } =>
-//                  ptr.t
-//              }
-//            case Deref(cls, _) if cls.t.asByValueClass.isDefined =>
-//              cls.collect {
-//                case DerefPointer(ptr) if ptr.t.asPointer.get.element == cls.t && ptr.exists { case Local(Ref(v)) => bindings.contains(v) } =>
-//                  ptr.t
-//              }
-//          }
-//          case Perm(body, _) => body.flatCollect {
-//            // TODO: This could be inlinepattern!
-//            case FieldLocation(cls, _) if cls.t.asByValueClass.isDefined =>
-//              cls.collect {
-//                case DerefPointer(ptr) if ptr.t.asPointer.get.element == cls.t && ptr.exists { case Local(Ref(v)) => bindings.contains(v) } =>
-//                  ptr.t
-//              }
-//            case Deref(cls, _) if cls.t.asByValueClass.isDefined =>
-//              cls.collect {
-//                case DerefPointer(ptr) if ptr.t.asPointer.get.element == cls.t && ptr.exists { case Local(Ref(v)) => bindings.contains(v) } =>
-//                  ptr.t
-//              }
-//          }
-//        }
-//
-//        foldStar(dereferencedClasses.toSet.map({c: Type[Pre] =>
-//          val newPointer = dispatch(c) match {
-//            case TPointer(inner, unique) => TNonNullPointer(inner, unique)
-//            case t@TNonNullPointer(_, _) => t
-//          }
-//          PolarityDependent(foralls[Post](Seq(newPointer, newPointer), {case Seq(p, q) => ((p !== q) && CurPerm(PointerLocation(p)(NonNullPointerNull)) > NoPerm() && CurPerm(PointerLocation(q)(NonNullPointerNull)) > NoPerm()) ==> (DerefPointer(p)(NonNullPointerNull) !== DerefPointer(q)(NonNullPointerNull))}, {case Seq(p, q) => Seq(Seq(DerefPointer(p)(NonNullPointerNull), DerefPointer(q)(NonNullPointerNull)))}), tt)
-//        }).toSeq :+ super.dispatch(starall))
-//
-//      }
       case dp @ DerefPointer(ptr) if dp.t.asByValueClass.isDefined =>
         PointerToAdt(dispatch(ptr), dispatch(dp.t))(dp.blame)(dp.o)
       case ps @ PointerSubscript(ptr, index) if ps.t.asByValueClass.isDefined =>

--- a/src/rewrite/vct/rewrite/DisambiguateLocation.scala
+++ b/src/rewrite/vct/rewrite/DisambiguateLocation.scala
@@ -48,7 +48,9 @@ case class DisambiguateLocation[Pre <: Generation]() extends Rewriter[Pre] {
   ): Location[Post] =
     expr match {
       case expr if expr.t.asPointer.isDefined =>
-        PointerLocation(dispatch(expr))(blame)
+        if (expr.t.asPointer.get.element.asByValueClass.isDefined) {
+          throw NotALocation(expr)
+        } else { PointerLocation(dispatch(expr))(blame) }
       case expr if expr.t.asByValueClass.isDefined =>
         ByValueClassLocation(dispatch(expr))(blame)
       case DerefHeapVariable(ref) => HeapVariableLocation(succ(ref.decl))

--- a/src/rewrite/vct/rewrite/EncodeArrayValues.scala
+++ b/src/rewrite/vct/rewrite/EncodeArrayValues.scala
@@ -111,14 +111,16 @@ case class EncodeArrayValues[Pre <: Generation]() extends Rewriter[Pre] {
       : mutable.Map[(Type[Pre], Int, Int, Boolean), Procedure[Post]] = mutable
     .Map()
 
-  val pointerArrayCreationMethods: mutable.Map[(Type[Pre], Option[BigInt]), Procedure[Post]] =
-    mutable.Map()
+  val pointerArrayCreationMethods
+      : mutable.Map[(Type[Pre], Option[BigInt]), Procedure[Post]] = mutable
+    .Map()
 
   val nonNullPointerArrayCreationMethods
-      : mutable.Map[(Type[Pre], Option[BigInt]), Procedure[Post]] = mutable.Map()
+      : mutable.Map[(Type[Pre], Option[BigInt]), Procedure[Post]] = mutable
+    .Map()
 
-  val constPointerArrayCreationMethods: mutable.Map[Type[Pre], Procedure[Post]] =
-    mutable.Map()
+  val constPointerArrayCreationMethods
+      : mutable.Map[Type[Pre], Procedure[Post]] = mutable.Map()
 
   val freeMethods: mutable.Map[PointerType[
     Post
@@ -157,28 +159,31 @@ case class EncodeArrayValues[Pre <: Generation]() extends Rewriter[Pre] {
       /*@
         requires ptr != NULL;
         requires \pointer_block_offset(ptr) == 0;
+        (if ptr is not struct type)
         requires (\forall* int i; 0 <= i && i < \pointer_block_length(ptr); Perm(&ptr[i], write));
         (if ptr is struct type):
         requires (\forall int i, j; 0 <= i,j && i,j < \pointer_block_length(ptr); i!=j ==> &ptr[i] != &ptr[j]);
         requires (\forall* int i; 0 <= i && i < \pointer_block_length(ptr); Perm(ptr[i], write));
         (and recurse for struct fields)
        */
-      var requiresT: Seq[(Expr[Post], Expr[Pre] => PointerFreeError)] = Seq(
-        (
-          PointerBlockOffset(ptr)(FramedPtrBlockOffset) === zero,
-          (p: Expr[Pre]) => PointerOffsetNonZero(p),
-        ),
-        (
-          makeStruct.makePerm(
-            i =>
-              PointerLocation(PointerAdd(ptr, i.get)(FramedPtrOffset))(
-                FramedPtrOffset
+      var requiresT: Seq[(Expr[Post], Expr[Pre] => PointerFreeError)] = Seq((
+        PointerBlockOffset(ptr)(FramedPtrBlockOffset) === zero,
+        (p: Expr[Pre]) => PointerOffsetNonZero(p),
+      ))
+      if (pointerT.element.asByValueClass.isEmpty) {
+        requiresT =
+          requiresT :+
+            (
+              makeStruct.makePerm(
+                i =>
+                  PointerLocation(PointerAdd(ptr, i.get)(FramedPtrOffset))(
+                    FramedPtrOffset
+                  ),
+                IteratedPtrInjective,
               ),
-            IteratedPtrInjective,
-          ),
-          (p: Expr[Pre]) => PointerInsufficientFreePermission(p),
-        ),
-      )
+              (p: Expr[Pre]) => PointerInsufficientFreePermission(p),
+            )
+      }
       requiresT =
         if (!typeIsRef(pointerT.element))
           requiresT
@@ -403,7 +408,7 @@ case class EncodeArrayValues[Pre <: Generation]() extends Rewriter[Pre] {
         args = dimArgs,
         requires = UnitAccountedPredicate(requires),
         ensures = UnitAccountedPredicate(ensures),
-        decreases = Some(DecreasesClauseNoRecursion[Post]())
+        decreases = Some(DecreasesClauseNoRecursion[Post]()),
       )(o.where(name =
         if (initialize)
           "make_array_initialized"
@@ -432,17 +437,21 @@ case class EncodeArrayValues[Pre <: Generation]() extends Rewriter[Pre] {
     val newFieldPerms = fields.map(member => {
       val loc =
         (i: Variable[Post]) => Deref[Post](struct(i), succ(member))(DerefPerm)
-      var anns: Seq[(Expr[Post], Expr[Pre] => PointerFreeError)] = Seq((
-        makeStruct.makePerm(
-          i => FieldLocation[Post](struct(i), succ(member)),
-          IteratedPtrInjective,
-        ),
-        (p: Expr[Pre]) =>
-          PointerInsufficientFreeFieldPermission(
-            p,
-            Referrable.originName(member),
-          ),
-      ))
+      var anns: Seq[(Expr[Post], Expr[Pre] => PointerFreeError)] = {
+        if (member.t.asByValueClass.isEmpty) {
+          Seq((
+            makeStruct.makePerm(
+              i => FieldLocation[Post](struct(i), succ(member)),
+              IteratedPtrInjective,
+            ),
+            (p: Expr[Pre]) =>
+              PointerInsufficientFreeFieldPermission(
+                p,
+                Referrable.originName(member),
+              ),
+          ))
+        } else { Nil }
+      }
       anns =
         if (typeIsRef(member.t))
           anns :+
@@ -500,11 +509,15 @@ case class EncodeArrayValues[Pre <: Generation]() extends Rewriter[Pre] {
         access: Variable[Post] => Expr[Post],
         innerType: Type[Post],
         unique: Option[BigInt],
-        isConst: Boolean
+        isConst: Boolean,
     ): Expr[Post] = {
       implicit val o: Origin = arrayCreationOrigin
       val zero = const[Post](0)
-      val t = if(!isConst) TNonNullPointer(innerType, unique) else TNonNullConstPointer(innerType)
+      val t =
+        if (!isConst)
+          TNonNullPointer(innerType, unique)
+        else
+          TNonNullConstPointer(innerType)
       val cast = Cast(access(i), TypeValue(t))
       val body = (zero <= i.get && i.get < size) ==> (cast === access(i))
       Forall(Seq(i), Seq(Seq(cast)), body)
@@ -521,11 +534,12 @@ case class EncodeArrayValues[Pre <: Generation]() extends Rewriter[Pre] {
       elementType: Type[Pre],
       nullable: Boolean,
       unique: Option[BigInt],
-      isConst: Boolean
+      isConst: Boolean,
   ) = {
     implicit val o: Origin = arrayCreationOrigin
     // !nullable? then 'ar != null ==> ...'; otherwise 'ar != null ** ...'
     // ar.length == size
+    // (if type ar[i] is not a struct)
     // forall ar[i] :: Perm(ar[i], write)
     // (if type ar[i] is pointer or struct):
     // forall i,j :: i!=j ==> ar[i] != ar[j]
@@ -552,7 +566,7 @@ case class EncodeArrayValues[Pre <: Generation]() extends Rewriter[Pre] {
           (PointerBlockOffset(result)(FramedPtrBlockOffset) === zero)
 
       // Pointer location needs pointer add, not pointer subscript
-      if(!isConst) {
+      if (!isConst && elementType.asByValueClass.isEmpty) {
         ensures =
           ensures &* makeStruct.makePerm(
             i =>
@@ -582,11 +596,13 @@ case class EncodeArrayValues[Pre <: Generation]() extends Rewriter[Pre] {
       val innerType = dispatch(elementType)
       // TODO: Ask alexander what this is supposed to add. I did not want to copy all the
       // applyAsTypeFunction in ImportPointer towards ImportConstPointer to get this to work
-      if(!isConst) {
+      if (!isConst) {
         ensures =
           ensures &* makeStruct.makeCast(
             i => PointerAdd(result, i.get)(FramedPtrOffset),
-            innerType, unique, isConst
+            innerType,
+            unique,
+            isConst,
           )
       }
 
@@ -595,13 +611,24 @@ case class EncodeArrayValues[Pre <: Generation]() extends Rewriter[Pre] {
         else { ensures }
 
       val returnT = {
-        if(isConst && !nullable) TNonNullConstPointer(innerType)
-        else if(isConst) TConstPointer(innerType)
-        else if(!nullable) TNonNullPointer(innerType, unique)
-        else TPointer(innerType, unique)
+        if (isConst && !nullable)
+          TNonNullConstPointer(innerType)
+        else if (isConst)
+          TConstPointer(innerType)
+        else if (!nullable)
+          TNonNullPointer(innerType, unique)
+        else
+          TPointer(innerType, unique)
       }
-      val name = if(isConst) "make_const_pointer_array_" + innerType.toString
-        else "make_pointer_array_" + innerType.toString + "" + (if(nullable) "_nullable" else "")
+      val name =
+        if (isConst)
+          "make_const_pointer_array_" + innerType.toString
+        else
+          "make_pointer_array_" + innerType.toString + "" +
+            (if (nullable)
+               "_nullable"
+             else
+               "")
       procedure(
         blame = AbstractApplicable,
         contractBlame = TrueSatisfiable,
@@ -609,7 +636,7 @@ case class EncodeArrayValues[Pre <: Generation]() extends Rewriter[Pre] {
         args = Seq(sizeArg),
         requires = UnitAccountedPredicate(requires),
         ensures = UnitAccountedPredicate(ensures),
-        decreases = Some(DecreasesClauseNoRecursion[Post]())
+        decreases = Some(DecreasesClauseNoRecursion[Post]()),
       )(o.where(name = name))
     }))
   }
@@ -642,8 +669,15 @@ case class EncodeArrayValues[Pre <: Generation]() extends Rewriter[Pre] {
           Nil,
         )(ArrayCreationFailed(newArr))
       case newPointerArr @ NewPointerArray(element, size, unique) =>
-        val method = pointerArrayCreationMethods
-          .getOrElseUpdate((element, unique), makePointerCreationMethodFor(element, nullable = true, unique, isConst=false))
+        val method = pointerArrayCreationMethods.getOrElseUpdate(
+          (element, unique),
+          makePointerCreationMethodFor(
+            element,
+            nullable = true,
+            unique,
+            isConst = false,
+          ),
+        )
         ProcedureInvocation[Post](
           method.ref,
           Seq(dispatch(size)),
@@ -655,7 +689,12 @@ case class EncodeArrayValues[Pre <: Generation]() extends Rewriter[Pre] {
       case newPointerArr @ NewNonNullPointerArray(element, size, unique) =>
         val method = nonNullPointerArrayCreationMethods.getOrElseUpdate(
           (element, unique),
-          makePointerCreationMethodFor(element, nullable = false, unique, isConst=false),
+          makePointerCreationMethodFor(
+            element,
+            nullable = false,
+            unique,
+            isConst = false,
+          ),
         )
         ProcedureInvocation[Post](
           method.ref,
@@ -666,8 +705,15 @@ case class EncodeArrayValues[Pre <: Generation]() extends Rewriter[Pre] {
           Nil,
         )(PointerArrayCreationFailed(newPointerArr, newPointerArr.blame))
       case ncpa @ NewConstPointerArray(element, size) =>
-        val method = constPointerArrayCreationMethods
-          .getOrElseUpdate((element), makePointerCreationMethodFor(element, nullable = true, None, isConst=true))
+        val method = constPointerArrayCreationMethods.getOrElseUpdate(
+          (element),
+          makePointerCreationMethodFor(
+            element,
+            nullable = true,
+            None,
+            isConst = true,
+          ),
+        )
         ProcedureInvocation[Post](
           method.ref,
           Seq(dispatch(size)),
@@ -677,8 +723,15 @@ case class EncodeArrayValues[Pre <: Generation]() extends Rewriter[Pre] {
           Nil,
         )(PointerArrayCreationFailed(ncpa, ncpa.blame))
       case ncpa @ NewNonNullConstPointerArray(element, size) =>
-        val method = constPointerArrayCreationMethods
-          .getOrElseUpdate((element), makePointerCreationMethodFor(element, nullable = false, None, isConst=true))
+        val method = constPointerArrayCreationMethods.getOrElseUpdate(
+          (element),
+          makePointerCreationMethodFor(
+            element,
+            nullable = false,
+            None,
+            isConst = true,
+          ),
+        )
         ProcedureInvocation[Post](
           method.ref,
           Seq(dispatch(size)),

--- a/src/rewrite/vct/rewrite/EncodeByValueClassUsage.scala
+++ b/src/rewrite/vct/rewrite/EncodeByValueClassUsage.scala
@@ -248,10 +248,8 @@ case class EncodeByValueClassUsage[Pre <: Generation]() extends Rewriter[Pre] {
         })
       case Local(Ref(v))
           if inContract.isEmpty && heapLocalArgSucc.contains(v) =>
-        DerefPointer(heapLocalArgSucc(v).get(PanicBlame(
+        heapLocalArgSucc(v).get(PanicBlame(
           "Missing permission to procedure argument of struct type, no suitable blame available"
-        )))(PanicBlame(
-          "Missing permission to dereference procedure argument of struct type, no suitable blame available"
         ))
       case _ => node.rewriteDefault()
     }

--- a/src/rewrite/vct/rewrite/EncodeByValueClassUsage.scala
+++ b/src/rewrite/vct/rewrite/EncodeByValueClassUsage.scala
@@ -305,6 +305,10 @@ case class EncodeByValueClassUsage[Pre <: Generation]() extends Rewriter[Pre] {
       case dp @ DerefPointer(Local(Ref(_))) =>
         // This can happen if the user specifies a local of type pointer to TByValueClass
         rewriteInCopyContext2(dispatch(dp), dp.blame, t, target, context)
+      case Then(value, post) =>
+        Block(Seq(doCopy(value, target, t, context), dispatch(post)))(e.o)
+      case With(pre, value) =>
+        Block(Seq(dispatch(pre), doCopy(value, target, t, context)))(e.o)
       case _ =>
         println(e)
         ???

--- a/src/rewrite/vct/rewrite/EncodeByValueClassUsage.scala
+++ b/src/rewrite/vct/rewrite/EncodeByValueClassUsage.scala
@@ -339,19 +339,13 @@ case class EncodeByValueClassUsage[Pre <: Generation]() extends Rewriter[Pre] {
           target,
           context,
         )
-      case dp @ DerefPointer(HeapLocal(Ref(_)) | DerefHeapVariable(Ref(_))) =>
+      case dp @ DerefPointer(_) =>
         rewriteInCopyContext2(dispatch(dp), dp.blame, t, target, context)
-      case ps @ PointerSubscript(
-            HeapLocal(Ref(_)) | DerefHeapVariable(Ref(_)),
-            _,
-          ) =>
+      case ps @ PointerSubscript(_, _) =>
         rewriteInCopyContext2(dispatch(ps), ps.blame, t, target, context)
-      case deref @ Deref(_, Ref(f)) =>
+      case deref @ Deref(_, _) =>
         // TODO: Improve blame message here
         copyClassValue2(deref.rewriteDefault(), t, target, f => deref.blame)
-      case dp @ DerefPointer(Local(Ref(_))) =>
-        // This can happen if the user specifies a local of type pointer to TByValueClass
-        rewriteInCopyContext2(dispatch(dp), dp.blame, t, target, context)
       case Then(value, post) =>
         Block(Seq(doCopy(value, target, t, context), dispatch(post)))(e.o)
       case With(pre, value) =>

--- a/src/rewrite/vct/rewrite/EncodeByValueClassUsage.scala
+++ b/src/rewrite/vct/rewrite/EncodeByValueClassUsage.scala
@@ -46,6 +46,16 @@ case object EncodeByValueClassUsage extends RewriterBuilder {
     }
   }
 
+  private case class InvocationBlameAdapter(blame: Blame[InvocationFailure])
+      extends Blame[PointerDerefError] {
+    override def blame(error: PointerDerefError) =
+      error match {
+        case e @ CopyClassFailed(_, _, _) => blame.blame(e)
+        case e @ CopyClassFailedBeforeCall(_, _, _) => blame.blame(e)
+        case _ => ???
+      }
+  }
+
   case class UnsupportedStructPerm(o: Origin) extends UserError {
     override def code: String = "unsupportedStructPerm"
     override def text: String =
@@ -64,19 +74,16 @@ case object EncodeByValueClassUsage extends RewriterBuilder {
   private case class InAssignmentStatement(assignment: Assign[_])
       extends CopyContext
 
-  private case class NoCopy() extends CopyContext
 }
 
 case class EncodeByValueClassUsage[Pre <: Generation]() extends Rewriter[Pre] {
 
   import EncodeByValueClassUsage._
 
-  private val inAssignment: ScopedStack[Unit] = ScopedStack()
-  private val copyContext: ScopedStack[CopyContext] = ScopedStack()
-  copyContext.push(NoCopy())
   private val classCreationMethodsSucc
       : SuccessionMap[TByValueClass[Pre], Procedure[Post]] = SuccessionMap()
 
+  // Duplicated in LowerHeapVariables, keep in sync
   def makeClassCreationMethod(t: TByValueClass[Pre]): Procedure[Post] = {
     implicit val o: Origin = t.cls.decl.o
 
@@ -96,77 +103,45 @@ case class EncodeByValueClassUsage[Pre <: Generation]() extends Rewriter[Pre] {
   override def dispatch(node: Statement[Pre]): Statement[Post] = {
     implicit val o: Origin = node.o
     node match {
-      case HeapLocalDecl(local)
-          if local.t.asPointer.get.element.asByValueClass.isDefined => {
-        val t = local.t.asPointer.get.element.asByValueClass.get
-        val newLocal = localHeapVariables.dispatch(local)
-        Block(Seq(
-          HeapLocalDecl(newLocal),
-//          Assign(
-//            HeapLocal[Post](newLocal.ref),
-//            NewNonNullPointerArray(t, const(1))(PanicBlame("Size > 0")),
-//          )(AssignLocalOk),
-          // TODO: Only do this if the first use does not overwrite it again (do something similar to what I implemented in ImportPointer)....
-          Assign(
-            newLocal.get(DerefAssignTarget),
-            procedureInvocation[Post](
-              TrueSatisfiable,
-              classCreationMethodsSucc
-                .getOrElseUpdate(t, makeClassCreationMethod(t)).ref,
-            ),
-          )(AssignLocalOk),
-        ))
-      }
       case assign: Assign[Pre] =>
-        val target = inAssignment.having(()) { dispatch(assign.target) }
+        val target = dispatch(assign.target)
         assign.target.t match {
-          case _: TByValueClass[Pre] =>
-            copyContext.having(InAssignmentStatement(assign)) {
-              assign.rewrite(target = target)
-            }
+          case t: TByValueClass[Pre] =>
+            doCopy(assign.value, target, t, InAssignmentStatement(assign))
           case _ => assign.rewrite(target = target)
         }
       case _ => node.rewriteDefault()
     }
   }
 
-  private def copyClassValue(
+  private def copyClassValue2(
       obj: Expr[Post],
       t: TByValueClass[Pre],
+      target: Expr[Post],
       blame: InstanceField[Pre] => Blame[InsufficientPermission],
-  ): Expr[Post] = {
+  ): Statement[Post] = {
     implicit val o: Origin = obj.o
     val ov = new Variable[Post](obj.t)(o.where(name = "original"))
-    val v = new Variable[Post](dispatch(t))(o.where(name = "copy"))
     val children = t.cls.decl.decls.collect { case f: InstanceField[Pre] =>
-      Assign[Post](
-        Deref[Post](v.get, succ(f))(DerefAssignTarget),
-        f.t match {
-          case inner: TByValueClass[Pre] =>
-            copyClassValue(Deref[Post](ov.get, succ(f))(blame(f)), inner, blame)
-          case _ => Deref[Post](ov.get, succ(f))(blame(f))
-        },
-      )(AssignLocalOk)
+      f.t match {
+        case inner: TByValueClass[Pre] =>
+          copyClassValue2(
+            Deref[Post](ov.get, succ(f))(blame(f)),
+            inner,
+            Deref[Post](target, succ(f))(DerefAssignTarget),
+            blame,
+          )
+        case _ =>
+          Assign[Post](
+            Deref[Post](target, succ(f))(DerefAssignTarget),
+            Deref[Post](ov.get, succ(f))(blame(f)),
+          )(AssignLocalOk)
+      }
     }
-    ScopedExpr(
-      Seq(ov, v),
-      Then(
-        With(
-          assignLocal(ov.get, obj),
-          PreAssignExpression(
-            v.get,
-            procedureInvocation[Post](
-              TrueSatisfiable,
-              classCreationMethodsSucc
-                .getOrElseUpdate(t, makeClassCreationMethod(t)).ref,
-            ),
-          )(AssignLocalOk),
-        ),
-        Block(children),
-      ),
-    )
+    Scope(Seq(ov), Block(assignLocal(ov.get, obj) +: children))
   }
 
+  // Duplicated in LowerHeapVariables, keep in sync
   private def unwrapClassPerm(
       obj: Expr[Post],
       perm: Location[Post] => Expr[Post],
@@ -186,7 +161,7 @@ case class EncodeByValueClassUsage[Pre <: Generation]() extends Rewriter[Pre] {
       val loc = FieldLocation[Post](obj, succ(member))
       member.t match {
         case inner: TByValueClass[Pre] =>
-          perm(loc) &* unwrapClassPerm(
+          unwrapClassPerm(
             Deref[Post](obj, succ(member))(blame),
             perm,
             inner,
@@ -209,7 +184,6 @@ case class EncodeByValueClassUsage[Pre <: Generation]() extends Rewriter[Pre] {
           classCreationMethodsSucc
             .getOrElseUpdate(t, makeClassCreationMethod(t)).ref,
         )
-      case _ if inAssignment.nonEmpty => node.rewriteDefault()
       case Perm(ByValueClassLocation(e), p) =>
         val permission = dispatch(p)
         unwrapClassPerm(
@@ -235,69 +209,138 @@ case class EncodeByValueClassUsage[Pre <: Generation]() extends Rewriter[Pre] {
           )
         } else { node.rewriteDefault() }
       case assign: PreAssignExpression[Pre] =>
-        val target = inAssignment.having(()) { dispatch(assign.target) }
-        if (assign.target.t.asByValueClass.isDefined) {
-          copyContext.having(InAssignmentExpression(assign)) {
-            assign.rewrite(target = target)
-          }
-        } else {
-          // No need for copy semantics in this context
-          copyContext.having(NoCopy()) { assign.rewrite(target = target) }
+        val target = dispatch(assign.target)
+        assign.t match {
+          case t: TByValueClass[Pre] =>
+            With(
+              doCopy(assign.value, target, t, InAssignmentExpression(assign)),
+              target,
+            )
+          case _ => assign.rewrite(target = target)
         }
       case invocation: Invocation[Pre] =>
         invocation.rewrite(args = invocation.args.map { a =>
-          if (a.t.asByValueClass.isDefined) {
-            copyContext.having(InCall(invocation)) { dispatch(a) }
-          } else { copyContext.having(NoCopy()) { dispatch(a) } }
+          a.t match {
+            case t: TByValueClass[Pre] =>
+              val v = new Variable(dispatch(t))(a.o.where(name = "copy"))
+              ScopedExpr(
+                Seq(v),
+                With(
+                  Assign(
+                    v.get(a.o),
+                    procedureInvocation[Post](
+                      TrueSatisfiable,
+                      classCreationMethodsSucc
+                        .getOrElseUpdate(t, makeClassCreationMethod(t)).ref,
+                    )(a.o),
+                  )(AssignLocalOk)(a.o),
+                  With(
+                    doCopy(a, v.get(a.o), t, InCall(invocation)),
+                    v.get(a.o),
+                  )(a.o),
+                )(a.o),
+              )(a.o)
+            case _ => dispatch(a)
+          }
         })
-      case dp @ DerefPointer(HeapLocal(Ref(v)))
-          if v.t.asPointer.get.element.asByValueClass.isDefined =>
-        rewriteInCopyContext(dp, v.t.asPointer.get.element.asByValueClass.get)
-      case dp @ DerefPointer(DerefHeapVariable(Ref(v)))
-          if v.t.asPointer.get.element.asByValueClass.isDefined =>
-        rewriteInCopyContext(dp, v.t.asPointer.get.element.asByValueClass.get)
-      case deref @ Deref(_, Ref(f))
-          if f.t.asByValueClass.isDefined && copyContext.top != NoCopy() =>
-        // TODO: Improve blame message here
-        copyClassValue(
-          deref.rewriteDefault(),
-          f.t.asByValueClass.get,
-          f => deref.blame,
-        )
-      case dp @ DerefPointer(Local(Ref(v)))
-          if v.t.asPointer.get.element.asByValueClass.isDefined =>
-        // This can happen if the user specifies a local of type pointer to TByValueClass
-        rewriteInCopyContext(dp, v.t.asPointer.get.element.asByValueClass.get)
       case _ => node.rewriteDefault()
     }
   }
 
-  private def rewriteInCopyContext(
-      dp: DerefPointer[Pre],
+  private def doCopy(
+      e: Expr[Pre],
+      target: Expr[Post],
       t: TByValueClass[Pre],
-  ): Expr[Post] = {
+      context: CopyContext,
+  ): Statement[Post] =
+    e match {
+      case assign: PreAssignExpression[Pre] =>
+        val innerTarget = dispatch(assign.target)
+        Block(Seq(
+          doCopy(assign.value, innerTarget, t, InAssignmentExpression(assign)),
+          doCopy(assign.value, target, t, context),
+        ))(assign.o)
+      case invocation: Invocation[Pre] =>
+        val newInvocation = invocation.rewrite(args = invocation.args.map { a =>
+          a.t match {
+            case t: TByValueClass[Pre] =>
+              val v = new Variable(dispatch(t))(a.o.where(name = "copy"))
+              ScopedExpr(
+                Seq(v),
+                With(
+                  Assign(
+                    v.get(a.o),
+                    procedureInvocation[Post](
+                      TrueSatisfiable,
+                      classCreationMethodsSucc
+                        .getOrElseUpdate(t, makeClassCreationMethod(t)).ref,
+                    )(a.o),
+                  )(AssignLocalOk)(a.o),
+                  With(
+                    doCopy(a, v.get(a.o), t, InCall(invocation)),
+                    v.get(a.o),
+                  )(a.o),
+                )(a.o),
+              )(a.o)
+            case _ => dispatch(a)
+          }
+        })
+        rewriteInCopyContext2(
+          newInvocation,
+          InvocationBlameAdapter(invocation.blame),
+          t,
+          target,
+          context,
+        )
+      case dp @ DerefPointer(HeapLocal(Ref(_)) | DerefHeapVariable(Ref(_))) =>
+        rewriteInCopyContext2(dispatch(dp), dp.blame, t, target, context)
+      case ps @ PointerSubscript(
+            HeapLocal(Ref(_)) | DerefHeapVariable(Ref(_)),
+            _,
+          ) =>
+        rewriteInCopyContext2(dispatch(ps), ps.blame, t, target, context)
+      case deref @ Deref(_, Ref(f)) =>
+        // TODO: Improve blame message here
+        copyClassValue2(deref.rewriteDefault(), t, target, f => deref.blame)
+      case dp @ DerefPointer(Local(Ref(_))) =>
+        // This can happen if the user specifies a local of type pointer to TByValueClass
+        rewriteInCopyContext2(dispatch(dp), dp.blame, t, target, context)
+      case _ =>
+        println(e)
+        ???
+    }
+
+  private def rewriteInCopyContext2(
+      e: Expr[Post],
+      blame: Blame[PointerDerefError],
+      t: TByValueClass[Pre],
+      target: Expr[Post],
+      context: CopyContext,
+  ): Statement[Post] = {
     val cls = t.cls.decl.asInstanceOf[ByValueClass[Pre]]
 
-    copyContext.top match {
+    context match {
       case InCall(invocation) =>
-        copyClassValue(
-          dp.rewriteDefault(),
+        copyClassValue2(
+          e,
           t,
-          f => ClassCopyInCallFailed(dp.blame, invocation, cls, f),
+          target,
+          f => ClassCopyInCallFailed(blame, invocation, cls, f),
         )
       case InAssignmentExpression(assignment) =>
-        copyClassValue(
-          dp.rewriteDefault(),
+        copyClassValue2(
+          e,
           t,
-          f => ClassCopyInAssignmentFailed(dp.blame, assignment, cls, f),
+          target,
+          f => ClassCopyInAssignmentFailed(blame, assignment, cls, f),
         )
       case InAssignmentStatement(assignment) =>
-        copyClassValue(
-          dp.rewriteDefault(),
+        copyClassValue2(
+          e,
           t,
-          f => ClassCopyInAssignmentFailed(dp.blame, assignment, cls, f),
+          target,
+          f => ClassCopyInAssignmentFailed(blame, assignment, cls, f),
         )
-      case NoCopy() => dp.rewriteDefault()
     }
   }
 }

--- a/src/rewrite/vct/rewrite/EncodeByValueClassUsage.scala
+++ b/src/rewrite/vct/rewrite/EncodeByValueClassUsage.scala
@@ -82,6 +82,9 @@ case class EncodeByValueClassUsage[Pre <: Generation]() extends Rewriter[Pre] {
 
   private val classCreationMethodsSucc
       : SuccessionMap[TByValueClass[Pre], Procedure[Post]] = SuccessionMap()
+  private val heapLocalArgSucc
+      : SuccessionMap[Variable[Pre], LocalHeapVariable[Post]] = SuccessionMap()
+  private val inContract: ScopedStack[Unit] = ScopedStack()
 
   // Duplicated in LowerHeapVariables, keep in sync
   def makeClassCreationMethod(t: TByValueClass[Pre]): Procedure[Post] = {
@@ -121,7 +124,7 @@ case class EncodeByValueClassUsage[Pre <: Generation]() extends Rewriter[Pre] {
       blame: InstanceField[Pre] => Blame[InsufficientPermission],
   ): Statement[Post] = {
     implicit val o: Origin = obj.o
-    val ov = new Variable[Post](obj.t)(o.where(name = "original"))
+    val ov = new Variable[Post](dispatch(t))(o.where(name = "original"))
     val children = t.cls.decl.decls.collect { case f: InstanceField[Pre] =>
       f.t match {
         case inner: TByValueClass[Pre] =>
@@ -243,7 +246,53 @@ case class EncodeByValueClassUsage[Pre <: Generation]() extends Rewriter[Pre] {
             case _ => dispatch(a)
           }
         })
+      case Local(Ref(v))
+          if inContract.isEmpty && heapLocalArgSucc.contains(v) =>
+        DerefPointer(heapLocalArgSucc(v).get(PanicBlame(
+          "Missing permission to procedure argument of struct type, no suitable blame available"
+        )))(PanicBlame(
+          "Missing permission to dereference procedure argument of struct type, no suitable blame available"
+        ))
       case _ => node.rewriteDefault()
+    }
+  }
+
+  override def dispatch(decl: Declaration[Pre]): Unit = {
+    implicit val o: Origin = decl.o
+    decl match {
+      // TODO: AS: This transformation should be moved to LangCToCol to get proper blames
+      case proc: Procedure[Pre] =>
+        val byValueArgs = proc.args.filter(_.t.asByValueClass.isDefined)
+        globalDeclarations.succeed(
+          proc,
+          proc.rewrite(
+            body = proc.body.map(b =>
+              Scope(
+                Nil,
+                localHeapVariables.scope {
+                  Block(byValueArgs.flatMap { v =>
+                    val newVar =
+                      new LocalHeapVariable(
+                        TNonNullPointer(dispatch(v.t), None)
+                      )
+                    heapLocalArgSucc(v) = newVar
+                    Seq(
+                      HeapLocalDecl(newVar),
+                      Assign(
+                        newVar.get(PanicBlame(
+                          "Should always have access to local variable just after declaration"
+                        )),
+                        Local[Post](succ(v)),
+                      )(AssignLocalOk),
+                    )
+                  } :+ dispatch(b))
+                },
+              )
+            ),
+            contract = inContract.having(()) { dispatch(proc.contract) },
+          ),
+        )
+      case _ => super.dispatch(decl)
     }
   }
 
@@ -309,6 +358,18 @@ case class EncodeByValueClassUsage[Pre <: Generation]() extends Rewriter[Pre] {
         Block(Seq(doCopy(value, target, t, context), dispatch(post)))(e.o)
       case With(pre, value) =>
         Block(Seq(dispatch(pre), doCopy(value, target, t, context)))(e.o)
+      case Local(Ref(v)) if heapLocalArgSucc.contains(v) =>
+        rewriteInCopyContext2(
+          heapLocalArgSucc(v).get(PanicBlame(
+            "Missing permission to procedure argument of struct type, no suitable blame available"
+          ))(e.o),
+          PanicBlame(
+            "Failed to copy struct that originated from a procedure argument, no suitable blame available"
+          ),
+          t,
+          target,
+          context,
+        )
       case _ =>
         println(e)
         ???

--- a/src/rewrite/vct/rewrite/LowerHeapVariables.scala
+++ b/src/rewrite/vct/rewrite/LowerHeapVariables.scala
@@ -2,29 +2,48 @@ package vct.rewrite
 
 import vct.col.rewrite.{Generation, Rewriter, RewriterBuilder}
 import vct.col.ast.{
-  Variable,
-  LocalHeapVariable,
-  HeapVariable,
-  DerefPointer,
-  TNonNullPointer,
-  Program,
-  Expr,
-  Statement,
-  HeapLocal,
-  PointerLocation,
-  HeapVariableLocation,
-  DerefHeapVariable,
+  Assign,
   Block,
-  Scope,
-  Local,
-  Location,
+  DecreasesClauseNoRecursion,
+  Deref,
+  DerefHeapVariable,
+  DerefPointer,
+  Expr,
+  FieldLocation,
+  HeapLocal,
   HeapLocalDecl,
+  HeapVariable,
+  HeapVariableLocation,
+  InstanceField,
+  Local,
+  LocalHeapVariable,
+  Location,
+  Perm,
+  PointerLocation,
+  Procedure,
+  Program,
+  Result,
+  Scope,
+  Statement,
+  TByValueClass,
+  TNonNullPointer,
+  UnitAccountedPredicate,
+  Variable,
+  WritePerm,
 }
-import vct.col.origin.Origin
+import vct.col.origin.{
+  AbstractApplicable,
+  AssignLocalOk,
+  NonNullPointerNull,
+  Origin,
+  PanicBlame,
+  TrueSatisfiable,
+}
 import vct.col.util.AstBuildHelpers._
 import vct.col.ref.Ref
 import vct.col.util.{CurrentRewriteProgramContext, SuccessionMap}
 import vct.result.VerificationError
+import vct.rewrite.EncodeByValueClassUsage.UnsupportedStructPerm
 
 case object LowerHeapVariables extends RewriterBuilder {
   override def key: String = "lowerHeapVariables"
@@ -42,6 +61,81 @@ case class LowerHeapVariables[Pre <: Generation]() extends Rewriter[Pre] {
       : SuccessionMap[HeapVariable[Pre], HeapVariable[Post]] = SuccessionMap()
   private val globalLowered
       : SuccessionMap[HeapVariable[Pre], HeapVariable[Post]] = SuccessionMap()
+  private val classCreationMethodsSucc
+      : SuccessionMap[TByValueClass[Pre], Procedure[Post]] = SuccessionMap()
+  private val classPointerCreationMethodsSucc
+      : SuccessionMap[(TByValueClass[Pre], Option[BigInt]), Procedure[Post]] =
+    SuccessionMap()
+
+  // Duplicate from EncodeByValueClassUsage, keep in sync
+  def makeClassCreationMethod(t: TByValueClass[Pre]): Procedure[Post] = {
+    implicit val o: Origin = t.cls.decl.o
+
+    globalDeclarations.declare(withResult((result: Result[Post]) =>
+      procedure[Post](
+        blame = AbstractApplicable,
+        contractBlame = TrueSatisfiable,
+        returnType = dispatch(t),
+        ensures = UnitAccountedPredicate(
+          unwrapClassPerm(result, Perm(_, WritePerm()), t)
+        ),
+        decreases = Some(DecreasesClauseNoRecursion[Post]()),
+      )
+    ))
+  }
+
+  def makeClassPointerCreationMethod(
+      t: TByValueClass[Pre],
+      unique: Option[BigInt],
+  ): Procedure[Post] = {
+    implicit val o: Origin = t.cls.decl.o
+
+    globalDeclarations.declare(withResult((result: Result[Post]) =>
+      procedure[Post](
+        blame = AbstractApplicable,
+        contractBlame = TrueSatisfiable,
+        returnType = TNonNullPointer(dispatch(t), unique),
+        ensures = UnitAccountedPredicate(unwrapClassPerm(
+          DerefPointer(result)(NonNullPointerNull),
+          Perm(_, WritePerm()),
+          t,
+        )),
+        decreases = Some(DecreasesClauseNoRecursion[Post]()),
+      )
+    ))
+  }
+
+  private def unwrapClassPerm(
+      obj: Expr[Post],
+      perm: Location[Post] => Expr[Post],
+      structType: TByValueClass[Pre],
+      visited: Seq[TByValueClass[Pre]] = Seq(),
+  ): Expr[Post] = {
+    if (visited.contains(structType))
+      throw UnsupportedStructPerm(
+        obj.o
+      ) // We do not allow this notation for recursive structs
+    implicit val o: Origin = obj.o
+    val blame = PanicBlame("Field permission is framed")
+    val fields = structType.cls.decl.decls.collect {
+      case f: InstanceField[Pre] => f
+    }
+    val newFieldPerms = fields.map(member => {
+      val loc = FieldLocation[Post](obj, succ(member))
+      member.t match {
+        case inner: TByValueClass[Pre] =>
+          unwrapClassPerm(
+            Deref[Post](obj, succ(member))(blame),
+            perm,
+            inner,
+            structType +: visited,
+          )
+        case _ => perm(loc)
+      }
+    })
+
+    foldStar(newFieldPerms)
+  }
 
   override def dispatch(program: Program[Pre]): Program[Post] = {
     val dereferencedHeapLocals = program.collect {
@@ -117,7 +211,31 @@ case class LowerHeapVariables[Pre <: Generation]() extends Rewriter[Pre] {
           localLowered(v) = new Variable[Post](dispatch(v.t))(v.o)
           variables.declare(localLowered(v))
         }
-        Block(Nil)
+        if (v.t.asPointer.get.element.asByValueClass.isDefined) {
+          val t = v.t.asPointer.get.element.asByValueClass.get
+          if (localStripped.contains(v)) {
+            Assign(
+              localStripped(v).get,
+              procedureInvocation[Post](
+                TrueSatisfiable,
+                classCreationMethodsSucc
+                  .getOrElseUpdate(t, makeClassCreationMethod(t)).ref,
+              ),
+            )(AssignLocalOk)
+          } else {
+            val unique = v.t.asPointer.get.unique
+            Assign(
+              localLowered(v).get,
+              procedureInvocation[Post](
+                TrueSatisfiable,
+                classPointerCreationMethodsSucc.getOrElseUpdate(
+                  (t, unique),
+                  makeClassPointerCreationMethod(t, unique),
+                ).ref,
+              ),
+            )(AssignLocalOk)
+          }
+        } else { Block(Nil) }
       case _ => node.rewriteDefault()
     }
   }

--- a/src/rewrite/vct/rewrite/PinSilverNodes.scala
+++ b/src/rewrite/vct/rewrite/PinSilverNodes.scala
@@ -29,7 +29,9 @@ case class PinSilverNodes[Pre <: Generation]() extends Rewriter[Pre] {
               dispatch(value),
             )(assn.blame)(stat.o)
           case other =>
-            throw Unreachable("Invalid assignment target (check missing?)")
+            throw Unreachable(
+              s"Invalid assignment target (check missing?): $other"
+            )
         }
       case other => rewriteDefault(other)
     }

--- a/src/rewrite/vct/rewrite/ResolveScale.scala
+++ b/src/rewrite/vct/rewrite/ResolveScale.scala
@@ -94,6 +94,13 @@ case class ResolveScale[Pre <: Generation]() extends Rewriter[Pre] {
       case l: Let[Pre] => l.rewrite(main = scale(l.main, amount))
       case InlinePattern(inner, parent, group) =>
         InlinePattern(scale(inner, amount), parent, group)
+      case a @ Asserting(condition, body) =>
+        a.rewrite(
+          condition = scale(condition, amount),
+          body = scale(body, amount),
+        )
+      case a @ Assuming(assn, inner) =>
+        a.rewrite(assn = scale(assn, amount), inner = scale(inner, amount))
       case other => throw WrongScale(other)
     }
   }

--- a/src/rewrite/vct/rewrite/adt/ImportPointer.scala
+++ b/src/rewrite/vct/rewrite/adt/ImportPointer.scala
@@ -5,7 +5,7 @@ import ImportADT.typeText
 import hre.util.ScopedStack
 import vct.col.origin._
 import vct.col.ref.Ref
-import vct.col.rewrite.Generation
+import vct.col.rewrite.{ClassToRef, Generation}
 import vct.col.util.AstBuildHelpers.{functionInvocation, _}
 import vct.col.util.SuccessionMap
 
@@ -23,7 +23,11 @@ case object ImportPointer extends ImportADTBuilder("pointer") {
   )
 
   private val AsTypeOrigin: Origin = Origin(
-    Seq(LabelContext("classToRef, asType function"))
+    Seq(LabelContext("adtPointer, asType function"))
+  )
+
+  private val PointerToAdtOrigin: Origin = Origin(
+    Seq(LabelContext("adtPointer, pointerToAdt function"))
   )
 
   private case class PointerNullOptNone(
@@ -110,6 +114,9 @@ case class ImportPointer[Pre <: Generation](importer: ImportADTImporter)
 
   private val asTypeFunctions: mutable.Map[Type[Pre], Function[Post]] = mutable
     .Map()
+  private val toAdtFunctions
+      : mutable.Map[(AxiomaticDataType[Pre], Seq[Type[Pre]]), Function[Post]] =
+    mutable.Map()
   private val context: ScopedStack[Context] = ScopedStack()
   private var casts: Set[(Type[Pre], Type[Pre])] = Set.empty
 
@@ -144,26 +151,29 @@ case class ImportPointer[Pre <: Generation](importer: ImportADTImporter)
 
     val result =
       new Variable[Post](TAxiomatic(pointerAdt.ref, Nil))(o.where(name = "res"))
-    globalDeclarations.declare(procedure[Post](
-      blame = AbstractApplicable,
-      contractBlame = TrueSatisfiable,
-      returnType = TVoid(),
-      outArgs = Seq(result),
-      ensures = UnitAccountedPredicate(
+    var ensures =
+      (ADTFunctionInvocation[Post](
+        typeArgs = Some((blockAdt.ref, Nil)),
+        ref = blockLength.ref,
+        args = Seq(ADTFunctionInvocation[Post](
+          typeArgs = Some((pointerAdt.ref, Nil)),
+          ref = pointerBlock.ref,
+          args = Seq(result.get),
+        )),
+      ) === const(1)) &*
         (ADTFunctionInvocation[Post](
-          typeArgs = Some((blockAdt.ref, Nil)),
-          ref = blockLength.ref,
-          args = Seq(ADTFunctionInvocation[Post](
-            typeArgs = Some((pointerAdt.ref, Nil)),
-            ref = pointerBlock.ref,
-            args = Seq(result.get),
-          )),
-        ) === const(1)) &*
-          (ADTFunctionInvocation[Post](
-            typeArgs = Some((pointerAdt.ref, Nil)),
-            ref = pointerOffset.ref,
-            args = Seq(result.get),
-          ) === const(0)) &* Perm(
+          typeArgs = Some((pointerAdt.ref, Nil)),
+          ref = pointerOffset.ref,
+          args = Seq(result.get),
+        ) === const(0))
+    pointerT.element match {
+      // TODO: Using a label to keep track of this information is quite ugly and I should replace it with something better
+      case TAxiomatic(adt, _)
+          if adt.decl.o.find[LabelContext]
+            .exists(_.label == ClassToRef.ByValueClassADTLabel) =>
+      case _ =>
+        ensures =
+          ensures &* Perm(
             SilverFieldLocation(
               obj =
                 FunctionInvocation[Post](
@@ -183,7 +193,15 @@ case class ImportPointer[Pre <: Generation](importer: ImportADTImporter)
                 ).ref,
             ),
             WritePerm(),
-          ) &* (asType(t, result.get) === result.get)
+          )
+    }
+    globalDeclarations.declare(procedure[Post](
+      blame = AbstractApplicable,
+      contractBlame = TrueSatisfiable,
+      returnType = TVoid(),
+      outArgs = Seq(result),
+      ensures = UnitAccountedPredicate(
+        ensures &* (asType(t, result.get) === result.get)
       ),
       decreases = Some(DecreasesClauseNoRecursion[Post]()),
     ))
@@ -424,11 +442,13 @@ case class ImportPointer[Pre <: Generation](importer: ImportADTImporter)
   override def postCoerce(e: Expr[Pre]): Expr[Post] = {
     implicit val o: Origin = e.o
     e match {
-      case f @ Forall(_, triggers, _) if !f.o.find[LabelContext].exists(_.label == "generated quantifier")=>
+      case f @ Forall(_, triggers, _)
+          if !f.o.find[LabelContext]
+            .exists(_.label == "generated quantifier") =>
         f.rewrite(triggers =
           triggers.map(_.map(rewriteTopLevelPointerSubscriptInTrigger))
         )
-      case s @ Starall(_, triggers, _)  =>
+      case s @ Starall(_, triggers, _) =>
         s.rewrite(triggers =
           triggers.map(_.map(rewriteTopLevelPointerSubscriptInTrigger))
         )
@@ -622,6 +642,46 @@ case class ImportPointer[Pre <: Generation](importer: ImportADTImporter)
         adtFunctionInvocation[Post](
           ref = pointerAddress.ref,
           args = Seq(unwrapOption(p, addr.blame), dispatch(elementSize)),
+        )
+      case to @ PointerToAdt(p, TAxiomatic(Ref(adt), args)) =>
+        functionInvocation(
+          TrueSatisfiable,
+          ref =
+            toAdtFunctions.getOrElseUpdate(
+              (adt, args), {
+                globalDeclarations.declare(
+                  function[Post](
+                    AbstractApplicable,
+                    TrueSatisfiable,
+                    TAxiomatic(succ(adt), args.map(dispatch)),
+                    Seq(new Variable[Post](TAxiomatic(pointerAdt.ref, Nil))(
+                      PointerToAdtOrigin.where(name = "p")
+                    )),
+                  )(PointerToAdtOrigin.where(name =
+                    "ptr_to_" + adt.o.find[SourceName].map(_.name)
+                      .getOrElse("unknown")
+                  ))
+                )
+              },
+            ).ref,
+          args = Seq(p match {
+            case PointerAdd(_, _) => unwrapOption(p, to.blame)
+            case _
+                if context.topOption.contains(InAxiom()) ||
+                  p.o.find[LabelContext]
+                    .exists(_.label == "classToRef cast helpers") =>
+              unwrapOption(p, to.blame)
+            case _ =>
+              FunctionInvocation[Post](
+                ref = pointerAdd.ref,
+                args = Seq(unwrapOption(p, to.blame), const(0)),
+                typeArgs = Nil,
+                Nil,
+                Nil,
+              )(PanicBlame(
+                "Pointer out of bounds, but this should not be possible since index equals 0"
+              ))
+          }),
         )
       case other => super.postCoerce(other)
     }

--- a/src/rewrite/vct/rewrite/adt/ImportPointer.scala
+++ b/src/rewrite/vct/rewrite/adt/ImportPointer.scala
@@ -544,7 +544,8 @@ case class ImportPointer[Pre <: Generation](importer: ImportADTImporter)
         val newValue = dispatch(value)
         (targetType, value.t) match {
           case (target: PointerType[Pre], value: PointerType[Pre])
-              if target.unique != value.unique =>
+              if target.unique != value.unique &&
+                target.element == value.element =>
             // Should not occur
             ???
           case (TPointer(innerType, _), TPointer(_, _)) =>

--- a/src/rewrite/vct/rewrite/adt/ImportPointer.scala
+++ b/src/rewrite/vct/rewrite/adt/ImportPointer.scala
@@ -424,11 +424,11 @@ case class ImportPointer[Pre <: Generation](importer: ImportADTImporter)
   override def postCoerce(e: Expr[Pre]): Expr[Post] = {
     implicit val o: Origin = e.o
     e match {
-      case f @ Forall(_, triggers, _) =>
+      case f @ Forall(_, triggers, _) if !f.o.find[LabelContext].exists(_.label == "generated quantifier")=>
         f.rewrite(triggers =
           triggers.map(_.map(rewriteTopLevelPointerSubscriptInTrigger))
         )
-      case s @ Starall(_, triggers, _) =>
+      case s @ Starall(_, triggers, _)  =>
         s.rewrite(triggers =
           triggers.map(_.map(rewriteTopLevelPointerSubscriptInTrigger))
         )

--- a/src/rewrite/vct/rewrite/exc/EncodeBreakReturn.scala
+++ b/src/rewrite/vct/rewrite/exc/EncodeBreakReturn.scala
@@ -127,7 +127,7 @@ case class EncodeBreakReturn[Pre <: Generation]() extends Rewriter[Pre] {
               )
             case LLVMLoopContract(_) => throw ExtraNode
           }
-        case None => super.dispatch(contract)
+        case _ => super.dispatch(contract)
       }
     }
   }

--- a/src/rewrite/vct/rewrite/exc/EncodeBreakReturn.scala
+++ b/src/rewrite/vct/rewrite/exc/EncodeBreakReturn.scala
@@ -1,18 +1,20 @@
 package vct.col.rewrite.exc
 
 import vct.col.ast._
-import RewriteHelpers._
-import hre.util.ScopedStack
-import vct.col.rewrite.error.ExcludedByPassOrder
-import vct.col.origin.{LabelContext, Origin, PanicBlame, PreferredName}
-import vct.col.ref.{LazyRef, Ref}
+import vct.col.rewrite.error.{ExcludedByPassOrder, ExtraNode}
+import vct.col.origin.{
+  AssignLocalOk,
+  LabelContext,
+  Origin,
+  PanicBlame,
+  PreferredName,
+}
+import vct.col.ref.Ref
 import vct.col.util.AstBuildHelpers._
-import vct.col.rewrite.{Generation, Rewriter, RewriterBuilder, Rewritten}
+import vct.col.rewrite.{Generation, Rewriter, RewriterBuilder}
 import vct.col.util.SuccessionMap
 
 import scala.collection.mutable
-import scala.collection.mutable.ArrayBuffer
-import scala.reflect.ClassTag
 
 case object EncodeBreakReturn extends RewriterBuilder {
   override def key: String = "breakReturn"
@@ -50,15 +52,15 @@ case class EncodeBreakReturn[Pre <: Generation]() extends Rewriter[Pre] {
 
   def needReturn(method: AbstractMethod[Pre]): Boolean =
     method match {
-      case procedure: Procedure[Pre] => true
-      case constructor: Constructor[Pre] => false
-      case method: InstanceMethod[Pre] => true
-      case method: InstanceOperatorMethod[Pre] => true
+      case _: Procedure[Pre] => true
+      case _: Constructor[Pre] => false
+      case _: InstanceMethod[Pre] => true
+      case _: InstanceOperatorMethod[Pre] => true
     }
 
   case class BreakReturnToGoto(
       returnTarget: Option[LabelDecl[Post]],
-      resultVariable: Option[Local[Post]],
+      resultVariable: Option[Expr[Post]],
   ) extends Rewriter[Pre] {
     val breakLabels: mutable.Set[LabelDecl[Pre]] = mutable.Set()
     val postLabeledStatement: SuccessionMap[LabelDecl[Pre], LabelDecl[Post]] =
@@ -97,11 +99,35 @@ case class EncodeBreakReturn[Pre <: Generation]() extends Rewriter[Pre] {
 
         case Return(result) =>
           Block(Seq(
-            assignLocal(resultVariable.get, dispatch(result)),
+            Assign(resultVariable.get, dispatch(result))(AssignLocalOk),
             Goto(returnTarget.get.ref),
           ))
 
-        case other => rewriteDefault(other)
+        case other => super.dispatch(other)
+      }
+    }
+
+    override def dispatch(contract: LoopContract[Pre]): LoopContract[Post] = {
+      implicit val o: Origin = contract.o
+      resultVariable match {
+        case Some(dp @ DerefPointer(HeapLocal(_))) =>
+          val perm = Perm(
+            ByValueClassLocation(dp)(PanicBlame(
+              "Lost permission to return variable"
+            )),
+            WritePerm(),
+          )
+          contract match {
+            case inv @ LoopInvariant(invariant, _) =>
+              inv.rewrite(invariant = dispatch(invariant) &* perm)
+            case it @ IterationContract(requires, ensures, _) =>
+              it.rewrite(
+                requires = dispatch(requires) &* perm,
+                ensures = dispatch(ensures) &* perm,
+              )
+            case LLVMLoopContract(_) => throw ExtraNode
+          }
+        case None => super.dispatch(contract)
       }
     }
   }
@@ -176,7 +202,7 @@ case class EncodeBreakReturn[Pre <: Generation]() extends Rewriter[Pre] {
             )),
           )
 
-        case other => rewriteDefault(other)
+        case other => super.dispatch(other)
       }
     }
   }
@@ -185,7 +211,7 @@ case class EncodeBreakReturn[Pre <: Generation]() extends Rewriter[Pre] {
     decl match {
       case method: AbstractMethod[Pre] =>
         method.body match {
-          case None => rewriteDefault(method)
+          case None => super.dispatch(method)
           case Some(body) =>
             allScopes.anyDeclare(allScopes.anySucceedOnly(
               method,
@@ -231,26 +257,53 @@ case class EncodeBreakReturn[Pre <: Generation]() extends Rewriter[Pre] {
 
                   if (needReturn(method)) {
                     val resultTarget = new LabelDecl[Post]()(ReturnTarget)
-                    val resultVar =
-                      new Variable(dispatch(method.returnType))(ReturnVariable)
-                    val newBody = BreakReturnToGoto(
-                      Some(resultTarget),
-                      Some(resultVar.get(ReturnVariable)),
-                    ).dispatch(body)
 
-                    Scope(
-                      Seq(resultVar),
-                      Block(Seq(
-                        newBody,
-                        Label(resultTarget, Block(Nil)),
-                        Return(resultVar.get),
-                      )),
-                    )
+                    if (method.returnType.asByValueClass.isDefined) {
+                      val v =
+                        new LocalHeapVariable(
+                          TNonNullPointer(dispatch(method.returnType), None)
+                        )(ReturnVariable)
+                      val getter =
+                        v.get(PanicBlame("Missing access to return variable"))(
+                          ReturnVariable
+                        )
+                      val newBody = BreakReturnToGoto(
+                        Some(resultTarget),
+                        Some(getter),
+                      ).dispatch(body)
+                      Scope(
+                        Nil,
+                        Block(Seq(
+                          HeapLocalDecl(v),
+                          newBody,
+                          Label(resultTarget, Block(Nil)),
+                          Return(getter),
+                        )),
+                      )
+                    } else {
+                      val v =
+                        new Variable(dispatch(method.returnType))(
+                          ReturnVariable
+                        )
+                      val getter = v.get(ReturnVariable)
+                      val newBody = BreakReturnToGoto(
+                        Some(resultTarget),
+                        Some(getter),
+                      ).dispatch(body)
+                      Scope(
+                        Seq(v),
+                        Block(Seq(
+                          newBody,
+                          Label(resultTarget, Block(Nil)),
+                          Return(getter),
+                        )),
+                      )
+                    }
                   } else { BreakReturnToGoto(None, None).dispatch(body) }
                 }
               })),
             ))
         }
-      case other => rewriteDefault(other)
+      case other => super.dispatch(other)
     }
 }

--- a/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
@@ -599,9 +599,6 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
         implicit val o: Origin = pallasResArgPermOrigin
         c.rewrite(contextEverywhere =
           (Local(arg) !== Null()) &* Perm(
-            AmbiguousLocation(Local(arg))(LLVMSretPerm),
-            WritePerm[Post](),
-          ) &* Perm(
             AmbiguousLocation(DerefPointer(Local(arg))(LLVMSretPerm))(
               LLVMSretPerm
             ),

--- a/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
@@ -1271,28 +1271,12 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
     val newT = rw.dispatch(t)
     val v = Local[Post](rw.succ(alloc.variable.decl))
     val elements = rw.dispatch(alloc.numElements)
-    t match {
-      case structType: LLVMTStruct[Pre] =>
-        Block(Seq(
-          assignLocal(
-            v,
-            NewNonNullPointerArray[Post](newT, elements, None)(PanicBlame(
-              "allocation should never fail"
-            )),
-          ),
-          Assign(
-            DerefPointer(v)(PanicBlame("pointer is framed in allocation")),
-            NewObject[Post](structMap.ref(structType)),
-          )(PanicBlame("assignment should never fail")),
-        ))
-      case _ =>
-        assignLocal(
-          v,
-          NewNonNullPointerArray[Post](newT, elements, None)(PanicBlame(
-            "allocation should never fail"
-          )),
-        )
-    }
+    assignLocal(
+      v,
+      NewNonNullPointerArray[Post](newT, elements, None)(PanicBlame(
+        "allocation should never fail"
+      )),
+    )
   }
 
   def rewriteMemset(memset: LLVMMemset[Pre]): Statement[Post] = {

--- a/src/viper/viper/api/transform/ColToSilver.scala
+++ b/src/viper/viper/api/transform/ColToSilver.scala
@@ -503,14 +503,14 @@ case class ColToSilver(program: col.Program[_]) {
             pos = pos(res),
             info = expInfo(res),
           ),
-          permValue,
+          Some(permValue),
         )(pos = pos(res), info = expInfo(res))
 
       case res @ col
             .Perm(col.PredicateLocation(app: col.PredicateApply[_]), perm) =>
         silver.PredicateAccessPredicate(
           pred(app, info = Some(expInfo(res))),
-          exp(perm),
+          Some(exp(perm)),
         )(pos = pos(res), info = expInfo(res))
 
       case col.Wand(left, right) =>
@@ -541,7 +541,7 @@ case class ColToSilver(program: col.Program[_]) {
                 pos = pos(loc),
                 info = expInfo(e),
               ),
-              silver.WildcardPerm()(),
+              Some(silver.WildcardPerm()()),
             )(pos = pos(e), info = expInfo(e))
           case col
                 .PredicateLocation(col.PredicateApply(Ref(predicate), args)) =>
@@ -550,7 +550,7 @@ case class ColToSilver(program: col.Program[_]) {
                 pos = pos(loc),
                 info = expInfo(e),
               ),
-              silver.WildcardPerm()(),
+              Some(silver.WildcardPerm()()),
             )(pos = pos(e), expInfo(e))
           case default => ??(default)
         }
@@ -741,14 +741,14 @@ case class ColToSilver(program: col.Program[_]) {
   def fold(f: col.FoldTarget[_]): silver.PredicateAccessPredicate =
     f match {
       case col.ScaledPredicateApply(inv: col.PredicateApply[_], perm) =>
-        silver.PredicateAccessPredicate(pred(inv, Some(expInfo(f))), exp(perm))(
+        silver.PredicateAccessPredicate(pred(inv, Some(expInfo(f))), Some(exp(perm)))(
           pos = pos(f),
           info = expInfo(f),
         )
       case col.ValuePredicateApply(inv: col.PredicateApply[_]) =>
         silver.PredicateAccessPredicate(
           pred(inv, Some(expInfo(f))),
-          silver.WildcardPerm()(pos = pos(f), info = expInfo(f)),
+          Some(silver.WildcardPerm()(pos = pos(f), info = expInfo(f))),
         )(pos = pos(f), info = expInfo(f))
       case other => ??(other)
     }

--- a/src/viper/viper/api/transform/SilverToCol.scala
+++ b/src/viper/viper/api/transform/SilverToCol.scala
@@ -448,7 +448,7 @@ case class SilverToCol[G](
             f(loc.rcv),
             new UnresolvedRef(loc.field.name),
           ),
-          f(perm),
+          f(perm.getOrElse(silver.FullPerm()())),
         )
       case silver.Forall(variables, triggers, exp) =>
         if (exp.isPure)
@@ -520,7 +520,7 @@ case class SilverToCol[G](
             perm,
           ) =>
         col.Scale[G](
-          f(perm),
+          f(perm.getOrElse(silver.FullPerm()())),
           col.PredicateApplyExpr(
             col.PredicateApply(new UnresolvedRef(predicateName), args.map(f))
           ),

--- a/test/main/vct/test/integration/examples/CSpec.scala
+++ b/test/main/vct/test/integration/examples/CSpec.scala
@@ -22,7 +22,7 @@ class CSpec extends VercorsSpec {
     int x = 4.0 % 1;
   }
   """
-  vercors should fail withCode "ptrPerm" using silicon in "cannot access field of struct after freeing" c
+  vercors should fail withCode "assignFieldFailed" using silicon in "cannot access field of struct after freeing" c
     """
     #include <stdlib.h>
 
@@ -118,7 +118,7 @@ class CSpec extends VercorsSpec {
     }
     """
 
-  vercors should fail withCode "ptrPerm" using silicon in "Deref field of zero perm ptr" c
+  vercors should fail withCode "assignFieldFailed" using silicon in "Deref field of zero perm ptr" c
     """
     struct d{
       int x;
@@ -126,7 +126,7 @@ class CSpec extends VercorsSpec {
     int main(){
       struct d s1;
       struct d* s2 = &s1;
-      //@ exhale Perm(s2, 1\1);
+      //@ exhale Perm(s2->x, 1\1);
       s2->x = 1;
     }
     """

--- a/test/main/vct/test/integration/examples/CSpec.scala
+++ b/test/main/vct/test/integration/examples/CSpec.scala
@@ -712,4 +712,46 @@ void test(int* xs, int nx, int ny){
   }
 }
   """
+  vercors should verify using silicon in "Struct from pointer subscript passed by value" c
+  """
+#include <assert.h>
+
+struct s {int x; int y;};
+
+/*@
+ requires Perm(v, write);
+ //ensures v.x == \old(v.x);
+ ensures Perm(\result, write);
+ ensures \result.x == x;
+*/
+struct s set_x(struct s v, int x) {
+  v.x = x;
+  return v;
 }
+
+/*@
+ requires p != NULL ** \pointer_length(p) == 1 ** Perm(&p->x, read);
+ ensures \result == p->x;
+*/
+/*@ pure */int get_x(struct s *p) {
+    return p->x;
+}
+
+void main(){
+    struct s p[1];
+    p[0].x = 5;
+    p[0].y = 10;
+    int x = get_x(p);
+    // Gets the correct value
+    assert(x == 5);
+    struct s v2 = set_x(p[0], 3);
+    // Since p[0] is passed by value, it is not changed
+    //@ assert(p[0].x == 5);
+    assert(p[0].x == 5);
+    assert(p[0].y == 10);
+    // But the returned valued is changed
+    assert(v2.x == 3 && p[0].y == 10);
+}
+  """
+}
+

--- a/test/main/vct/test/integration/examples/QualifierSpec.scala
+++ b/test/main/vct/test/integration/examples/QualifierSpec.scala
@@ -150,7 +150,7 @@ class StructQualifierSpec extends VercorsSpec {
 
   /*@
     context xs != NULL && xs2 != NULL;
-    requires x1 != NULL ** \pointer_length(x1)==1 ** Perm(x1, write) ** Perm(*x1, write);
+    requires x1 != NULL ** \pointer_length(x1)==1 ** Perm(*x1, write);
     context Perm(v, write) ** v.xxs != NULL;
   @*/
 
@@ -177,7 +177,7 @@ class StructQualifierSpec extends VercorsSpec {
 
   /*@
     context xs != NULL;
-    context x1 != NULL ** \pointer_length(x1)==1 ** Perm(x1, write) ** Perm(*x1, write);
+    context x1 != NULL ** \pointer_length(x1)==1 ** Perm(*x1, write);
   @*/
   int f(/*@unique_pointer_field<xs, 2>@*/ struct vec*  x1, /*@ unique<2> @*/ int* xs){
     x1->xs = xs;
@@ -214,7 +214,7 @@ class StructQualifierSpec extends VercorsSpec {
 
   /*@
     context xs != NULL;
-    context x1 != NULL ** \pointer_length(x1)==1 ** Perm(x1, write) ** Perm(*x1, write);
+    context x1 != NULL ** \pointer_length(x1)==1 ** Perm(*x1, write);
   @*/
   int f(/*@unique_pointer_field<xs, 2>@*/ struct vec*  x1, /*@ unique<2> @*/ int* xs){
     x1->xs = xs;
@@ -259,7 +259,7 @@ class StructQualifierSpec extends VercorsSpec {
 
   /*@
     context xs1 != NULL && ys1 != NULL;
-    context v != NULL ** \pointer_length(v)==1 ** Perm(v, write) ** Perm(*v, write);
+    context v != NULL ** \pointer_length(v)==1 ** Perm(*v, write);
   @*/
   int f(/*@unique_pointer_field<ys, 1>@*/ /*@unique_pointer_field<xs, 2>@*/ struct vec*  v,
     /*@ unique<2> @*/ int* xs1,
@@ -347,7 +347,7 @@ class StructQualifierSpec extends VercorsSpec {
   };
 
   /*@
-    context v != NULL ** \pointer_length(v)==1 ** Perm(v, 1\100) ** Perm(&v->xs, 1\100);
+    context v != NULL ** \pointer_length(v)==1 ** Perm(&v->xs, 1\100);
     ensures \result == v->xs;
   @*/
   /*@unique<1>@*/ int* get_xs(/*@unique_pointer_field<xs, 1>@*/ struct vec* v){
@@ -355,7 +355,7 @@ class StructQualifierSpec extends VercorsSpec {
    }
 
   /*@
-    context v != NULL ** \pointer_length(v)==1 ** Perm(v, write) ** Perm(*v, write);
+    context v != NULL ** \pointer_length(v)==1 ** Perm(*v, write);
     context v->xs != NULL;
   @*/
   int f(/*@unique_pointer_field<xs, 2>@*/ struct vec*  v){
@@ -909,7 +909,7 @@ struct vec {
   /*@
     given int* ys;
     yields int* res;
-    context v != NULL ** \pointer_length(v)==1 ** Perm(v, 1\100) ** Perm(&v->xs, 1\100);
+    context v != NULL ** \pointer_length(v)==1 ** Perm(&v->xs, 1\100);
     ensures v->xs  == \result;
   @*/
   int* get_xs(struct vec* v){
@@ -917,7 +917,7 @@ struct vec {
    }
 
   /*@
-    context v != NULL ** \pointer_length(v)==1 ** Perm(v, write) ** Perm(*v, write);
+    context v != NULL ** \pointer_length(v)==1 ** Perm(*v, write);
     context v->xs != NULL;
   @*/
   int f(/*@unique_pointer_field<xs, 1>@*/ struct vec*  v, /*@unique<1>@*/ int* ys){
@@ -1011,7 +1011,7 @@ struct vec {
     /*@ unique<1> */int * /*@ unique<2> */ xs;
 };
 
-//@ requires v != NULL ** Value(v) ** Value(*v);
+//@ requires v != NULL ** Value(*v);
 int f(struct vec*  v){
     /*@ unique<1> @*/ int* xs2 = v->xs;
     /*@ unique<1> */int * /*@ unique<2>*/ *xs3 = &v->xs;
@@ -1082,7 +1082,6 @@ struct dim {
 };
 /*@
 inline resource dim_perm(struct dim *dim, rational p, int i) =
- Perm(&dim[i], 1\2) **
  Perm(dim[i].min, 1\2) **
  Perm(dim[i].stride, 1\2) **
  Perm(dim[i].extent, 1\2) **

--- a/test/main/vct/test/integration/examples/QualifierSpec.scala
+++ b/test/main/vct/test/integration/examples/QualifierSpec.scala
@@ -279,7 +279,7 @@ class StructQualifierSpec extends VercorsSpec {
 
   /*@
     context xs1 != NULL && ys1 != NULL;
-    context v != NULL ** \pointer_length(v)==1 ** Perm(v, write) ** Perm(*v, write);
+    context v != NULL ** \pointer_length(v)==1 ** Perm(*v, write);
   @*/
   int f(/*@unique_pointer_field<xs, 1>@*/ /*@unique_pointer_field<xs, 2>@*/ struct vec*  v,
     /*@ unique<2> @*/ int* xs1,
@@ -298,7 +298,7 @@ class StructQualifierSpec extends VercorsSpec {
   };
 
   /*@
-    context v != NULL ** \pointer_length(v)==1 ** Perm(v, 1\100) ** Perm(&v->xs, 1\100);
+    context v != NULL ** \pointer_length(v)==1 ** Perm(&v->xs, 1\100);
     ensures \result == v->xs;
   @*/
   /*@ unique<1> @*/ int* get_xs(/*@unique_pointer_field<xs, 1>@*/ struct vec* v){
@@ -306,7 +306,7 @@ class StructQualifierSpec extends VercorsSpec {
    }
 
   /*@
-    context v != NULL ** \pointer_length(v)==1 ** Perm(v, write) ** Perm(*v, write);
+    context v != NULL ** \pointer_length(v)==1 ** Perm(*v, write);
     context v->xs != NULL;
   @*/
   int f(/*@unique_pointer_field<xs, 2>@*/ struct vec*  v){
@@ -322,7 +322,7 @@ class StructQualifierSpec extends VercorsSpec {
   };
 
   /*@
-    context v != NULL ** \pointer_length(v)==1 ** Perm(v, 1\100) ** Perm(&v->xs, 1\100);
+    context v != NULL ** \pointer_length(v)==1 ** Perm(&v->xs, 1\100);
     ensures \result == v->xs;
   @*/
   int* get_xs(struct vec* v){
@@ -330,7 +330,7 @@ class StructQualifierSpec extends VercorsSpec {
    }
 
   /*@
-    context v != NULL ** \pointer_length(v)==1 ** Perm(v, write) ** Perm(*v, write);
+    context v != NULL ** \pointer_length(v)==1 ** Perm(*v, write);
     context v->xs != NULL;
   @*/
   int f(/*@unique_pointer_field<xs, 2>@*/ struct vec*  v){
@@ -371,7 +371,7 @@ struct vec {
   };
 
   /*@
-    context v != NULL ** \pointer_length(v)==1 ** Perm(v, 1\100) ** Perm(&v->xs, 1\100);
+    context v != NULL ** \pointer_length(v)==1 ** Perm(&v->xs, 1\100);
     ensures v->xs  == \result;
   @*/
   int* get_xs(struct vec* v){
@@ -380,7 +380,7 @@ struct vec {
 
   /*@
   ghost
-    context v != NULL ** \pointer_length(v)==1 ** Perm(v, 1\100) ** Perm(v->xs, 1\100) ** v->xs != NULL;
+    context v != NULL ** \pointer_length(v)==1 ** Perm(v->xs, 1\100) ** v->xs != NULL;
     context 1 \in m.keys && m[1].size >0 ==> m[1][0].fst != NULL;
     ensures \result != NULL;
   int* get_xs2(struct vec* v, map<int, seq<tuple<int*, void*> > > m){
@@ -395,7 +395,7 @@ struct vec {
   /*@
     given map<int, seq<tuple<int*, void*> > > m;
     context 1 \in m.keys && m[1].size >0 ==> m[1][0].fst != NULL;
-    context v != NULL ** \pointer_length(v)==1 ** Perm(v, write) ** Perm(*v, write);
+    context v != NULL ** \pointer_length(v)==1 ** Perm(*v, write);
     context v->xs != NULL;
   @*/
   int f(/*@unique_pointer_field<xs, 1>@*/ struct vec*  v){
@@ -412,7 +412,7 @@ struct vec {
   };
 
   /*@
-    context v != NULL ** \pointer_length(v)==1 ** Perm(v, 1\100) ** Perm(&v->xs, 1\100) ** Perm(&v->n, 1\100);
+    context v != NULL ** \pointer_length(v)==1 ** Perm(&v->xs, 1\100) ** Perm(&v->n, 1\100);
     ensures \result == &(v->n);
   @*/
   int* get_xs(struct vec* v){
@@ -420,7 +420,7 @@ struct vec {
    }
 
   /*@
-    context v != NULL ** \pointer_length(v)==1 ** Perm(v, write) ** Perm(*v, write);
+    context v != NULL ** \pointer_length(v)==1 ** Perm(*v, write);
     context v->xs != NULL;
     context v->n == 42;
   @*/
@@ -812,7 +812,7 @@ struct vec {
   };
 
   /*@
-    context v != NULL ** \pointer_length(v)==1 ** Perm(v, 1\100) ** Perm(&v->xs, 1\100);
+    context v != NULL ** \pointer_length(v)==1 ** Perm(&v->xs, 1\100);
     ensures v->xs  == \result;
   @*/
   int* get_xs(struct vec* v){
@@ -821,7 +821,7 @@ struct vec {
 
   /*@
   ghost
-    context v != NULL ** \pointer_length(v)==1 ** Perm(v, 1\100) ** Perm(v->xs, 1\100) ** v->xs != NULL;
+    context v != NULL ** \pointer_length(v)==1 ** Perm(v->xs, 1\100) ** v->xs != NULL;
     context 1 \in m.keys && m[1].size >0 ==> m[1][0].fst != NULL;
     ensures \result != NULL;
   int* get_xs2(struct vec* v, map<int, seq<tuple<int*, void*> > > m){
@@ -836,7 +836,7 @@ struct vec {
   /*@
     given map<int, seq<tuple<int*, void*> > > m;
     context 1 \in m.keys && m[1].size >0 ==> m[1][0].fst != NULL;
-    context v != NULL ** \pointer_length(v)==1 ** Perm(v, write) ** Perm(*v, write);
+    context v != NULL ** \pointer_length(v)==1 ** Perm(*v, write);
     context v->xs != NULL;
   @*/
   int f(/*@unique_pointer_field<xs, 1>@*/ struct vec*  v){
@@ -857,7 +857,7 @@ struct vec {
   };
 
   /*@
-    context v != NULL ** \pointer_length(v)==1 ** Perm(v, 1\100) ** Perm(&v->xs, 1\100);
+    context v != NULL ** \pointer_length(v)==1 ** Perm(&v->xs, 1\100);
     ensures \result == v->xs;
   @*/
   int* get_xs(struct vec* v){
@@ -883,7 +883,7 @@ struct vec {
   /*@
     given int* ys;
     yields int* res;
-    context v != NULL ** \pointer_length(v)==1 ** Perm(v, 1\100) ** Perm(&v->xs, 1\100);
+    context v != NULL ** \pointer_length(v)==1 ** Perm(&v->xs, 1\100);
     ensures v->xs  == \result;
   @*/
   int* get_xs(struct vec* v){
@@ -891,7 +891,7 @@ struct vec {
    }
 
   /*@
-    context v != NULL ** \pointer_length(v)==1 ** Perm(v, write) ** Perm(*v, write);
+    context v != NULL ** \pointer_length(v)==1 ** Perm(*v, write);
     context v->xs != NULL;
   @*/
   int f(/*@unique_pointer_field<xs, 1>@*/ struct vec*  v, int* ys){
@@ -1103,8 +1103,6 @@ struct buf {
 inline resource buffer_pred(struct buf *buf, rational p, int n_dims) =
  buf != NULL **
  \pointer_length(buf) == 1 **
- Perm(buf, p) **
- Perm(&buf->shape, p) **
  Perm(&buf->shape.dim, p) **
  buf->shape.dim != NULL **
  \pointer_length(buf->shape.dim) == n_dims **


### PR DESCRIPTION
Checklist:

- [ ] The wiki is updated in accordance with the changes in this PR. For example: syntax changes, semantics changes, VerCors flags changes, etc.

# PR description
This means that a program like this:

```c
struct A {
  int b;
  int c;
};

//@ requires a != NULL ** Perm(a) ** Perm(*a);
//@ ensures Perm(a) ** Perm(*a) ** a->b == 10;
void foo(struct A *a) {
    a->b = 10;
}
```

Can now be written:


```c
struct A {
  int b;
  int c;
};

//@ requires a != NULL ** Perm(*a);
//@ ensures Perm(*a) ** a->b == 10;
void foo(struct A *a) {
    a->b = 10;
}
```

This change was made because there is no reason to keep track of the permission to a struct and the permission to its fields separately. Internally there is now simply a function which turns a pointer to a struct into the struct adt without accessing a field therefore we don't require any resources to access the pointers which to the fields.