### PR TITLE
OpenCL vector fix, fix for SMT solver query & get info from opencl correctly

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -400,7 +400,7 @@ object vercors extends Module {
     }
 
     def key = "col"
-    def deps = T { Agg.empty }
+    def deps = T { Agg(ivy"org.sosy-lab:java-smt:3.14.3") }
     override def sources = T {
       helpers.implTraits.run()
       super.sources()

--- a/examples/concepts/gpgpu/dynamic_shared_opencl.cl
+++ b/examples/concepts/gpgpu/dynamic_shared_opencl.cl
@@ -5,13 +5,13 @@
 #include <opencl.h>
 
 /*@
-  context get_local_size(0) == 32 && get_local_size(1) == 1 && get_local_size(2) == 1;
-  context get_num_groups(0) > 0 && get_num_groups(1) == 1 && get_num_groups(2) == 1;
+  context get_work_dim() == 1;
+  context get_local_size(0) == 32;
+  context get_num_groups(0) > 0;
 
   context in != NULL && out != NULL;
   context \pointer_length(in) == 1;
   context \pointer_length(out) == n;
-  context n > 0;
   context get_local_size(0) * get_num_groups(0) >= n;
   context Perm(in[0], write \ (get_local_size(0) * get_num_groups(0)));
   context \gtid<n ==> Perm({:out[\gtid]:}, write);
@@ -22,18 +22,18 @@
   ensures \gtid<n ==> {:out[\gtid]:} == \old(out[\gtid]) + in[0];
 @*/
 __kernel void blur_x(global int* in, global int* out, int n, local int* s) {
-  int tid = get_group_id(0) * get_local_size(0) + get_local_id(0);
+  int tid = get_global_id(0);
   if(get_local_id(0) == 0) {
     s[get_local_id(0)] = in[0];
   }
 
   /*@
     context Perm(in[0], write \ (get_local_size(0) * get_num_groups(0)));
-    context get_group_id(0) * get_local_size(0) + get_local_id(0)<n ==> Perm({:out[get_group_id(0) * get_local_size(0) + get_local_id(0)]:}, write);
-    context get_group_id(0) * get_local_size(0) + get_local_id(0)<n ==> \old(out[get_group_id(0) * get_local_size(0) + get_local_id(0)]) == {:out[get_group_id(0) * get_local_size(0) + get_local_id(0)]:};
+    context \gtid<n ==> Perm({:out[\gtid]:}, write);
+    context \gtid<n ==> \old(out[\gtid]) == {:out[\gtid]:};
 
-    requires get_local_id(0) == 0 ==> Perm(s[0], write);
-    requires get_local_id(0) == 0 ==> s[0] == in[0];
+    requires \ltid == 0 ==> Perm(s[0], write);
+    requires \ltid == 0 ==> s[0] == in[0];
 
     ensures Perm(s[0], write \ get_local_size(0)); 
 

--- a/examples/concepts/gpgpu/global_fence_opencl.cl
+++ b/examples/concepts/gpgpu/global_fence_opencl.cl
@@ -5,13 +5,13 @@
 #include <opencl.h>
 
 /*@
-  context get_local_size(0) == 32 && get_local_size(1) == 1 && get_local_size(2) == 1;
-  context get_num_groups(0) == 4 && get_num_groups(1) == 1 && get_num_groups(2) == 1;
+  context get_work_dim() == 1;
+  context get_local_size(0) == 32;
+  context get_num_groups(0) == 4;
 
   context in != NULL && out != NULL;
   context \pointer_length(in) == 1;
   context \pointer_length(out) == n;
-  context n > 0;
   context get_local_size(0) * get_num_groups(0) >= n;
   context Perm(in[0], write \ (get_local_size(0) * get_num_groups(0)));
   context \gtid<n ==> Perm({:out[\gtid]:}, write);
@@ -29,8 +29,8 @@ __kernel void blur_x(global int* in, global int* out, int n, global int* s) {
 
   /*@
     context Perm(in[0], write \ (get_local_size(0) * get_num_groups(0)));
-    context get_group_id(0) * get_local_size(0) + get_local_id(0)<n ==> Perm({:out[get_group_id(0) * get_local_size(0) + get_local_id(0)]:}, write);
-    context get_group_id(0) * get_local_size(0) + get_local_id(0)<n ==> \old(out[get_group_id(0) * get_local_size(0) + get_local_id(0)]) == {:out[get_group_id(0) * get_local_size(0) + get_local_id(0)]:};
+    context \gtid<n ==> Perm({:out[\gtid]:}, write);
+    context \gtid<n ==> \old(out[\gtid]) == {:out[get_group_id(0) * get_local_size(0) + get_local_id(0)]:};
 
     requires get_local_id(0) == 0 ==> Perm(s[get_group_id(0)], write);
     requires get_local_id(0) == 0 ==> s[get_group_id(0)] == in[0];

--- a/examples/concepts/gpgpu/opencl_vector_add.cl
+++ b/examples/concepts/gpgpu/opencl_vector_add.cl
@@ -2,25 +2,31 @@
 
 
 /*@
-  context get_local_size(0) == 32 && get_local_size(1) == 1 && get_local_size(2) == 1;
-  context get_num_groups(0) > 0 && get_num_groups(1) == 1 && get_num_groups(2) == 1;
+  context get_work_dim() == 1;
+  context get_local_size(0) == 32;
+  context get_num_groups(0) > 0;
   context a != NULL && b != NULL && c != NULL;
   context \pointer_length(a) >= size && \pointer_length(b) >= size && \pointer_length(c) >= size;
-  context \gtid*2 < size ==> (Perm({:a[\gtid*2]:}, 1\2) ** Perm({:1:b[\gtid*2]:}, 1\2) ** Perm({:2:c[\gtid*2]:}, 1\1));
-  context \gtid*2+1 < size ==> (Perm({:a[\gtid*2+1]:}, 1\2) ** Perm({:1:b[\gtid*2+1]:}, 1\2) ** Perm({:2:c[\gtid*2+1]:}, 1\1));
-  ensures \gtid*2 < size ==> {:2:c[\gtid*2]:} == {:a[\gtid*2]:} + {:1:b[\gtid*2]:};
-  ensures \gtid*2+1 < size ==> {:2:c[\gtid*2+1]:} == {:a[\gtid*2+1]:} + {:1:b[\gtid*2+1]:};
+  context (\forall* int i; 0<=i && i<4 && \gtid*4+3 < size;
+    Perm({:a[\gtid*4+i]:}, 1\2) ** Perm({:1:b[\gtid*4+i]:}, 1\2) ** Perm({:2:c[\gtid*4+i]:}, 1\1));
+  context (\forall* int i; 0<=i && i< size%4 && \gtid*4+3 >= size && \gtid*4 < size;
+    Perm({:a[\gtid*4+i]:}, 1\2) ** Perm({:1:b[\gtid*4+i]:}, 1\2) ** Perm({:2:c[\gtid*4+i]:}, 1\1));
+
+  ensures (\forall int i; 0<=i && i<4 && \gtid*4+3 < size;
+    {:c[\gtid*4+i]:} == a[\gtid*4+i] + b[\gtid*4+i]);
+  ensures (\forall int i; 0<=i && i< size%4 && \gtid*4+3 >= size && \gtid*4 < size;
+    {:c[\gtid*4+i]:} == a[\gtid*4+i] + b[\gtid*4+i]);
 @*/
 __kernel void addArrays(__global int* a, __global int* b, __global int* c, int size) {
     int tid = get_global_id(0);
-    if (2*tid+1 < size) {
-        // int2 a2 = (int2)(a[2*tid], a[2*tid+1]);
-        int2 a2 = vload2(tid, a) /*@ given {r=1\2} @*/;
-        // int2 b2 = (int2)(b[2*tid], b[2*tid+1]);
-        int2 b2 = vload2(tid, b) /*@ given {r=1\2} @*/;
-        int2 c2 = a2 + b2;
-        vstore2(c2, tid, c);
-    } else if(2*tid+1 == size) {
-        c[2*tid] = a[2*tid] + b[2*tid];
+    if (4*tid+3 < size) {
+        int4 a2 = vload4(tid, a);
+        int4 b2 = vload4(tid, b);
+        int4 c2 = a2 + b2;
+        vstore4(c2, tid, c);
+    } else {
+      if(4*tid+2 < size) c[4*tid+2] = a[4*tid+2] + b[4*tid+2];
+      if(4*tid+1 < size) c[4*tid+1] = a[4*tid+1] + b[4*tid+1]; 
+      if(4*tid < size) c[4*tid] = a[4*tid] + b[4*tid];
     }
 }

--- a/examples/concepts/gpgpu/opencl_vector_simple.cl
+++ b/examples/concepts/gpgpu/opencl_vector_simple.cl
@@ -21,8 +21,9 @@
 }
 
 /*@
-  context get_local_size(0) == 32 && get_local_size(1) == 1 && get_local_size(2) == 1;
-  context get_num_groups(0) > 0 && get_num_groups(1) == 1 && get_num_groups(2) == 1;
+  context get_work_dim() == 1;
+  context get_local_size(0) == 32;
+  context get_num_groups(0) > 0;
   context a != NULL && \pointer_length(a) >= 1;
   context (\gtid < 1 ==> Perm({:a[\gtid]:}, write));
 @*/

--- a/examples/concepts/gpgpu/static_shared_opencl.cl
+++ b/examples/concepts/gpgpu/static_shared_opencl.cl
@@ -5,13 +5,13 @@
 #include <opencl.h>
 
 /*@
-  context get_local_size(0) == 32 && get_local_size(1) == 1 && get_local_size(2) == 1;
-  context get_num_groups(0) > 0 && get_num_groups(1) == 1 && get_num_groups(2) == 1;
+  context get_work_dim() == 1;
+  context get_local_size(0) == 32;
+  context get_num_groups(0) > 0;
 
   context in != NULL && out != NULL;
   context \pointer_length(in) == 1;
   context \pointer_length(out) == n;
-  context n > 0;
   context get_local_size(0) * get_num_groups(0) >= n;
   context Perm(in[0], write \ (get_local_size(0) * get_num_groups(0)));
   context \gtid<n ==> Perm({:out[\gtid]:}, write);
@@ -22,18 +22,18 @@
 @*/
 __kernel void blur_x(global int* in, global int* out, int n) {
   local int s[1];
-  int tid = get_group_id(0) * get_local_size(0) + get_local_id(0);
+  int tid = get_global_id(0);
   if(get_local_id(0) == 0) {
     s[get_local_id(0)] = in[0];
   }
 
   /*@
     context Perm(in[0], write \ (get_local_size(0) * get_num_groups(0)));
-    context get_group_id(0) * get_local_size(0) + get_local_id(0)<n ==> Perm({:out[get_group_id(0) * get_local_size(0) + get_local_id(0)]:}, write);
-    context get_group_id(0) * get_local_size(0) + get_local_id(0)<n ==> \old(out[get_group_id(0) * get_local_size(0) + get_local_id(0)]) == {:out[get_group_id(0) * get_local_size(0) + get_local_id(0)]:};
+    context \gtid<n ==> Perm({:out[\gtid]:}, write);
+    context \gtid<n ==> \old(out[\gtid]) == {:out[\gtid]:};
 
-    requires get_local_id(0) == 0 ==> Perm(s[0], write);
-    requires get_local_id(0) == 0 ==> s[0] == in[0];
+    requires \ltid == 0 ==> Perm(s[0], write);
+    requires \ltid == 0 ==> s[0] == in[0];
 
     ensures Perm(s[0], write \ get_local_size(0));
 

--- a/examples/verifythis/2024/challenge2.pvl
+++ b/examples/verifythis/2024/challenge2.pvl
@@ -12,17 +12,17 @@ ensures (\forall int i=0..n(); |{:\result[i]:}| == 2);
 // Everything is NO_TASK or a valid task (thus: a graph)
 ensures (\forall int i=0..n(), int j=0..2; {:\result[i][j]:} == NO_TASK() || (0 <= \result[i][j] && \result[i][j] < n()));
 // The graph contains no cycles:
-ensures (\forall int i=0..n(); height(\result, i, set<int>{}) != -1);
+ensures (\forall int i=0..n(); {:height(\result, i, set<int>{}):} != -1);
 // The children of every node are unique:
 ensures (\forall int i=0..n(); {:\result[i]:}[0] == NO_TASK() || \result[i][0] != \result[i][1]);
 // The graph is a tree (not just a DAG):
-ensures (\forall int i=0..n(); i == ROOT_TASK() ? parentGraph(\result, i) == -1 : parentGraph(\result, i) != -1);
+ensures (\forall int i=0..n(); i == ROOT_TASK() ? {:parentGraph(\result, i):} == -1 : parentGraph(\result, i) != -1);
 // Every node is the parent of its children (this one should be possible to infer from the above, but was quite hard to prove)
 ensures (\forall int i=0..n(), int j=0..2; {:\result[i][j]:} == NO_TASK() || parentGraph(\result, \result[i][j]) == i);
 decreases;
 pure seq<seq<int>> subtask();
 
-requires (\forall int i; i \in xs; 0 <= i && i < n);
+requires (\forall int i; {:i \in xs:}; 0 <= i && i < n);
 requires n >= 0;
 ensures |xs| <= n;
 ensures \result == xs;
@@ -36,7 +36,7 @@ pure set<int> pigeon(set<int> xs, int n) =
 
 // -1 when a cycle occurs, in [0, n) otherwise
 requires |graph| == n() && (\forall int i=0..n(); |{:graph[i]:}| == 2);
-requires (\forall int i; i \in seen; 0 <= i && i < n());
+requires (\forall int i; {:i \in seen:}; 0 <= i && i < n());
 decreases n() - |seen|;
 pure int height(seq<seq<int>> graph, int pos, set<int> seen) =
     pos \in seen
@@ -187,14 +187,14 @@ class Main {
         |q| == p() **
         // Each worker has a unique queue
         (\forall int i=0..p(), int j=0..p(); {:q[i]:} == {:q[j]:} ==> i == j) **
-        (\forall* int i=0..p(); {:q[i]:} != null ** Perm({:q[i].tasks:}, 1\2)) **
+        (\forall* int i=0..p(); {:q[i]:} != null ** Perm({:1:q[i].tasks:}, 1\2)) **
         (\forall* int i=0..n(); Perm({:executed[i]:}, 1\2)) **
         // Every task in a queue is in subtask()
-        (\forall int i=0..p(), int j=0..|q[i].tasks|; 0 <= {:q[i].tasks[j]:} && {:q[i].tasks[j]:} < n()) **
+        (\forall int i=0..p(), int j=0..|q[i].tasks|; 0 <= {:q[i].tasks[j]:} && q[i].tasks[j] < n()) **
         task_owner != null ** task_owner.length == n() **
         (\forall* int i=0..n(); Perm({:task_owner[i]:}, write)) **
         // Every task owned by a worker is in subtask()
-        (\forall int i=0..n(); task_owner[i] != -1; 0 <= {:task_owner[i]:} && {:task_owner[i]:} < p()) **
+        (\forall int i=0..n(); task_owner[i] != -1; 0 <= {:task_owner[i]:} && task_owner[i] < p()) **
         // Every task in a queue has not been executed yet
         (\forall int i=0..p(), int j=0..|q[i].tasks|; !executed[{:q[i].tasks[j]:}]) **
         // Every task owned by a worker has not been executed yet
@@ -217,7 +217,7 @@ class Main {
         // If a worker is waiting no other worker may set that worker's communication cell to NOT_WAITING
         (\forall int i=0..p(); is_waiting[i] ==> {:communication_cells[i]:} != NOT_WAITING()) **
         // Every task in a communication cell: is a valid task in subtask()
-        (\forall int i=0..p(); communication_cells[i] != NOT_WAITING() && communication_cells[i] != WAITING(); 0 <= {:communication_cells[i]:} && {:communication_cells[i]:} < n()) **
+        (\forall int i=0..p(); communication_cells[i] != NOT_WAITING() && communication_cells[i] != WAITING(); 0 <= {:communication_cells[i]:} && communication_cells[i] < n()) **
         // Every task in a communication cell: has not been executed
         (\forall int i=0..p(); communication_cells[i] != NOT_WAITING() && communication_cells[i] != WAITING(); !executed[{:communication_cells[i]:}]) **
         // Every task in a communication cell: is not in a queue

--- a/res/universal/res/c/emmintrin.h
+++ b/res/universal/res/c/emmintrin.h
@@ -56,38 +56,38 @@ __m128i /*@ pure @*/ _mm_set1_epi64x (long long __A)
 // SSE2
 
 /*@
-  requires __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<4; Perm(__P[i], read));
+  requires __P != NULL ** \pointer_length(__P) >= 4 ** (\forall* int i; 0<=i && i<4; Perm(__P[i], read));
   ensures __P[0] == \result[0] && __P[1] == \result[1] && __P[2] == \result[2] && __P[3] == \result[3];
 @*/
 /*@ pure @*/ __m128 _mm_loadu_ps (float *__P);
 
 /*@
-  requires __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<4; Perm(__P[i], read));
+  requires __P != NULL ** \pointer_length(__P) >= 4 ** (\forall* int i; 0<=i && i<4; Perm(__P[i], read));
   ensures __P[0] == \result[0] && __P[1] == \result[1] && __P[2] == \result[2] && __P[3] == \result[3];
 @*/
 /*@ pure @*/ __m128 _mm_load_ps (float *__P);
 
 /*@
-  requires __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<2; Perm(__P[i], read));
+  requires __P != NULL ** \pointer_length(__P) >= 2 ** (\forall* int i; 0<=i && i<2; Perm(__P[i], read));
   ensures __P[0] == \result[0] && __P[1] == \result[1];
 @*/
 /*@ pure @*/ __m128d _mm_loadu_pd (double *__P);
 
 /*@
-  requires __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<2; Perm(__P[i], read));
+  requires __P != NULL ** \pointer_length(__P) >= 2 ** (\forall* int i; 0<=i && i<2; Perm(__P[i], read));
   ensures __P[0] == \result[0] && __P[1] == \result[1];
 @*/
 /*@ pure @*/ __m128d _mm_load_pd (double *__P);
 
 /*@
-  requires __P != NULL ** \pointer_length((long long *)__P) >= 8 ** (\forall* int i; 0<=i && i<2; Perm(((long long *)__P)[i], read));
+  requires __P != NULL ** \pointer_length((long long *)__P) >= 2 ** (\forall* int i; 0<=i && i<2; Perm(((long long *)__P)[i], read));
   ensures ((long long*)__P)[0] == \result[0] && ((long long*)__P)[1] == \result[1];
 @*/
 /*@ pure @*/ __m128i _mm_loadu_epi64 (void *__P);
 
 
 /*@
-  requires __P != NULL ** \pointer_length((long long *)__P) >= 8 ** (\forall* int i; 0<=i && i<2; Perm(((long long *)__P)[i], read));
+  requires __P != NULL ** \pointer_length((long long *)__P) >= 2 ** (\forall* int i; 0<=i && i<2; Perm(((long long *)__P)[i], read));
   ensures ((long long*)__P)[0] == \result[0] && ((long long*)__P)[1] == \result[1];
 @*/
 /*@ pure @*/ __m128i _mm_load_epi64 (void *__P);
@@ -108,26 +108,26 @@ __m128i /*@ pure @*/ _mm_set1_epi64x (long long __A)
 /*@ pure @*/ __m256 _mm256_load_ps (float *__P);
 
 /*@
-  requires __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<4; Perm(__P[i], read));
+  requires __P != NULL ** \pointer_length(__P) >= 4 ** (\forall* int i; 0<=i && i<4; Perm(__P[i], read));
   ensures __P[0] == \result[0] && __P[1] == \result[1] && __P[2] == \result[2] && __P[3] == \result[3];
 @*/
 /*@ pure @*/ __m256d _mm256_loadu_pd (double *__P);
 
 /*@
-  requires __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<4; Perm(__P[i], read));
+  requires __P != NULL ** \pointer_length(__P) >= 4 ** (\forall* int i; 0<=i && i<4; Perm(__P[i], read));
   ensures __P[0] == \result[0] && __P[1] == \result[1] && __P[2] == \result[2] && __P[3] == \result[3];
 @*/
 /*@ pure @*/ __m256d _mm256_load_pd (double *__P);
 
 /*@
-  requires __P != NULL ** \pointer_length((long long *)__P) >= 8 ** (\forall* int i; 0<=i && i<4; Perm(((long long *)__P)[i], read));
+  requires __P != NULL ** \pointer_length((long long *)__P) >= 4 ** (\forall* int i; 0<=i && i<4; Perm(((long long *)__P)[i], read));
   ensures ((long long*)__P)[0] == \result[0] && ((long long*)__P)[1] == \result[1] && ((long long*)__P)[2] == \result[2] && ((long long*)__P)[3] == \result[3];
 @*/
 /*@ pure @*/ __m256i _mm256_loadu_epi64 (void *__P);
 
 
 /*@
-  requires __P != NULL ** \pointer_length((long long *)__P) >= 8 ** (\forall* int i; 0<=i && i<4; Perm(((long long *)__P)[i], read));
+  requires __P != NULL ** \pointer_length((long long *)__P) >= 4 ** (\forall* int i; 0<=i && i<4; Perm(((long long *)__P)[i], read));
   ensures ((long long*)__P)[0] == \result[0] && ((long long*)__P)[1] == \result[1] && ((long long*)__P)[2] == \result[2] && ((long long*)__P)[3] == \result[3];
 @*/
 /*@ pure @*/ __m256i _mm256_load_epi64 (void *__P);
@@ -135,37 +135,37 @@ __m128i /*@ pure @*/ _mm_set1_epi64x (long long __A)
 /**** Stores ****/
 // SSE2
 /*@
-  context __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<4; Perm(__P[i], write));
+  context __P != NULL ** \pointer_length(__P) >= 4 ** (\forall* int i; 0<=i && i<4; Perm(__P[i], write));
   ensures __P[0] == __A[0] && __P[1] == __A[1] && __P[2] == __A[2] && __P[3] == __A[3];
 @*/
 void _mm_store_ps (float *__P, __m128 __A);
 
 /*@
-  context __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<4; Perm(__P[i], write));
+  context __P != NULL ** \pointer_length(__P) >= 4 ** (\forall* int i; 0<=i && i<4; Perm(__P[i], write));
   ensures __P[0] == __A[0] && __P[1] == __A[1] && __P[2] == __A[2] && __P[3] == __A[3];
 @*/
 void _mm_storeu_ps (float *__P, __m128 __A);
 
 /*@
-  context __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<2; Perm(__P[i], write));
+  context __P != NULL ** \pointer_length(__P) >= 2 ** (\forall* int i; 0<=i && i<2; Perm(__P[i], write));
   ensures __P[0] == __A[0] && __P[1] == __A[1];
 @*/
 void _mm_store_pd (double *__P, __m128d __A);
 
 /*@
-  context __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<2; Perm(__P[i], write));
+  context __P != NULL ** \pointer_length(__P) >= 2 ** (\forall* int i; 0<=i && i<2; Perm(__P[i], write));
   ensures __P[0] == __A[0] && __P[1] == __A[1];
 @*/
 void _mm_storeu_pd (double *__P, __m128d __A);
 
 /*@
-  context __P != NULL ** \pointer_length((long long *)__P) >= 8 ** (\forall* int i; 0<=i && i<2; Perm(((long long *)__P)[i], write));
+  context __P != NULL ** \pointer_length((long long *)__P) >= 2 ** (\forall* int i; 0<=i && i<2; Perm(((long long *)__P)[i], write));
   ensures ((long long *) __P)[0] == __A[0] && ((long long *) __P)[1] == __A[1];
 @*/
 void _mm_storeu_epi64 (void *__P, __m128i __A);
 
 /*@
-  context __P != NULL ** \pointer_length((long long *)__P) >= 8 ** (\forall* int i; 0<=i && i<2; Perm(((long long *)__P)[i], write));
+  context __P != NULL ** \pointer_length((long long *)__P) >= 2 ** (\forall* int i; 0<=i && i<2; Perm(((long long *)__P)[i], write));
   ensures ((long long *) __P)[0] == __A[0] && ((long long *) __P)[1] == __A[1];
 @*/
 void _mm_store_epi64 (void *__P, __m128i __A);
@@ -186,25 +186,25 @@ void _mm256_store_ps (float *__P, __m256 __A);
 void _mm256_storeu_ps (float *__P, __m256 __A);
 
 /*@
-  context __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<4; Perm(__P[i], write));
+  context __P != NULL ** \pointer_length(__P) >= 4 ** (\forall* int i; 0<=i && i<4; Perm(__P[i], write));
   ensures __P[0] == __A[0] && __P[1] == __A[1] && __P[2] == __A[2] && __P[3] == __A[3];
 @*/
 void _mm256_store_pd (double *__P, __m256d __A);
 
 /*@
-  context __P != NULL ** \pointer_length(__P) >= 8 ** (\forall* int i; 0<=i && i<4; Perm(__P[i], write));
+  context __P != NULL ** \pointer_length(__P) >= 4 ** (\forall* int i; 0<=i && i<4; Perm(__P[i], write));
   ensures __P[0] == __A[0] && __P[1] == __A[1] && __P[2] == __A[2] && __P[3] == __A[3];
 @*/
 void _mm256_storeu_pd (double *__P, __m256d __A);
 
 /*@
-  context __P != NULL ** \pointer_length((long long *)__P) >= 8 ** (\forall* int i; 0<=i && i<4; Perm(((long long *)__P)[i], write));
+  context __P != NULL ** \pointer_length((long long *)__P) >= 4 ** (\forall* int i; 0<=i && i<4; Perm(((long long *)__P)[i], write));
   ensures ((long long *) __P)[0] == __A[0] && ((long long *) __P)[1] == __A[1] && ((long long *) __P)[2] == __A[2] && ((long long *) __P)[3] == __A[3];
 @*/
 void _mm256_storeu_epi64 (void *__P, __m256i __A);
 
 /*@
-  context __P != NULL ** \pointer_length((long long *)__P) >= 8 ** (\forall* int i; 0<=i && i<4; Perm(((long long *)__P)[i], write));
+  context __P != NULL ** \pointer_length((long long *)__P) >= 4 ** (\forall* int i; 0<=i && i<4; Perm(((long long *)__P)[i], write));
   ensures ((long long *) __P)[0] == __A[0] && ((long long *) __P)[1] == __A[1] && ((long long *) __P)[2] == __A[2] && ((long long *) __P)[3] == __A[3];
 @*/
 void _mm256_store_epi64 (void *__P, __m256i __A);

--- a/res/universal/res/c/opencl.h
+++ b/res/universal/res/c/opencl.h
@@ -96,71 +96,61 @@ typedef __opencl_vector_type__(double, 16) double16;
 // https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_C.html#vector-data-load-and-store-functions
 
 /*@
-  given rational r;
   context p != NULL;
-  context r > 0\1 && r < write;
   context offset >= 0;
   context \pointer_length(p) >= offset*2+2;
-  context Perm(p[offset*2], r) ** Perm(p[offset*2+1], r);
+  requires Perm(p[offset*2], read) ** Perm(p[offset*2+1], read);
   ensures \result.s0 == p[offset*2] && \result.s1 == p[offset*2+1];
 @*/
-int2 vload2(int offset, int* p);
+/*@ pure */ int2 vload2(int offset, int* p);
 
 /*@
-  given rational r;
   context p != NULL;
-  context r > 0\1 && r < write;
   context offset >= 0;
-  context \pointer_length(p) >= offset*2+3;
-  context Perm(p[offset*2], r) ** Perm(p[offset*2+1], r) ** Perm(p[offset*2+2], r);
-  ensures \result.s0 == p[offset*2] && \result.s1 == p[offset*2+1] && \result.s2 == p[offset*2+2];
+  context \pointer_length(p) >= offset*3+3;
+  requires Perm(p[offset*3], read) ** Perm(p[offset*3+1], read) ** Perm(p[offset*3+2], read);
+  ensures \result.s0 == p[offset*3] && \result.s1 == p[offset*3+1] && \result.s2 == p[offset*3+2];
 @*/
-int3 vload3(int offset, int* p);
+/*@ pure */ int3 vload3(int offset, int* p);
 
 /*@
-  given rational r;
   context p != NULL;
-  context r > 0\1 && r < write;
   context offset >= 0;
-  context \pointer_length(p) >= offset*2+4;
-  context Perm(p[offset*2], r) ** Perm(p[offset*2+1], r) ** Perm(p[offset*2+2], r) ** Perm(p[offset*2+3], r);
-  ensures \result.s0 == p[offset*2] && \result.s1 == p[offset*2+1] && \result.s2 == p[offset*2+2]
-      && \result.s3 == p[offset*2+3];
+  context \pointer_length(p) >= offset*4+4;
+  requires Perm(p[offset*4], read) ** Perm(p[offset*4+1], read) ** Perm(p[offset*4+2], read) ** Perm(p[offset*4+3], read);
+  ensures \result.s0 == p[offset*4] && \result.s1 == p[offset*4+1] && \result.s2 == p[offset*4+2]
+      && \result.s3 == p[offset*4+3];
 @*/
-int4 vload4(int offset, int* p);
+/*@ pure */ int4 vload4(int offset, int* p);
 
 /*@
-  given rational r;
   context p != NULL;
-  context r > 0\1 && r < write;
   context offset >= 0;
-  context \pointer_length(p) >= offset*2+8;
-  context Perm(p[offset*2], r) ** Perm(p[offset*2+1], r) ** Perm(p[offset*2+2], r) ** Perm(p[offset*2+3], r)
-     ** Perm(p[offset*2+4], r) ** Perm(p[offset*2+5], r) ** Perm(p[offset*2+6], r) ** Perm(p[offset*2+7], r);
-  ensures \result.s0 == p[offset*2] && \result.s1 == p[offset*2+1] && \result.s2 == p[offset*2+2]
-      && \result.s3 == p[offset*2+3] && \result.s4 == p[offset*2+4] && \result.s5 == p[offset*2+5]
-      && \result.s6 == p[offset*2+6] && \result.s7 == p[offset*2+7];
+  context \pointer_length(p) >= offset*8+8;
+  requires Perm(p[offset*8], read) ** Perm(p[offset*8+1], read) ** Perm(p[offset*8+2], read) ** Perm(p[offset*8+3], read)
+     ** Perm(p[offset*8+4], read) ** Perm(p[offset*8+5], read) ** Perm(p[offset*8+6], read) ** Perm(p[offset*8+7], read);
+  ensures \result.s0 == p[offset*8] && \result.s1 == p[offset*8+1] && \result.s2 == p[offset*8+2]
+      && \result.s3 == p[offset*8+3] && \result.s4 == p[offset*8+4] && \result.s5 == p[offset*8+5]
+      && \result.s6 == p[offset*8+6] && \result.s7 == p[offset*8+7];
 @*/
-int8 vload8(int offset, int* p);
+/*@ pure */ int8 vload8(int offset, int* p);
 
 /*@
-  given rational r;
   context p != NULL;
-  context r > 0\1 && r < write;
   context offset >= 0;
-  context \pointer_length(p) >= offset*2+16;
-  context Perm(p[offset*2], r) ** Perm(p[offset*2+1], r) ** Perm(p[offset*2+2], r) ** Perm(p[offset*2+3], r)
-     ** Perm(p[offset*2+4], r) ** Perm(p[offset*2+5], r) ** Perm(p[offset*2+6], r) ** Perm(p[offset*2+7], r)
-     ** Perm(p[offset*2+8], r) ** Perm(p[offset*2+9], r) ** Perm(p[offset*2+10], r) ** Perm(p[offset*2+11], r)
-     ** Perm(p[offset*2+12], r) ** Perm(p[offset*2+13], r) ** Perm(p[offset*2+14], r) ** Perm(p[offset*2+15], r);
-  ensures \result.s0 == p[offset*2] && \result.s1 == p[offset*2+1] && \result.s2 == p[offset*2+2]
-      && \result.s3 == p[offset*2+3] && \result.s4 == p[offset*2+4] && \result.s5 == p[offset*2+5]
-      && \result.s6 == p[offset*2+6] && \result.s7 == p[offset*2+7] && \result.s8 == p[offset*2+8]
-      && \result.s9 == p[offset*2+9] && \result.sA == p[offset*2+10] && \result.sB == p[offset*2+11]
-      && \result.sC == p[offset*2+12] && \result.sD == p[offset*2+13] && \result.sE == p[offset*2+14]
-      && \result.sF == p[offset*2+15];
+  context \pointer_length(p) >= offset*16+16;
+  requires Perm(p[offset*16], read) ** Perm(p[offset*16+1], read) ** Perm(p[offset*16+2], read) ** Perm(p[offset*16+3], read)
+     ** Perm(p[offset*16+4], read) ** Perm(p[offset*16+5], read) ** Perm(p[offset*16+6], read) ** Perm(p[offset*16+7], read)
+     ** Perm(p[offset*16+8], read) ** Perm(p[offset*16+9], read) ** Perm(p[offset*16+10], read) ** Perm(p[offset*16+11], read)
+     ** Perm(p[offset*16+12], read) ** Perm(p[offset*16+13], read) ** Perm(p[offset*16+14], read) ** Perm(p[offset*16+15], read);
+  ensures \result.s0 == p[offset*16] && \result.s1 == p[offset*16+1] && \result.s2 == p[offset*16+2]
+      && \result.s3 == p[offset*16+3] && \result.s4 == p[offset*16+4] && \result.s5 == p[offset*16+5]
+      && \result.s6 == p[offset*16+6] && \result.s7 == p[offset*16+7] && \result.s8 == p[offset*16+8]
+      && \result.s9 == p[offset*16+9] && \result.sA == p[offset*16+10] && \result.sB == p[offset*16+11]
+      && \result.sC == p[offset*16+12] && \result.sD == p[offset*16+13] && \result.sE == p[offset*16+14]
+      && \result.sF == p[offset*16+15];
 @*/
-int16 vload16(int offset, int* p);
+/*@ pure */ int16 vload16(int offset, int* p);
 
 /*@
   context p != NULL;
@@ -174,52 +164,52 @@ void vstore2(int2 data, int offset, int* p);
 /*@
   context p != NULL;
   context offset >= 0;
-  context \pointer_length(p) >= offset*2+3;
-  context Perm(p[offset*2], write) ** Perm(p[offset*2+1], write) ** Perm(p[offset*2+2], write);
-  ensures data.s0 == p[offset*2] && data.s1 == p[offset*2+1] && data.s2 == p[offset*2+2];
+  context \pointer_length(p) >= offset*3+3;
+  context Perm(p[offset*3], write) ** Perm(p[offset*3+1], write) ** Perm(p[offset*3+2], write);
+  ensures data.s0 == p[offset*3] && data.s1 == p[offset*3+1] && data.s2 == p[offset*3+2];
 @*/
 void vstore3(int3 data, int offset, int* p);
 
 /*@
   context p != NULL;
   context offset >= 0;
-  context \pointer_length(p) >= offset*2+4;
-  context Perm(p[offset*2], write) ** Perm(p[offset*2+1], write) ** Perm(p[offset*2+2], write)
-     ** Perm(p[offset*2+3], write);
-  ensures data.s0 == p[offset*2] && data.s1 == p[offset*2+1] && data.s2 == p[offset*2+2]
-          && data.s3 == p[offset*2+3];
+  context \pointer_length(p) >= offset*4+4;
+  context Perm(p[offset*4], write) ** Perm(p[offset*4+1], write) ** Perm(p[offset*4+2], write)
+     ** Perm(p[offset*4+3], write);
+  ensures data.s0 == p[offset*4] && data.s1 == p[offset*4+1] && data.s2 == p[offset*4+2]
+          && data.s3 == p[offset*4+3];
 @*/
 void vstore4(int4 data, int offset, int* p);
 
 /*@
   context p != NULL;
   context offset >= 0;
-  context \pointer_length(p) >= offset*2+8;
-  context Perm(p[offset*2], write) ** Perm(p[offset*2+1], write) ** Perm(p[offset*2+2], write)
-     ** Perm(p[offset*2+3], write) ** Perm(p[offset*2+4], write) ** Perm(p[offset*2+5], write)
-     ** Perm(p[offset*2+6], write) ** Perm(p[offset*2+7], write);
-  ensures data.s0 == p[offset*2] && data.s1 == p[offset*2+1] && data.s2 == p[offset*2+2]
-          && data.s3 == p[offset*2+3] && data.s4 == p[offset*2+4] && data.s5 == p[offset*2+5]
-          && data.s6 == p[offset*2+6] && data.s7 == p[offset*2+7];
+  context \pointer_length(p) >= offset*8+8;
+  context Perm(p[offset*8], write) ** Perm(p[offset*8+1], write) ** Perm(p[offset*8+2], write)
+     ** Perm(p[offset*8+3], write) ** Perm(p[offset*8+4], write) ** Perm(p[offset*8+5], write)
+     ** Perm(p[offset*8+6], write) ** Perm(p[offset*8+7], write);
+  ensures data.s0 == p[offset*8] && data.s1 == p[offset*8+1] && data.s2 == p[offset*8+2]
+          && data.s3 == p[offset*8+3] && data.s4 == p[offset*8+4] && data.s5 == p[offset*8+5]
+          && data.s6 == p[offset*8+6] && data.s7 == p[offset*8+7];
 @*/
 void vstore8(int8 data, int offset, int* p);
 
 /*@
   context p != NULL;
   context offset >= 0;
-  context \pointer_length(p) >= offset*2+16;
-  context Perm(p[offset*2], write) ** Perm(p[offset*2+1], write) ** Perm(p[offset*2+2], write)
-     ** Perm(p[offset*2+3], write) ** Perm(p[offset*2+4], write) ** Perm(p[offset*2+5], write)
-     ** Perm(p[offset*2+6], write) ** Perm(p[offset*2+7], write) ** Perm(p[offset*2+8], write)
-     ** Perm(p[offset*2+9], write) ** Perm(p[offset*2+10], write) ** Perm(p[offset*2+11], write)
-     ** Perm(p[offset*2+12], write) ** Perm(p[offset*2+13], write) ** Perm(p[offset*2+14], write)
-     ** Perm(p[offset*2+15], write);
-  ensures data.s0 == p[offset*2] && data.s1 == p[offset*2+1] && data.s2 == p[offset*2+2]
-          && data.s3 == p[offset*2+3] && data.s4 == p[offset*2+4] && data.s5 == p[offset*2+5]
-          && data.s6 == p[offset*2+6] && data.s7 == p[offset*2+7] && data.s8 == p[offset*2+8]
-          && data.s9 == p[offset*2+9] && data.sA == p[offset*2+10] && data.sB == p[offset*2+11]
-          && data.sC == p[offset*2+12] && data.sD == p[offset*2+13] && data.sE == p[offset*2+14]
-          && data.sF == p[offset*2+15];
+  context \pointer_length(p) >= offset*16+16;
+  context Perm(p[offset*16], write) ** Perm(p[offset*16+1], write) ** Perm(p[offset*16+2], write)
+     ** Perm(p[offset*16+3], write) ** Perm(p[offset*16+4], write) ** Perm(p[offset*16+5], write)
+     ** Perm(p[offset*16+6], write) ** Perm(p[offset*16+7], write) ** Perm(p[offset*16+8], write)
+     ** Perm(p[offset*16+9], write) ** Perm(p[offset*16+10], write) ** Perm(p[offset*16+11], write)
+     ** Perm(p[offset*16+12], write) ** Perm(p[offset*16+13], write) ** Perm(p[offset*16+14], write)
+     ** Perm(p[offset*16+15], write);
+  ensures data.s0 == p[offset*16] && data.s1 == p[offset*16+1] && data.s2 == p[offset*16+2]
+          && data.s3 == p[offset*16+3] && data.s4 == p[offset*16+4] && data.s5 == p[offset*16+5]
+          && data.s6 == p[offset*16+6] && data.s7 == p[offset*16+7] && data.s8 == p[offset*16+8]
+          && data.s9 == p[offset*16+9] && data.sA == p[offset*16+10] && data.sB == p[offset*16+11]
+          && data.sC == p[offset*16+12] && data.sD == p[offset*16+13] && data.sE == p[offset*16+14]
+          && data.sF == p[offset*16+15];
 @*/
 void vstore16(int16 data, int offset, int* p);
 

--- a/res/universal/res/simplify/simplify.pvl
+++ b/res/universal/res/simplify/simplify.pvl
@@ -189,7 +189,7 @@ axiom starall_bool {
     (∀* T t; (body!t)) == (∀ T t; (body!t)))
 }
 /* LvdH: I Think it is actually quite bad to split quantifiers here, when a user specified a trigger. Since it removes
-   control over the triggering of the quantifier. I think we should not allow this. */
+   control over the triggering of the quantifier. I think we should not allow this.
 axiom forall_and {
   (∀type<any> T, boolean b1, boolean b2;
     (∀T t; (b1!t) && (b2!t)) ==

--- a/res/universal/res/simplify/simplify.pvl
+++ b/res/universal/res/simplify/simplify.pvl
@@ -188,7 +188,8 @@ axiom starall_bool {
   (∀type<any> T, boolean body;
     (∀* T t; (body!t)) == (∀ T t; (body!t)))
 }
-
+/* LvdH: I Think it is actually quite bad to split quantifiers here, when a user specified a trigger. Since it removes
+   control over the triggering of the quantifier. I think we should not allow this. */
 axiom forall_and {
   (∀type<any> T, boolean b1, boolean b2;
     (∀T t; (b1!t) && (b2!t)) ==
@@ -200,7 +201,7 @@ axiom starall_star {
     (∀* T t; (r1!t) ** (r2!t)) ==
     ((∀* T t; (r1!t)) ** (∀* T t; (r2!t))))
 }
-
+*/
 axiom starall_select {
   (∀type<any> X, boolean cond, resource t, resource f;
     (∀* X x; (cond!x) ? (t!x) : (f!x)) ==

--- a/src/col/vct/col/ast/util/ExpressionEqualityCheck.scala
+++ b/src/col/vct/col/ast/util/ExpressionEqualityCheck.scala
@@ -1,13 +1,22 @@
 package vct.col.ast.util
 
+import org.sosy_lab.common.ShutdownNotifier
+import org.sosy_lab.common.configuration.Configuration
+import org.sosy_lab.common.log.LogManager
+import org.sosy_lab.java_smt.SolverContextFactory
+import org.sosy_lab.java_smt.SolverContextFactory.Solvers
+import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula
+import org.sosy_lab.java_smt.api._
 import vct.col.ast.util.ExpressionEqualityCheck.isConstantInt
 import vct.col.ast._
+import vct.col.origin._
 import vct.col.typerules.CoercionUtils
 import vct.col.util.AstBuildHelpers._
 import vct.result.VerificationError.UserError
 
 import scala.collection.mutable
 import scala.reflect.ClassTag
+import scala.util.Using
 
 object ExpressionEqualityCheck {
   def apply[G](
@@ -25,6 +34,190 @@ object ExpressionEqualityCheck {
   trait Sign
   case class Pos() extends Sign
   case class Neg() extends Sign
+
+  case class AskSMTSolver[G](constraints: Iterable[Expr[G]], test: Expr[G]) {
+    private implicit val o: Origin = Origin(
+      Seq(PreferredName(Seq("unknown")), LabelContext("simplification"))
+    )
+
+    def isBool(e: Expr[_]): Boolean = {
+      CoercionUtils.getCoercion(e.t, TBool()).isDefined
+    }
+
+    def isInt(e: Expr[_]): Boolean = {
+      CoercionUtils.getCoercion(e.t, TInt()).isDefined
+    }
+
+    def check(): Boolean = {
+      val options = Configuration.builder()
+        .setOption("solver.nonLinearArithmetic", "APPROXIMATE_FALLBACK");
+      val config = options.build()
+      val logManager = LogManager.createNullLogManager
+      val shutDown = ShutdownNotifier.createDummy
+      var id = 0
+
+      Using(SolverContextFactory.createSolverContext(
+        config,
+        logManager,
+        shutDown,
+        Solvers.SMTINTERPOL,
+      )) { ctx =>
+        Using(ctx.newProverEnvironment()) { prover =>
+          val fmgr = ctx.getFormulaManager
+          val varIntMap: mutable.Map[Variable[G], IntegerFormula] = mutable
+            .Map()
+          val varBoolMap: mutable.Map[Variable[G], BooleanFormula] = mutable
+            .Map()
+          val bmgr = fmgr.getBooleanFormulaManager
+          val imgr = fmgr.getIntegerFormulaManager
+
+          def tdiv(a: Expr[G], b: Expr[G]): Expr[G] =
+            Select(
+              a >= const(0) || a % b === const(0),
+              a / b,
+              a / b + Select(b > const(0), const(1), const(-1)),
+            )
+
+          def tmod(a: Expr[G], b: Expr[G]): Expr[G] =
+            Select(
+              a >= const(0) || a % b === const(0),
+              a % b,
+              a % b - Select(b > const(0), b, -b),
+            )
+
+          def addConstraint(e: Expr[G]): Boolean = {
+            addBool(e) match {
+              case Some(b1) => prover.addConstraint(b1); true
+              case None => false
+            }
+          }
+
+          def addBool(e: Expr[G]): Option[BooleanFormula] = {
+            e match {
+              case Select(c, t, f) =>
+                for {
+                  c1 <- addBool(c); t1 <- addBool(t); f1 <- addBool(f)
+                } yield bmgr.ifThenElse(c1, t1, f1)
+              case SeqMember(e1, Range(from, to)) =>
+                for {
+                  i1 <- addInt(e1); fromi <- addInt(from); toi <- addInt(to)
+                } yield bmgr
+                  .and(imgr.lessOrEquals(fromi, i1), imgr.lessThan(i1, toi))
+              case SetMember(e1, RangeSet(from, to)) =>
+                for {
+                  i1 <- addInt(e1); fromi <- addInt(from); toi <- addInt(to)
+                } yield bmgr
+                  .and(imgr.lessOrEquals(fromi, i1), imgr.lessThan(i1, toi))
+              case Or(e1, e2) =>
+                for {
+                  b1 <- addBool(e1); b2 <- addBool(e2)
+                } yield bmgr.or(b1, b2)
+              case And(e1, e2) =>
+                for {
+                  b1 <- addBool(e1); b2 <- addBool(e2)
+                } yield bmgr.and(b1, b2)
+              case Implies(e1, e2) =>
+                for {
+                  b1 <- addBool(e1); b2 <- addBool(e2)
+                } yield bmgr.implication(b1, b2)
+              case Not(e1) => for { b1 <- addBool(e1) } yield bmgr.not(b1)
+              case Eq(e1, e2) if isBool(e1) && isBool(e2) =>
+                for {
+                  b1 <- addBool(e1); b2 <- addBool(e2)
+                } yield bmgr.equivalence(b1, b2)
+              case Eq(e1, e2) if isInt(e1) && isInt(e2) =>
+                for {
+                  b1 <- addInt(e1); b2 <- addInt(e2)
+                } yield imgr.equal(b1, b2)
+              case Neq(e1, e2) if isInt(e1) && isInt(e2) =>
+                for {
+                  b1 <- addInt(e1); b2 <- addInt(e2)
+                } yield bmgr.not(imgr.equal(b1, b2))
+              case Less(e1, e2) if isInt(e1) && isInt(e2) =>
+                for {
+                  b1 <- addInt(e1); b2 <- addInt(e2)
+                } yield imgr.lessThan(b1, b2)
+              case LessEq(e1, e2) if isInt(e1) && isInt(e2) =>
+                for {
+                  b1 <- addInt(e1); b2 <- addInt(e2)
+                } yield imgr.lessOrEquals(b1, b2)
+              case Greater(e1, e2) if isInt(e1) && isInt(e2) =>
+                for {
+                  b1 <- addInt(e1); b2 <- addInt(e2)
+                } yield imgr.greaterThan(b1, b2)
+              case GreaterEq(e1, e2) if isInt(e1) && isInt(e2) =>
+                for {
+                  b1 <- addInt(e1); b2 <- addInt(e2)
+                } yield imgr.greaterOrEquals(b1, b2)
+              case BooleanValue(b) => Some(bmgr.makeBoolean(b))
+              case Local(ref) if isBool(e) =>
+                if (varBoolMap.contains(ref.decl))
+                  Some(varBoolMap(ref.decl))
+                else {
+                  val x = bmgr.makeVariable(s"b$id")
+                  id += 1
+                  varBoolMap(ref.decl) = x
+                  Some(x)
+                }
+              case _ => None
+            }
+          }
+
+          def addInt(e: Expr[G]): Option[IntegerFormula] = {
+            e match {
+              case Select(c, t, f) =>
+                for {
+                  c1 <- addBool(c); t1 <- addInt(t); f1 <- addInt(f)
+                } yield bmgr.ifThenElse(c1, t1, f1)
+              case Plus(e1, e2) =>
+                for {
+                  i1 <- addInt(e1); i2 <- addInt(e2)
+                } yield imgr.add(i1, i2)
+              case Minus(e1, e2) =>
+                for {
+                  i1 <- addInt(e1); i2 <- addInt(e2)
+                } yield imgr.subtract(i1, i2)
+              case Mult(e1, e2) =>
+                for {
+                  i1 <- addInt(e1); i2 <- addInt(e2)
+                } yield imgr.multiply(i1, i2)
+              case FloorDiv(e1, e2) =>
+                for {
+                  i1 <- addInt(e1); i2 <- addInt(e2)
+                } yield imgr.divide(i1, i2)
+              // Ugly, but the SMT library does not allow us to define functions..
+              case TruncDiv(e1, e2) => addInt(tdiv(e1, e2))
+              case TruncMod(e1, e2) => addInt(tmod(e1, e2))
+              case Mod(e1, e2) =>
+                for {
+                  i1 <- addInt(e1); i2 <- addInt(e2)
+                } yield imgr.modulo(i1, i2)
+              case UMinus(e1) => for { i1 <- addInt(e1) } yield imgr.negate(i1)
+              case IntegerValue(i) => Some(imgr.makeNumber(i.toInt))
+              case Local(ref) if isInt(e) =>
+                if (varIntMap.contains(ref.decl))
+                  Some(varIntMap(ref.decl))
+                else {
+                  val x = imgr.makeVariable(s"i$id")
+                  id += 1
+                  varIntMap(ref.decl) = x
+                  Some(x)
+                }
+              case _ => None
+            }
+          }
+
+          for (c <- constraints) {
+            if (!addConstraint(c))
+              return false
+          }
+          if (!addConstraint(!test))
+            return false
+          prover.isUnsat
+        }
+      }
+    }.get.get
+  }
 }
 
 case class InconsistentVariableEquality(v: Local[_], x: BigInt, y: BigInt)
@@ -260,7 +453,13 @@ class ExpressionEqualityCheck[G](info: Option[AnnotationVariableInfo[G]]) {
           }
         }
       case Mod(e1, e2) if isLower => return Some(0)
-      case Mod(e1, e2) => isConstantIntRecurse(e2)
+      case Mod(e1, e2) => isConstantIntRecurse(e2).map(_.abs - 1)
+      case TruncMod(e1, e2) if isLower =>
+        lowerBoundRecurse(e1) match {
+          case Some(l1) if l1 >= 0 => return Some(0)
+          case _ => return isConstantIntRecurse(e2).map(i => -(i.abs - 1))
+        }
+      case TruncMod(e1, e2) => return isConstantIntRecurse(e2).map(_.abs - 1)
       case FloorDiv(e1, e2) if isConstantIntRecurse(e2).isDefined =>
         val divisor = isConstantIntRecurse(e2).get
         if (divisor == 0)

--- a/src/rewrite/vct/rewrite/SimplifyNestedQuantifiers.scala
+++ b/src/rewrite/vct/rewrite/SimplifyNestedQuantifiers.scala
@@ -259,15 +259,21 @@ case class SimplifyNestedQuantifiers[Pre <: Generation]()
           case Starall(_, Nil, _) =>
             val trigger = e.o.inlineContext(false).map(_.last)
               .getOrElse("unknown context")
-            logger.warn(
-              f"The binder `${e.o.shortPositionText}`:`${trigger} contains no triggers`"
-            )
+            // Do not warn for generated non-user code
+            if (trigger != "(empty source region)") {
+              logger.warn(
+                f"The binder ${e.o.shortPositionText}: '${trigger}' contains no triggers"
+              )
+            }
           case Forall(_, Nil, body) =>
             val trigger = e.o.inlineContext(false).map(_.last)
               .getOrElse("unknown context")
-            logger.warn(
-              f"The binder `${e.o.shortPositionText}`:`${trigger} contains no triggers`"
-            )
+            // Do not warn for generated non-user code
+            if (trigger != "(empty source region)") {
+              logger.warn(
+                f"The binder ${e.o.shortPositionText}: '${trigger}' contains no triggers"
+              )
+            }
           case _ =>
         }
         res

--- a/src/rewrite/vct/rewrite/SimplifyNestedQuantifiers.scala
+++ b/src/rewrite/vct/rewrite/SimplifyNestedQuantifiers.scala
@@ -1,29 +1,12 @@
 package vct.col.rewrite
 
-import com.google.common.collect.ImmutableList
 import com.typesafe.scalalogging.LazyLogging
 import hre.util.ScopedStack
-import org.sosy_lab.common.{NativeLibraries, ShutdownNotifier}
-import org.sosy_lab.common.configuration.Configuration
-import org.sosy_lab.common.log.LogManager
-import org.sosy_lab.java_smt.SolverContextFactory
-import org.sosy_lab.java_smt.SolverContextFactory.Solvers
-import org.sosy_lab.java_smt.api.{BooleanFormula, FormulaType}
-import org.sosy_lab.java_smt.api.NumeralFormula.IntegerFormula
-import org.sosy_lab.java_smt.api.SolverContext.ProverOptions
 import vct.col.ast.{Variable, _}
-import vct.col.ast.util.ExpressionEqualityCheck.{Neg, Pos}
+import vct.col.ast.util.ExpressionEqualityCheck.{Neg, Pos, AskSMTSolver}
 import vct.col.ast.util.{AnnotationVariableInfoGetter, ExpressionEqualityCheck}
 import vct.col.rewrite.util.Comparison
-import vct.col.origin.{
-  ArrayInsufficientPermission,
-  DiagnosticOrigin,
-  LabelContext,
-  Origin,
-  PanicBlame,
-  PointerBounds,
-  PreferredName,
-}
+import vct.col.origin.{LabelContext, Origin, PanicBlame, PreferredName}
 import vct.col.ref.Ref
 import vct.col.rewrite.SimplifyNestedQuantifiers.{
   InvalidTrigger,
@@ -59,10 +42,12 @@ import scala.util.Using
   */
 case object SimplifyNestedQuantifiers extends RewriterBuilder {
   override def key: String = "simplifyNestedQuantifiers"
+
   override def desc: String = "Simplify nested quantifiers."
 
   case class NotAllowedInTrigger(e: Expr[_]) extends UserError {
     override def code: String = "notAllowedInTrigger"
+
     override def text: String =
       e.o.messageInContext(
         "Arithmetic and logic operators are not allowed in triggers."
@@ -71,6 +56,7 @@ case object SimplifyNestedQuantifiers extends RewriterBuilder {
 
   case class NotAllowedInTriggerSet(e: Expr[_]) extends UserError {
     override def code: String = "notAllowedInTrigger"
+
     override def text: String =
       e.o.messageInContext(
         "We tried to rewrite multiple trigger sets for this forall, but that is only possible if they contain exactly the same" +
@@ -83,6 +69,7 @@ case object SimplifyNestedQuantifiers extends RewriterBuilder {
       missing: Set[Variable[_]],
   ) extends UserError {
     override def code: String = "invalidTriggerVars"
+
     override def text: String =
       Message.messagesInContext(
         triggers.map(err => err.o -> s"... these triggers.") ++
@@ -93,15 +80,17 @@ case object SimplifyNestedQuantifiers extends RewriterBuilder {
   case class InvalidTrigger(e: Expr[_], reasons: Seq[FailReason])
       extends UserError {
     override def code: String = "invalidTrigger"
+
     override def text: String =
       e.o.messageInContext(
-        "We did not succeed in rewriting this part of the trigger. Because of the following reasons:"
+        "We did not succeed in rewriting this part of the trigger. Because of the following reason:"
       ) ++ reasons.collectFirst { case r: VarNoUpperBound => Seq(r) }
-        .getOrElse(reasons).map(_.text).mkString("\n")
+        .getOrElse(reasons).head.text
   }
 
   case class InvalidTriggerPair(e1: Expr[_], e2: Expr[_]) extends UserError {
     override def code: String = "invalidTrigger"
+
     override def text: String =
       e1.o.messageInContext(
         "We cannot rewrite this pair of triggers, which contain arithmetic," +
@@ -467,7 +456,7 @@ case class SimplifyNestedQuantifiers[Pre <: Generation]()
     })
 
     // We can only rewrite quantifiers that contain at least one integer binding
-    if (!e.bindings.exists(_.t == TInt()))
+    if (!e.bindings.exists(_.t == TInt[Pre]()))
       return None
 
     // We can always try to remove independent variables
@@ -1591,198 +1580,14 @@ case class SimplifyNestedQuantifiers[Pre <: Generation]()
           linExpr: Expr[Pre],
       )
 
-      def isBool(e: Expr[_]): Boolean = {
-        CoercionUtils.getCoercion(e.t, TBool()).isDefined
-      }
-
-      def isInt(e: Expr[_]): Boolean = {
-        CoercionUtils.getCoercion(e.t, TInt()).isDefined
-      }
-
-      case class askSMTSolver(
-          constraints: Iterable[Expr[Pre]],
-          test: Expr[Pre],
-      ) {
-        def check(): Boolean = {
-          val options = Configuration.builder()
-            .setOption("solver.nonLinearArithmetic", "APPROXIMATE_FALLBACK");
-          val config = options.build()
-          val logManager = LogManager.createNullLogManager
-          val shutDown = ShutdownNotifier.createDummy
-          var id = 0
-
-          Using(SolverContextFactory.createSolverContext(
-            config,
-            logManager,
-            shutDown,
-            Solvers.SMTINTERPOL,
-          )) { ctx =>
-            Using(ctx.newProverEnvironment()) { prover =>
-              val fmgr = ctx.getFormulaManager
-              val varIntMap: mutable.Map[Variable[Pre], IntegerFormula] =
-                mutable.Map()
-              val varBoolMap: mutable.Map[Variable[Pre], BooleanFormula] =
-                mutable.Map()
-              val bmgr = fmgr.getBooleanFormulaManager
-              val imgr = fmgr.getIntegerFormulaManager
-
-              def tdiv(a: Expr[Pre], b: Expr[Pre]): Expr[Pre] =
-                Select(
-                  a >= const(0) || a % b === const(0),
-                  a / b,
-                  a / b + Select(b > const(0), const(1), const(-1)),
-                )
-
-              def tmod(a: Expr[Pre], b: Expr[Pre]): Expr[Pre] =
-                Select(
-                  a >= const(0) || a % b === const(0),
-                  a % b,
-                  a % b + Select(b > const(0), b, -b),
-                )
-
-              def addConstraint(e: Expr[Pre]): Boolean = {
-                addBool(e) match {
-                  case Some(b1) => prover.addConstraint(b1); true
-                  case None => false
-                }
-              }
-
-              def addBool(e: Expr[Pre]): Option[BooleanFormula] = {
-                e match {
-                  case Select(c, t, f) =>
-                    for {
-                      c1 <- addBool(c); t1 <- addBool(t); f1 <- addBool(f)
-                    } yield bmgr.ifThenElse(c1, t1, f1)
-                  case SeqMember(e1, Range(from, to)) =>
-                    for {
-                      i1 <- addInt(e1); fromi <- addInt(from); toi <- addInt(to)
-                    } yield bmgr
-                      .and(imgr.lessOrEquals(fromi, i1), imgr.lessThan(i1, toi))
-                  case SetMember(e1, RangeSet(from, to)) =>
-                    for {
-                      i1 <- addInt(e1); fromi <- addInt(from); toi <- addInt(to)
-                    } yield bmgr
-                      .and(imgr.lessOrEquals(fromi, i1), imgr.lessThan(i1, toi))
-                  case Or(e1, e2) =>
-                    for {
-                      b1 <- addBool(e1); b2 <- addBool(e2)
-                    } yield bmgr.or(b1, b2)
-                  case And(e1, e2) =>
-                    for {
-                      b1 <- addBool(e1); b2 <- addBool(e2)
-                    } yield bmgr.and(b1, b2)
-                  case Implies(e1, e2) =>
-                    for {
-                      b1 <- addBool(e1); b2 <- addBool(e2)
-                    } yield bmgr.implication(b1, b2)
-                  case Not(e1) => for { b1 <- addBool(e1) } yield bmgr.not(b1)
-                  case Eq(e1, e2) if isBool(e1) && isBool(e2) =>
-                    for {
-                      b1 <- addBool(e1); b2 <- addBool(e2)
-                    } yield bmgr.equivalence(b1, b2)
-                  case Eq(e1, e2) if isInt(e1) && isInt(e2) =>
-                    for {
-                      b1 <- addInt(e1); b2 <- addInt(e2)
-                    } yield imgr.equal(b1, b2)
-                  case Neq(e1, e2) if isInt(e1) && isInt(e2) =>
-                    for {
-                      b1 <- addInt(e1); b2 <- addInt(e2)
-                    } yield bmgr.not(imgr.equal(b1, b2))
-                  case Less(e1, e2) if isInt(e1) && isInt(e2) =>
-                    for {
-                      b1 <- addInt(e1); b2 <- addInt(e2)
-                    } yield imgr.lessThan(b1, b2)
-                  case LessEq(e1, e2) if isInt(e1) && isInt(e2) =>
-                    for {
-                      b1 <- addInt(e1); b2 <- addInt(e2)
-                    } yield imgr.lessOrEquals(b1, b2)
-                  case Greater(e1, e2) if isInt(e1) && isInt(e2) =>
-                    for {
-                      b1 <- addInt(e1); b2 <- addInt(e2)
-                    } yield imgr.greaterThan(b1, b2)
-                  case GreaterEq(e1, e2) if isInt(e1) && isInt(e2) =>
-                    for {
-                      b1 <- addInt(e1); b2 <- addInt(e2)
-                    } yield imgr.greaterOrEquals(b1, b2)
-                  case BooleanValue(b) => Some(bmgr.makeBoolean(b))
-                  case Local(ref) if isBool(e) =>
-                    if (varBoolMap.contains(ref.decl))
-                      Some(varBoolMap(ref.decl))
-                    else {
-                      val x = bmgr.makeVariable(s"b$id")
-                      id += 1
-                      varBoolMap(ref.decl) = x
-                      Some(x)
-                    }
-                  case _ => None
-                }
-              }
-
-              def addInt(e: Expr[Pre]): Option[IntegerFormula] = {
-                e match {
-                  case Select(c, t, f) =>
-                    for {
-                      c1 <- addBool(c); t1 <- addInt(t); f1 <- addInt(f)
-                    } yield bmgr.ifThenElse(c1, t1, f1)
-                  case Plus(e1, e2) =>
-                    for {
-                      i1 <- addInt(e1); i2 <- addInt(e2)
-                    } yield imgr.add(i1, i2)
-                  case Minus(e1, e2) =>
-                    for {
-                      i1 <- addInt(e1); i2 <- addInt(e2)
-                    } yield imgr.subtract(i1, i2)
-                  case Mult(e1, e2) =>
-                    for {
-                      i1 <- addInt(e1); i2 <- addInt(e2)
-                    } yield imgr.multiply(i1, i2)
-                  case FloorDiv(e1, e2) =>
-                    for {
-                      i1 <- addInt(e1); i2 <- addInt(e2)
-                    } yield imgr.divide(i1, i2)
-                  // Ugly, but the SMT library does not allow us to define functions..
-                  case TruncDiv(e1, e2) => addInt(tdiv(e1, e2))
-                  case TruncMod(e1, e2) => addInt(tmod(e1, e2))
-                  case Mod(e1, e2) =>
-                    for {
-                      i1 <- addInt(e1); i2 <- addInt(e2)
-                    } yield imgr.modulo(i1, i2)
-                  case UMinus(e1) =>
-                    for { i1 <- addInt(e1) } yield imgr.negate(i1)
-                  case IntegerValue(i) => Some(imgr.makeNumber(i.toInt))
-                  case Local(ref) if isInt(e) =>
-                    if (varIntMap.contains(ref.decl))
-                      Some(varIntMap(ref.decl))
-                    else {
-                      val x = imgr.makeVariable(s"i$id")
-                      id += 1
-                      varIntMap(ref.decl) = x
-                      Some(x)
-                    }
-                  case _ => None
-                }
-              }
-
-              for (c <- constraints) {
-                if (!addConstraint(c))
-                  return false
-              }
-              if (!addConstraint(!test))
-                return false
-              prover.isUnsat
-            }
-          }
-        }.get.get
-      }
-
       // Check in the other bounds if the specific expressions is present by a bound
       def isExprUpperBounded(
           e: Expr[Pre],
           boundRequired: Expr[Pre],
       ): Boolean = {
         // We are now officially desperate, so we are going to call the help of an SMT solver
-        val smt = askSMTSolver(quantifierData.constraints, e < boundRequired)
-        return smt.check()
+        val smt = AskSMTSolver(quantifierData.constraints, e < boundRequired)
+        smt.check()
       }
 
       /* We try to find a bound for x_{i-1} (xPrev). Thus a 'low' and 'up': low_{i-1} <= x_{i-1} < up_{i-1}
@@ -1836,7 +1641,7 @@ case class SimplifyNestedQuantifiers[Pre <: Generation]()
 
             // Check 1
             val rhs = simplifiedMult(aLast, nLastCandidate)
-            val smt = askSMTSolver(quantifierData.constraints, Eq(a, rhs))
+            val smt = AskSMTSolver(quantifierData.constraints, Eq(a, rhs))
             if (equalityChecker.equalExpressions(a, rhs) || smt.check()) {
               // For this check, it doesn't matter that n could be zero.
               // But if it is possibly zero, we need to make sure the quantifier domain is empty
@@ -1862,7 +1667,7 @@ case class SimplifyNestedQuantifiers[Pre <: Generation]()
             // Check 2
             val right = simplifiedMult(abs(aLast, sign), nLastCandidate)
             val left = abs(a, sign)
-            val smt2 = askSMTSolver(quantifierData.constraints, right <= left)
+            val smt2 = AskSMTSolver(quantifierData.constraints, right <= left)
             if (
               hasSameSign &&
               (equalityChecker.lessThenEq(right, left).getOrElse(false) ||

--- a/src/rewrite/vct/rewrite/lang/LangCToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangCToCol.scala
@@ -49,6 +49,12 @@ case object LangCToCol {
       )
   }
 
+  private case class WrongGPUDimension(o: Origin) extends UserError {
+    override def code: String = "wrongGPUDimension"
+    override def text: String =
+      o.messageInContext(s"We only support GPU dimensions up to size 3.")
+  }
+
   private case class WrongCType(decl: Declaration[_]) extends UserError {
     override def code: String = "wrongCType"
     override def text: String =
@@ -940,12 +946,53 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
     }
   }
 
+  def workDimConstrained(e: Expr[Pre]): Seq[RefCudaVecDim[Pre]] = {
+    def res(i: BigInt): Seq[RefCudaVecDim[Pre]] = {
+      var res = Seq[RefCudaVecDim[Pre]]()
+      if (i > 3)
+        throw WrongGPUDimension(e.o)
+      if (i < 3)
+        res =
+          res ++ Seq(
+            RefCudaVecZ[Pre](RefCudaThreadIdx()),
+            RefCudaVecZ[Pre](RefCudaBlockIdx()),
+          )
+      if (i < 2)
+        res =
+          res ++ Seq(
+            RefCudaVecY[Pre](RefCudaThreadIdx()),
+            RefCudaVecY[Pre](RefCudaBlockIdx()),
+          )
+      res
+    }
+
+    e match {
+      case AmbiguousEq(
+            inv @ CInvocation(_, Nil, Nil, Nil, _),
+            CIntegerValue(i, _),
+            _,
+            _,
+          ) if inv.ref.get.name == "get_work_dim" =>
+        res(i)
+      case AmbiguousEq(
+            CIntegerValue(i, _),
+            inv @ CInvocation(_, Nil, Nil, Nil, _),
+            _,
+            _,
+          ) if inv.ref.get.name == "get_work_dim" =>
+        res(i)
+      case _ => Seq()
+    }
+  }
+
   def dimsOfSize1(
       contract: ApplicableContract[Pre]
   ): Seq[RefCudaVecDim[Pre]] = {
     val UnitAccountedPredicate(contractRequires: Expr[Pre]) = contract.requires
-    (unfoldStar(contractRequires).flatMap(dimsOfSize1Expr) ++
-      unfoldStar(contract.contextEverywhere).flatMap(dimsOfSize1Expr)).distinct
+    (unfoldStar(contractRequires)
+      .flatMap(e => dimsOfSize1Expr(e) ++ workDimConstrained(e)) ++
+      unfoldStar(contract.contextEverywhere)
+        .flatMap(e => dimsOfSize1Expr(e) ++ workDimConstrained(e))).distinct
   }
 
   def kernelProcedure(
@@ -2166,6 +2213,10 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
     }
   }
 
+  def getGpuIdx[A](s: Seq[A], i: Int, o: Origin): A = {
+    s.applyOrElse(i, (_: Int) => throw WrongGPUDimension(o))
+  }
+
   /** Returns the local id of a thread in a given dimension.
     * @param index
     *   \- the dimension for which we want the thread id
@@ -2181,7 +2232,7 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
       RefCudaVecY[Pre](RefCudaThreadIdx()),
       RefCudaVecZ[Pre](RefCudaThreadIdx()),
     )
-    val v = idxs(index)
+    val v = getGpuIdx(idxs, index, o)
     cudaConstantDims.top.indices
       .getOrElse(v, cudaCurrentThreadIdx.top.indices(v)).get
   }
@@ -2201,7 +2252,7 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
       RefCudaVecY[Pre](RefCudaBlockIdx()),
       RefCudaVecZ[Pre](RefCudaBlockIdx()),
     )
-    val v = idxs(index)
+    val v = getGpuIdx(idxs, index, o)
     cudaConstantDims.top.indices
       .getOrElse(v, cudaCurrentBlockIdx.top.indices(v)).get
   }
@@ -2216,7 +2267,7 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
     */
   def getCudaLocalSize(index: Int, origin: Origin): Expr[Post] = {
     implicit val o: Origin = origin
-    cudaCurrentBlockDim.top.indices.values.toSeq.apply(index).get
+    getGpuIdx(cudaCurrentBlockDim.top.indices.values.toSeq, index, o).get
   }
 
   /** Returns the global size of a given dimension.
@@ -2229,7 +2280,7 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
     */
   def getCudaGroupSize(index: Int, o: Origin): Expr[Post] = {
     implicit val origin: Origin = o
-    cudaCurrentGridDim.top.indices.values.toSeq.apply(index).get
+    getGpuIdx(cudaCurrentGridDim.top.indices.values.toSeq, index, o).get
   }
 
   /** Rewrites a LocalThreadId and translates it to a linear ID value. The
@@ -2302,7 +2353,7 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
     val arg =
       if (args.size == 1) {
         args.head match {
-          case CIntegerValue(i, _) if i >= 0 && i < 3 => Some(i.toInt)
+          case CIntegerValue(i, _) => Some(i.toInt)
           case _ => None
         }
       } else

--- a/src/rewrite/vct/rewrite/lang/LangCToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangCToCol.scala
@@ -935,6 +935,25 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
         case _ => None
       }
 
+    def openClVec(name: String, idx: Expr[Pre]): Option[RefCudaVecDim[Pre]] = {
+      val dims = Seq[RefCudaVec[Pre] => RefCudaVecDim[Pre]](
+        RefCudaVecX[Pre],
+        RefCudaVecY[Pre],
+        RefCudaVecZ[Pre],
+      )
+      idx match {
+        case CIntegerValue(i, _) if i >= 0 && i < 3 =>
+          val dim = dims(i.toInt)
+          if (name == "get_local_size")
+            Some(dim(RefCudaThreadIdx()))
+          else if (name == "get_num_groups")
+            Some(dim(RefCudaBlockIdx()))
+          else
+            None
+        case _ => None
+      }
+    }
+
     e match {
       case AmbiguousEq(acc: CFieldAccess[Pre], CIntegerValue(i, _), _, _)
           if i == 1 =>
@@ -942,6 +961,12 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
       case AmbiguousEq(CIntegerValue(i, _), acc: CFieldAccess[Pre], _, _)
           if i == 1 =>
         cudaVec(acc.ref.get)
+      case AmbiguousEq(CIntegerValue(i, _), inv: CInvocation[Pre], _, _)
+          if i == 1 && inv.args.size == 1 =>
+        openClVec(inv.ref.get.name, inv.args.head)
+      case AmbiguousEq(inv: CInvocation[Pre], CIntegerValue(i, _), _, _)
+          if i == 1 && inv.args.size == 1 =>
+        openClVec(inv.ref.get.name, inv.args.head)
       case _ => None
     }
   }

--- a/test/main/vct/rewrite/ExpressionEqualitySpec.scala
+++ b/test/main/vct/rewrite/ExpressionEqualitySpec.scala
@@ -51,10 +51,10 @@ class ExpressionEqualitySpec extends AnyFlatSpec with Matchers {
 
   it should "SMT should prove correct about (c def) 10%3==1 " in {
     val smt = AskSMTSolver(Seq(),
-      TruncDiv(c(10), c(3))(blame) === c(1) &&
-        TruncDiv(c(10), c(-3))(blame) === c(1) &&
-        TruncDiv(c(-10), c(3))(blame) === c(-1) &&
-        TruncDiv(c(-10), c(-3))(blame) === c(-1)
+      TruncMod(c(10), c(3))(blame) === c(1) &&
+        TruncMod(c(10), c(-3))(blame) === c(1) &&
+        TruncMod(c(-10), c(3))(blame) === c(-1) &&
+        TruncMod(c(-10), c(-3))(blame) === c(-1)
     )
     assert(smt.check())
   }

--- a/test/main/vct/rewrite/ExpressionEqualitySpec.scala
+++ b/test/main/vct/rewrite/ExpressionEqualitySpec.scala
@@ -1,0 +1,71 @@
+package vct.rewrite
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import vct.col.ast._
+import vct.col.ast.util.ExpressionEqualityCheck.AskSMTSolver
+import vct.col.origin._
+import vct.col.rewrite.InitialGeneration
+import vct.col.util.AstBuildHelpers._
+
+class ExpressionEqualitySpec extends AnyFlatSpec with Matchers {
+  type G = InitialGeneration
+  implicit val o: Origin = DiagnosticOrigin
+  implicit val blame: Blame[VerificationFailure] = PanicBlame("")
+  val xs_ = new Variable[G](TArray[G](TInt[G]()))
+  val xs = Local[G](xs_.ref)
+
+  val xmin_ =
+    for (xmin <- 0 until 10)
+      yield (new Variable[G](TInt[G]())(o.where(name=s"xmin$xmin")))
+  val xmin: Seq[Expr[G]] =
+    for (xmin <- xmin_)
+      yield (Local[G](xmin.ref))
+
+  val ns_ =
+    for (n <- 0 until 10)
+      yield (new Variable[G](TInt[G]())(o.where(name=s"ns$n")))
+  val ns: Seq[Expr[G]] =
+    for (n <- ns_)
+      yield (Local[G](n.ref))
+  val as_ =
+    for (a <- 0 until 10)
+      yield (new Variable[G](TInt[G]())(o.where(name=s"as$a")))
+  val as: Seq[Expr[G]] =
+    for (n <- as_)
+      yield (Local[G](n.ref))
+
+
+  def c(i: Int) = const[G](i)
+  def abs(e: Expr[G]) = Select(e >= const(0), e, -e)
+
+  it should "SMT should prove correct about 0<=x % 4 <4" in {
+    val smt = AskSMTSolver(Seq(), as(0) % c(4) < c(4) && as(0) % c(4) >= c(0) )
+    assert(smt.check())
+  }
+
+  it should "SMT should prove correct about (c def) -4 < x % 4 < 4 " in {
+    val smt = AskSMTSolver(Seq(), TruncMod(as(0), c(4))(blame) < c(4) && TruncMod(as(0), c(4))(blame) > -c(4) )
+    assert(smt.check())
+  }
+
+  it should "SMT should prove correct about (c def) 10%3==1 " in {
+    val smt = AskSMTSolver(Seq(),
+      TruncDiv(c(10), c(3))(blame) === c(1) &&
+        TruncDiv(c(10), c(-3))(blame) === c(1) &&
+        TruncDiv(c(-10), c(3))(blame) === c(-1) &&
+        TruncDiv(c(-10), c(-3))(blame) === c(-1)
+    )
+    assert(smt.check())
+  }
+
+  it should "SMT should prove correct about (c def) 10/3==3 " in {
+    val smt = AskSMTSolver(Seq(),
+      TruncDiv(c(10), c(3))(blame) === c(3) &&
+        TruncDiv(c(10), c(-3))(blame) === c(-3) &&
+        TruncDiv(c(-10), c(3))(blame) === c(-3) &&
+        TruncDiv(c(-10), c(-3))(blame) === c(3)
+    )
+    assert(smt.check())
+  }
+}

--- a/test/main/vct/rewrite/NestedQuantifiersRewrite.scala
+++ b/test/main/vct/rewrite/NestedQuantifiersRewrite.scala
@@ -9,7 +9,6 @@ import vct.col.rewrite.InitialGeneration
 import vct.col.util.AstBuildHelpers._
 import vct.helper.ColHelper
 
-
 class NestedQuantifiersRewrite extends AnyFlatSpec with Matchers {
   type G = InitialGeneration
   implicit val o: Origin = DiagnosticOrigin

--- a/test/main/vct/test/integration/examples/GpgpuSpec.scala
+++ b/test/main/vct/test/integration/examples/GpgpuSpec.scala
@@ -15,6 +15,18 @@ class GpgpuSpec extends VercorsSpec {
   vercors should verify using silicon example "concepts/gpgpu/static_shared_opencl.cl"
 
   vercors should verify using silicon example "concepts/gpgpu/global_fence_opencl.cl"
+
+  vercors should error withCode "wrongGPUDimension" in "Wrong gpu dimension" c """
+#include <opencl.h>
+
+
+/*@
+  context get_local_size(4) == 32;
+@*/
+__kernel void addArrays(__global int* a) {
+    return;
+}
+    """
   // https://github.com/utwente-fmt/vercors/issues/852
   // vercors should verify using silicon example "concepts/gpgpu/GPGPU-Example-updates.cu"
   // https://github.com/utwente-fmt/vercors/issues/856


### PR DESCRIPTION
Few things:

I realized that many of the opencl vectors had wrong annotations. Indexing was all `...[2*tid+...]` but should be `...[s*tid+...]` for vector of size `s`.

I encoded TruncMod wrongly in the the AsmSMTSolver. I've placed it now in equalityChecker pass, and added a few unit tests to ensure it is correct now.

Lastly opencl was not getting that dimensions were constant, now it does. I've also added to shortcut of using 'get_work_dim()==1`