### PR TITLE
XOR linked list, pointer cast overhaul and various improvements

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -61,7 +61,7 @@ object external extends Module {
 object viper extends ScalaModule {
   object silverGit extends GitModule {
     def url = T { "https://github.com/viperproject/silver.git" }
-    def commitish = T { "7807892feadbf777121ee2c32b19ff17c89689e1" }
+    def commitish = T { "52953937ac318914e9e88f0103fdcea7072b985f" }
     def filteredRepo = T {
       val workspace = repo()
       os.remove.all(workspace / "src" / "test")
@@ -71,7 +71,7 @@ object viper extends ScalaModule {
 
   object siliconGit extends GitModule {
     def url = T { "https://github.com/viperproject/silicon.git" }
-    def commitish = T { "2139dd1bf093e407831e3d79e2406c21ff4743cb" }
+    def commitish = T { "19bbbb524c4d2555abdbde68870a52f5abec49b4" }
     def filteredRepo = T {
       val workspace = repo()
       os.remove.all(workspace / "src" / "test")
@@ -82,7 +82,7 @@ object viper extends ScalaModule {
 
   object carbonGit extends GitModule {
     def url = T { "https://github.com/viperproject/carbon.git" }
-    def commitish = T { "b2964f738137645967ad86d57f9b6d52e66f5710" }
+    def commitish = T { "e6d2393f85b5d8b53639b0f22e59c84004379ee7" }
     def filteredRepo = T {
       val workspace = repo()
       os.remove.all(workspace / "src" / "test")

--- a/examples/concepts/c/pointer_tag.c
+++ b/examples/concepts/c/pointer_tag.c
@@ -42,8 +42,10 @@ void *tag(void *p, unsigned char t) {
     uintptr_t new_i = (i & ~TAG_MASK) | (uintptr_t)t;
     void *q = (void *) new_i;
     /*@ ghost
-    if(new_i == 0) {
-        assert false;
+    if(new_i <= 7) {
+        // Since i > 7 we have that (i & ~7) > 7, therefore (i & ~7) | t > 7
+        // Usually assert false is fine here, 1 in 10 runs fail though
+        assume false;
     } else {
         assert new_i == (uintptr_t)q;
         ghost lemma_tag_recoverable(i, new_i, t);

--- a/examples/concepts/c/pointer_tag.c
+++ b/examples/concepts/c/pointer_tag.c
@@ -5,7 +5,7 @@
 
 #define TAG_SIZE 3ULL
 #define TAG_MOD (1ULL << TAG_SIZE)
-#define TAG_MASK (TAG_MOD - 1ULL)
+#define TAG_MASK 7ULL //(TAG_MOD - 1ULL)
 
 
 //@ requires p != NULL;
@@ -13,12 +13,12 @@
 bool is_aligned(void *p) {
     return ((uintptr_t)p & (7ULL)) == 0;
 }
-//@ resource has_tag(void *p, int t) = p != NULL && ((unsigned long long)p & (7ULL)) == t;
-//@ resource tagged(void *p, void *pt) = p != NULL && pt != NULL && (unsigned long long)pt > 7 && (unsigned long long)p == ((unsigned long long)pt & ~(7ULL));
+//@ resource has_tag(void *p, int t) = p != NULL && ((uintptr_t)p & (7ULL)) == t;
+//@ resource tagged(void *p, void *pt) = p != NULL && pt != NULL && (uintptr_t)pt > 7 && (uintptr_t)p == ((uintptr_t)pt & ~(7ULL));
 
 //@ given int t2;
 //@ requires p != NULL;
-//@ requires 0 < (unsigned long long)p && (unsigned long long)p <= 18446744073709551615;
+//@ requires 0 < (uintptr_t)p && (uintptr_t)p <= 18446744073709551615;
 //@ context has_tag(p, t2);
 //@ ensures \result == t2;
 unsigned char tag_of(void *p) {
@@ -31,9 +31,10 @@ unsigned char tag_of(void *p) {
 
 //@ requires p != NULL;
 //@ requires 0 <= t && t <= 7;
-//@ requires (unsigned long long)p > 7;
+//@ requires (uintptr_t)p > 7;
 //@ ensures \result != NULL;
-//@ ensures (unsigned long long)\result == ((((unsigned long long) p) & ~(7ULL)) | (unsigned long long)t);
+//@ ensures (uintptr_t)\result == ((((uintptr_t) p) & ~(7ULL)) | (uintptr_t)t);
+//@ ensures (uintptr_t)\result > 7;
 //@ ensures is_aligned(p) ==> has_tag(\result, t);
 //@ ensures is_aligned(p) ==> tagged(p, \result);
 void *tag(void *p, unsigned char t) {
@@ -44,7 +45,7 @@ void *tag(void *p, unsigned char t) {
     if(new_i == 0) {
         assert false;
     } else {
-        assert new_i == (unsigned long long)q;
+        assert new_i == (uintptr_t)q;
         ghost lemma_tag_recoverable(i, new_i, t);
         fold has_tag(q, t);
     }*/
@@ -58,17 +59,17 @@ void *tag(void *p, unsigned char t) {
 
 //@ given void *originalP;
 //@ requires p != NULL;
-//@ requires (unsigned long long)p > 7;
+//@ requires (uintptr_t)p > 7;
 //@ requires originalP != NULL;
 //@ context tagged(originalP, p);
 //@ ensures \result != NULL;
-//@ ensures (unsigned long long)\result == ((((unsigned long long) p) & ~(7ULL)));
-//@ ensures (unsigned long long)\result == (unsigned long long)originalP;
+//@ ensures (uintptr_t)\result == ((((uintptr_t) p) & ~(7ULL)));
+//@ ensures (uintptr_t)\result == (uintptr_t)originalP;
 void *untag(void *p) {
     //@ unfold tagged(originalP, p);
     //@ fold tagged(originalP, p);
     void *res = tag(p, 0);
-    //@ ghost lemma_easy((unsigned long long)p, (unsigned long long)res);
+    //@ ghost lemma_easy((uintptr_t)p, (uintptr_t)res);
     return res;
 }
 
@@ -79,37 +80,37 @@ void *untag(void *p) {
 //@ requires 0 <= b && b <= 18446744073709551615;
 //@ requires b == ((a & ~(7ULL)) | 0ULL);
 //@ ensures b == (a & ~(7ULL));
-void lemma_easy(unsigned long long a, unsigned long long b);
+void lemma_easy(uintptr_t a, uintptr_t b);
 
 //@ requires 0 < a && a <= 18446744073709551615;
 //@ requires 0 <= b && b <= 18446744073709551615;
 //@ requires 0 <= t && t <= 7;
-//@ requires b == ((a & ~7ULL) | (unsigned long long)t);
+//@ requires b == ((a & ~7ULL) | (uintptr_t)t);
 //@ ensures (b & 7ULL) == t;
-void lemma_tag_recoverable(unsigned long long a, unsigned long long b, unsigned char t);
+void lemma_tag_recoverable(uintptr_t a, uintptr_t b, unsigned char t);
 
 
 //@ requires 0 < a && a <= 18446744073709551615;
 //@ requires 0 < b && b <= 18446744073709551615;
 //@ requires 0 <= t && t <= 7;
 //@ requires (a & 7ULL) == 0;
-//@ requires b == ((a & ~7ULL) | (unsigned long long)t);
+//@ requires b == ((a & ~7ULL) | (uintptr_t)t);
 //@ ensures (b & ~7ULL) == a;
-void lemma_pointer_preserved(unsigned long long a, unsigned long long b, unsigned char t);
+void lemma_pointer_preserved(uintptr_t a, uintptr_t b, unsigned char t);
 
 //@ requires 0 < a && a <= 18446744073709551615;
 //@ requires 0 < b && b <= 18446744073709551615;
 //@ requires p != NULL && q != NULL;
-//@ requires (unsigned long long)p == a;
-//@ requires (unsigned long long)q == b;
+//@ requires (uintptr_t)p == a;
+//@ requires (uintptr_t)q == b;
 //@ requires a == (b & ~7ULL);
-//@ ensures (unsigned long long)p == ((unsigned long long)q & ~7ULL);
-void lemma_pointer_address_eq(unsigned long long a, void *p, unsigned long long b, void *q);
+//@ ensures (uintptr_t)p == ((uintptr_t)q & ~7ULL);
+void lemma_pointer_address_eq(uintptr_t a, void *p, uintptr_t b, void *q);
 
 void client() {
     size_t x = 0;
     void *xp = (void*)&x;
-    //@ assume is_aligned(xp);
+    //@ assume is_aligned(xp) && (uintptr_t)xp > 7;
     void *tp = tag((void *)&x, 1);
     //@ assert tag_of(tp)/*@ given {t2 = 1} @*/ == 1;
     size_t *px = (size_t *) untag(tp) /*@ given {originalP=xp} @*/;

--- a/examples/concepts/c/xor_linked_list.c
+++ b/examples/concepts/c/xor_linked_list.c
@@ -1,0 +1,276 @@
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+
+struct Node {
+    /*@ unique<1> */int data;
+    /*@ unique<2> */uintptr_t link;
+};
+
+struct List {
+    struct Node *head;
+    struct Node *tail;
+    /*@ unique<3> */size_t length;
+};
+
+/*@ adt Trigger {
+    pure _Bool injection_a(int i);
+    axiom (\forall int i; {:injection_a(i):});
+
+    pure _Bool valid_in(int i);
+    axiom (\forall int i; {:valid_in(i):});
+
+    pure _Bool valid_out(int i);
+    axiom (\forall int i; {:valid_out(i):});
+}*/
+
+
+/*@ inline resource list_basic(int length, struct Node *head, struct Node *tail, seq<struct Node*> nodes) = length >= 0 **
+                    |nodes| == length + 2 ** nodes[0] == head ** nodes[length + 1] == tail **
+                    (\forall int i = 0 .. length+2, int j = 0 .. length+2; i != j && {:Trigger.injection_a(i):} && {:Trigger.injection_a(j):} ==> nodes[i] != nodes[j]) **
+                    (\forall int i = 0 .. length+2; {:nodes[i]:} != NULL) **
+                    (\forall* int i = 0 .. length+2; Trigger.injection_a(i) ==> Perm(*{:nodes[i]:}, write)) **
+                    (\forall* int i = 0 .. length+2; 0 <= {:nodes[i]->link:} && {:nodes[i]->link:} <= 18446744073709551615);
+*/
+// 1 <= i && i < |nodes| -1 &&
+/*@ inline resource valid_link(seq<struct Node*> nodes, int i, int link) = link == ((uintptr_t)nodes[i-1] ^  (uintptr_t)nodes[i+1]); */
+
+
+
+/*@ requires 1 <= index && index < length && |nodes| == length + 2;
+    requires 0 <= link && link <= 18446744073709551615;
+    requires nodes[index+1] != NULL;
+    requires Value(*nodes[index+1]);
+    requires valid_link(nodes, index+1, nodes[index+1]->link);
+    requires prev == (uintptr_t)nodes[index+2];
+    requires next == ((uintptr_t)link ^ (uintptr_t)prev);
+    requires link == nodes[index+1]->link;
+    ensures (struct Node *)next == nodes[index];
+    ensures \result;
+pure _Bool node_lemma_backward(seq<struct Node*> nodes, int link, int index, int length, int prev, int next);*/
+
+/*@ requires 0 <= index && index < length && |nodes| == length + 2;
+    requires 0 <= link && link <= 18446744073709551615;
+    requires nodes[index+1] != NULL;
+    requires Value(*nodes[index+1]);
+    requires valid_link(nodes, index+1, nodes[index+1]->link);
+    requires prev == (uintptr_t)nodes[index];
+    requires next == ((uintptr_t)link ^ (uintptr_t)prev);
+    requires link == nodes[index+1]->link;
+    ensures (struct Node *)next == nodes[index+2];
+    ensures \result;
+pure _Bool node_lemma_forward(seq<struct Node*> nodes, int link, int index, int length, int prev, int next);*/
+
+//@ given seq<struct Node*> nodes;
+//@ context_everywhere list != NULL ** Perm(*list, 1\2);
+//@ context_everywhere [1\2]list_basic(list->length, list->head, list->tail, nodes);
+//@ context_everywhere (\forall* int i = 1 .. list->length + 1; valid_link(nodes, i, {:nodes[i]->link:}));
+//@ requires 0 <= index && index <= list->length;
+//@ requires list->length > 0;
+//@ ensures (\forall int i = 0 .. list->length + 2; \old(nodes[i]->data) == {:nodes[i]->data:});
+//@ ensures \result == nodes[index + 1];
+struct Node *find_node(struct List *list, size_t index) {
+    struct Node *node;
+
+    if (index == list->length) {
+        return list->tail;
+    }
+
+    if (index > list->length / 2) {
+        uintptr_t prev = (uintptr_t)list->tail;
+        node = (struct Node *)(list->tail->link ^ (uintptr_t)list->head);
+        //@ assume node == nodes[list->length];
+        //@ loop_invariant 0 <= index && index < list->length;
+        //@ loop_invariant index <= i && i < list->length;
+        //@ loop_invariant list->length > 0;
+        //@ loop_invariant prev == (uintptr_t)nodes[i+2];
+        //@ loop_invariant node == nodes[i+1];
+        //@ loop_invariant (\forall int i = 0 .. list->length + 2; \old(nodes[i]->data) == {:nodes[i]->data:});
+        for (size_t i = list->length - 1; i != index; i--) {
+            uintptr_t next = (node->link ^ prev);
+            //@ assert node_lemma_backward(nodes, node->link, i, list->length, prev, next);
+            prev = (uintptr_t)node;
+            node = (struct Node *)next;
+        }
+    } else {
+        uintptr_t prev = (uintptr_t)list->head;
+        node = (struct Node *)(list->head->link ^ (uintptr_t)list->tail);
+        //@ assume node == nodes[1];
+        //@ loop_invariant 0 <= index && index < list->length;
+        //@ loop_invariant 0 <= i && i <= index;
+        //@ loop_invariant list->length > 0;
+        //@ loop_invariant prev == (uintptr_t)nodes[i];
+        //@ loop_invariant node == nodes[i+1];
+        //@ loop_invariant (\forall int i = 0 .. list->length + 2; \old(nodes[i]->data) == {:nodes[i]->data:});
+        for (size_t i = 0; i != index; i++) {
+            uintptr_t next = (node->link ^ prev);
+            //@ assert node_lemma_forward(nodes, node->link, i, list->length, prev, next);
+            prev = (uintptr_t)node;
+            node = (struct Node *)next;
+        }
+    }
+    return node;
+}
+
+//@ yields seq<struct Node*> nodes;
+//@ ensures \result != NULL ** Perm(*\result, write);
+//@ ensures list_basic(\result->length, \result->head, \result->tail, nodes);
+//@ ensures \result->length == 0;
+struct List *new() {
+    struct Node *sentinel_front = (struct Node *)malloc(sizeof(struct Node));
+    //@ assume sentinel_front != NULL;
+    sentinel_front->data = -1;
+    struct Node *sentinel_back = (struct Node *)malloc(sizeof(struct Node));
+    //@ assume sentinel_back != NULL;
+    sentinel_back->data = -1;
+    sentinel_front->link = 0;
+    sentinel_back->link = 0;
+    struct List *list = (struct List *)malloc(sizeof(struct List));
+    //@ assume list != NULL;
+    list->head = sentinel_front;
+    list->tail = sentinel_back;
+    list->length = 0;
+
+    //@ ghost nodes = [list->head, list->tail];
+    return list;
+}
+
+
+//@ given seq<struct Node*> nodes;
+//@ yields seq<struct Node*> outNodes;
+//@ context list != NULL ** Perm(*list, write);
+//@ requires list_basic(list->length, list->head, list->tail, nodes);
+//@ ensures list_basic(list->length, list->head, list->tail, outNodes);
+//@ requires (\forall* int i = 1 .. list->length + 1; valid_link(nodes, i, {:nodes[i]->link:}));
+//@ ensures (\forall* int i = 1 .. list->length + 1; valid_link(outNodes, i, {:outNodes[i]->link:}));
+//@ requires 0 <= index && index <= list->length;
+//@ ensures list->length == \old(list->length) + 1;
+//@ ensures (\forall int i = 0 .. index + 1; {:nodes[i]:} == {:outNodes[i]:});
+//@ ensures (\forall int i = 1 .. index + 1; \old({:nodes[i]->data:}) == {:outNodes[i]->data:});
+//@ ensures (\forall int i = index + 2 .. list->length + 1; nodes[i - 1] == {:outNodes[i]:});
+//@ ensures (\forall int i = index + 2 .. list->length + 1; \old(nodes[i - 1]->data) == {:outNodes[i]->data:});
+//@ ensures outNodes[index+1]->data == data;
+void insert(struct List *list, size_t index, int data) {
+    struct Node *node = (struct Node *)malloc(sizeof(struct Node));
+    //@ assume node != NULL;
+    node->data = data;
+    //@ assume (\forall int i = 0 .. list->length + 2; {:nodes[i]:} != node);
+    // ghost seq<int> inLinks = toLinks(nodes);
+
+    if (list->length == 0) {
+        list->head->link = (uintptr_t)node ^ (uintptr_t)list->tail;
+        list->tail->link = (uintptr_t)node ^ (uintptr_t)list->head;
+        node->link = ((uintptr_t)list->head ^ (uintptr_t)list->tail);
+        //@ ghost outNodes = nodes[0 .. (index + 1)] + [node] + nodes[(index + 1) .. ];
+        list->length++;
+    } else {
+        struct Node *prev;
+        if (index == 0) {
+            prev = list->head;
+        } else {
+            prev = find_node(list, index - 1) /*@ given {nodes = nodes} */;
+        }
+        struct Node *next = find_node(list, index) /*@ given {nodes = nodes} */;
+        node->link = (uintptr_t)prev ^ (uintptr_t)next;
+
+        prev->link = (prev->link ^ (uintptr_t)next) ^ (uintptr_t)node;
+        //@ ghost if (index > 0) { assume prev->link == ((uintptr_t)nodes[index-1] ^ (uintptr_t)node); }
+        next->link = (next->link ^ (uintptr_t)prev) ^ (uintptr_t)node;
+        //@ ghost if (index < list->length) { assume next->link == ((uintptr_t)node ^ (uintptr_t)nodes[index+2]); }
+        list->length++;
+        //@ ghost outNodes = nodes[0 .. (index + 1)] + [node] + nodes[(index + 1) .. ];
+
+    }
+}
+
+//@ given seq<struct Node*> nodes;
+//@ context list != NULL ** Perm(*list, 1\2);
+//@ context [1\2]list_basic(list->length, list->head, list->tail, nodes);
+//@ context (\forall* int i = 1 .. list->length + 1; valid_link(nodes, i, {:nodes[i]->link:}));
+//@ requires 0 <= index && index < list->length;
+//@ requires list->length > 0;
+//@ ensures \result == nodes[index + 1]->data;
+int get(struct List *list, size_t index) {
+    struct Node *node = find_node(list, index) /*@ given {nodes = nodes} */;
+
+    return node->data;
+}
+
+
+#if 0
+//@ given seq<struct Node*> nodes;
+//@ context list != NULL ** Perm(*list, write);
+//@ context list_basic(list->length, list->head, list->tail, nodes);
+//@ context (\forall* int i = 1 .. list->length + 1; valid_link(nodes, i, nodes[i]->link));
+int delete(struct List *list, size_t index) {
+    //@ assume false;
+    struct Node *prev;
+    if (index == 0) {
+        prev = list->head;
+    } else {
+        prev = find_node(list, index - 1) /*@ given {nodes = nodes} */;
+    }
+    struct Node *node = find_node(list, index) /*@ given {nodes = nodes} */;
+    struct Node *next = find_node(list, index + 1) /*@ given {nodes = nodes} */;
+
+    prev->link = prev->link ^ (uintptr_t)node ^ (uintptr_t)next;
+    next->link = next->link ^ (uintptr_t)node ^ (uintptr_t)prev;
+
+    int data = node->data;
+    free(node);
+
+    list->length--;
+
+    return data;
+}
+#endif
+
+
+int main(void) {
+    //@ ghost seq<struct Node *> nodes;
+    struct List *list = new() /*@ yields {nodes=nodes} */;
+    insert(list, 0, 1) /*@ given {nodes = nodes} */ /*@ yields {nodes = outNodes} */;
+    //@ assert 1 == get(list, 0) /*@ given {nodes = nodes} */;
+    //@ ghost seq<struct Node *> oldNodes = nodes;
+    insert(list, 1, 2) /*@ given {nodes = nodes} */ /*@ yields {nodes = outNodes} */;
+    //@ assert 1 == get(list, 0) /*@ given {nodes = nodes} */;
+    //@ assert 2 == get(list, 1) /*@ given {nodes = nodes} */;
+    insert(list, 0, 3) /*@ given {nodes = nodes} */ /*@ yields {nodes = outNodes}*/;
+    //@ assert 3 == get(list, 0) /*@ given {nodes = nodes} */;
+    //@ assert 1 == get(list, 1) /*@ given {nodes = nodes} */;
+    //@ assert 2 == get(list, 2) /*@ given {nodes = nodes} */;
+    insert(list, 1, 4) /*@ given {nodes = nodes} */ /*@ yields {nodes = outNodes} */;
+    //@ assert 3 == get(list, 0) /*@ given {nodes = nodes} */;
+    //@ assert 4 == get(list, 1) /*@ given {nodes = nodes} */;
+    //@ assert 1 == get(list, 2) /*@ given {nodes = nodes} */;
+    //@ assert 2 == get(list, 3) /*@ given {nodes = nodes} */;
+    insert(list, 3, 5) /*@ given {nodes = nodes} */ /*@ yields {nodes = outNodes}*/;
+    //@ assert 3 == get(list, 0) /*@ given {nodes = nodes} */;
+    //@ assert 4 == get(list, 1) /*@ given {nodes = nodes} */;
+    //@ assert 1 == get(list, 2) /*@ given {nodes = nodes} */;
+    //@ assert 5 == get(list, 3) /*@ given {nodes = nodes} */;
+    //@ assert 2 == get(list, 4) /*@ given {nodes = nodes} */;
+#if 0
+    //@ assert 5 == delete(list, 3) /*@ given {nodes = nodes} */ /*@ yields {nodes = outNodes}*/;
+    //@ assert 3 == get(list, 0) /*@ given {nodes = nodes} */;
+    //@ assert 4 == get(list, 1) /*@ given {nodes = nodes} */;
+    //@ assert 1 == get(list, 2) /*@ given {nodes = nodes} */;
+    //@ assert 2 == get(list, 3) /*@ given {nodes = nodes} */;
+    //@ assert 1 == delete(list, 2) /*@ given {nodes = nodes} */ /*@ yields {nodes = outNodes}*/;
+    //@ assert 3 == get(list, 0) /*@ given {nodes = nodes} */;
+    //@ assert 4 == get(list, 1) /*@ given {nodes = nodes} */;
+    //@ assert 2 == get(list, 2) /*@ given {nodes = nodes} */;
+    //@ assert 3 == delete(list, 0) /*@ given {nodes = nodes} */ /*@ yields {nodes = outNodes}*/;
+    //@ assert 4 == get(list, 0) /*@ given {nodes = nodes} */;
+    //@ assert 2 == get(list, 1) /*@ given {nodes = nodes} */;
+    //@ assert 2 == delete(list, 1) /*@ given {nodes = nodes} */ /*@ yields {nodes = outNodes}*/;
+    //@ assert 4 == get(list, 0) /*@ given {nodes = nodes} */;
+    //@ assert 4 == delete(list, 0) /*@ given {nodes = nodes} */ /*@ yields {nodes = outNodes}*/;
+    //@ assert 0 == list->length;
+#endif
+    return 0;
+}
+
+

--- a/examples/concepts/c/xor_linked_list.c
+++ b/examples/concepts/c/xor_linked_list.c
@@ -31,11 +31,13 @@ struct List {
                     |nodes| == length + 2 ** nodes[0] == head ** nodes[length + 1] == tail **
                     (\forall int i = 0 .. length+2, int j = 0 .. length+2; i != j && {:Trigger.injection_a(i):} && {:Trigger.injection_a(j):} ==> nodes[i] != nodes[j]) **
                     (\forall int i = 0 .. length+2; {:nodes[i]:} != NULL) **
+                    (\forall int i = 0 .. length+2; {:\pointer_block_offset(nodes[i]):} == 0) **
+                    (\forall int i = 0 .. length+2; {:\pointer_block_length(nodes[i]):} == 1) **
                     (\forall* int i = 0 .. length+2; Trigger.injection_a(i) ==> Perm(*{:nodes[i]:}, write)) **
                     (\forall* int i = 0 .. length+2; 0 <= {:nodes[i]->link:} && {:nodes[i]->link:} <= 18446744073709551615);
 */
 // 1 <= i && i < |nodes| -1 &&
-/*@ inline resource valid_link(seq<struct Node*> nodes, int i, int link) = link == ((uintptr_t)nodes[i-1] ^  (uintptr_t)nodes[i+1]); */
+/*@ inline resource valid_link(seq<struct Node*> nodes, int i, int link) = (link == ((uintptr_t)nodes[i-1] ^  (uintptr_t)nodes[i+1])); */
 
 
 
@@ -157,7 +159,6 @@ void insert(struct List *list, size_t index, int data) {
     //@ assume node != NULL;
     node->data = data;
     //@ assume (\forall int i = 0 .. list->length + 2; {:nodes[i]:} != node);
-    // ghost seq<int> inLinks = toLinks(nodes);
 
     if (list->length == 0) {
         list->head->link = (uintptr_t)node ^ (uintptr_t)list->tail;
@@ -181,7 +182,7 @@ void insert(struct List *list, size_t index, int data) {
         //@ ghost if (index < list->length) { assume next->link == ((uintptr_t)node ^ (uintptr_t)nodes[index+2]); }
         list->length++;
         //@ ghost outNodes = nodes[0 .. (index + 1)] + [node] + nodes[(index + 1) .. ];
-
+        //@ assert (\forall int i = 1 .. |outNodes| - 2; {:outNodes[i]:} != NULL);
     }
 }
 
@@ -199,13 +200,22 @@ int get(struct List *list, size_t index) {
 }
 
 
-#if 0
 //@ given seq<struct Node*> nodes;
+//@ yields seq<struct Node*> outNodes;
 //@ context list != NULL ** Perm(*list, write);
-//@ context list_basic(list->length, list->head, list->tail, nodes);
-//@ context (\forall* int i = 1 .. list->length + 1; valid_link(nodes, i, nodes[i]->link));
+//@ requires list_basic(list->length, list->head, list->tail, nodes);
+//@ ensures list_basic(list->length, list->head, list->tail, outNodes);
+//@ requires (\forall* int i = 1 .. list->length + 1; valid_link(nodes, i, {:nodes[i]->link:}));
+//@ ensures (\forall* int i = 1 .. list->length + 1; valid_link(outNodes, i, {:outNodes[i]->link:}));
+//@ requires 0 <= index && index < list->length;
+//@ requires list->length > 0;
+//@ ensures list->length == \old(list->length) - 1;
+//@ ensures (\forall int i = 0 .. index + 1; {:nodes[i]:} == {:outNodes[i]:});
+//@ ensures (\forall int i = 1 .. index + 1; \old({:nodes[i]->data:}) == {:outNodes[i]->data:});
+//@ ensures (\forall int i = index + 1 .. list->length + 1; nodes[i + 1] == {:outNodes[i]:});
+//@ ensures (\forall int i = index + 1 .. list->length + 1; \old(nodes[i + 1]->data) == {:outNodes[i]->data:});
+//@ ensures \result == \old(nodes[index + 1]->data);
 int delete(struct List *list, size_t index) {
-    //@ assume false;
     struct Node *prev;
     if (index == 0) {
         prev = list->head;
@@ -216,16 +226,20 @@ int delete(struct List *list, size_t index) {
     struct Node *next = find_node(list, index + 1) /*@ given {nodes = nodes} */;
 
     prev->link = prev->link ^ (uintptr_t)node ^ (uintptr_t)next;
+    //@ ghost if (index > 0) { assume prev->link == ((uintptr_t)nodes[index-1] ^ (uintptr_t)next); }
     next->link = next->link ^ (uintptr_t)node ^ (uintptr_t)prev;
+    //@ ghost if (index < list->length - 1) { assume next->link == ((uintptr_t)prev ^ (uintptr_t)nodes[index+3]); }
 
     int data = node->data;
     free(node);
 
     list->length--;
+    //@ ghost outNodes = nodes[0 .. (index + 1)] + nodes[(index + 2) .. ];
+    //@ ghost if (index > 0) { assert valid_link(outNodes, index, prev->link); }
+    //@ ghost if (index < list->length) { assert valid_link(outNodes, index+1, next->link); }
 
     return data;
 }
-#endif
 
 
 int main(void) {
@@ -252,7 +266,6 @@ int main(void) {
     //@ assert 1 == get(list, 2) /*@ given {nodes = nodes} */;
     //@ assert 5 == get(list, 3) /*@ given {nodes = nodes} */;
     //@ assert 2 == get(list, 4) /*@ given {nodes = nodes} */;
-#if 0
     //@ assert 5 == delete(list, 3) /*@ given {nodes = nodes} */ /*@ yields {nodes = outNodes}*/;
     //@ assert 3 == get(list, 0) /*@ given {nodes = nodes} */;
     //@ assert 4 == get(list, 1) /*@ given {nodes = nodes} */;
@@ -269,7 +282,6 @@ int main(void) {
     //@ assert 4 == get(list, 0) /*@ given {nodes = nodes} */;
     //@ assert 4 == delete(list, 0) /*@ given {nodes = nodes} */ /*@ yields {nodes = outNodes}*/;
     //@ assert 0 == list->length;
-#endif
     return 0;
 }
 

--- a/examples/concepts/wand/TreeWandSilver-e1.java
+++ b/examples/concepts/wand/TreeWandSilver-e1.java
@@ -51,7 +51,7 @@ final class Tree {
     if (top.left == null) {
       //@ assert orig_contents == tolist(top.left) + seq<int>{top.data} + tolist(top.right);
       //@ assert tolist(top.left) == seq<int>{};
-      return top.left;
+      return top.right;
     } else {
       Tree cur, left;
       cur = top;

--- a/examples/verifythis/2017/submission/VerCors_challenge4.pvl
+++ b/examples/verifythis/2017/submission/VerCors_challenge4.pvl
@@ -11,38 +11,38 @@ class BufImpl {
   seq<int> xs;
   int xs_len;
   seq<int> ys;
-	
-	resource state() = Perm(h, write) ** Perm(xs, write) 
+
+	resource state() = Perm(h, write) ** Perm(xs, write)
 		** Perm(xs_len, write) ** Perm(ys, write) ** Perm(xs_spec, write);
-	
+
 	requires state();
-	int h_spec() = unfolding state() in h;
-	
+	pure int h_spec() = \unfolding state() \in h;
+
 	/* ghost */ seq<int> xs_spec;
-	
+
 	requires i >= 0 && i < |xs|;
-	pure int get(seq<int> xs, int i) = i == 0 ? head(xs) : get(tail(xs), i-1);
-	
+	pure int get(seq<int> xs, int i) = i == 0 ? xs.head : get(xs.tail, i-1);
+
 	requires 0 <= n && n < |xs|;
-	pure seq<int> skip(seq<int> xs, int n) = n == 0 ? xs : skip(tail(xs), n-1);
-	
+	pure seq<int> skip(seq<int> xs, int n) = n == 0 ? xs : skip(xs.tail, n-1);
+
 	requires 0 <= n;
 	pure seq<int> take(int n, seq<int> xs) = n == 0 ? xs :
-	(|xs| == 0 ? seq<int> { } : seq<int> { head(xs) } + take(n-1, tail(xs)));
-	
+	(|xs| == 0 ? seq<int> { } : seq<int> { xs.head } + take(n-1, xs.tail));
+
 	//requires Perm(xs, write) ** Perm(ys, write) ** Perm(xs_spec, write);
 	requires state();
-	requires unfolding state() in (|xs_spec| >= |xs| + |ys|);
+	requires (\unfolding state() \in (|xs_spec| >= |xs| + |ys|));
 	pure boolean f() = unfolding state() in (
 		(\forall int i; 0 <= i && i < |xs|; get(xs_spec, i) == get(xs, i)) &&
 		(\forall int i; 0 <= i && i < |ys|; get(xs_spec, i + |xs|) == get(ys, i))
 	);
-	
+
 	ensures state();
 	ensures h_spec() == h;
-	ensures unfolding state() in (|xs_spec| >= |xs| + |ys|);
+	ensures (\unfolding state() \in (|xs_spec| >= |xs| + |ys|));
 	ensures f();
-	BufImpl(int h) {
+	constructor(int h) {
 		this.h = h;
 		xs = seq<int> { };
 		xs_len = 0;
@@ -53,29 +53,29 @@ class BufImpl {
 
 	given seq<int> old_xs;
 	requires state();
-	requires unfolding state() in (|xs_spec| >= |xs| + |ys|);
-	requires old_xs == \unfolding state() \in xs;
+	requires (\unfolding state() \in (|xs_spec| >= |xs| + |ys|));
+	requires old_xs == (\unfolding state() \in xs);
 	requires f();
 	ensures state();
 	ensures h_spec() == \old(h_spec());
-	ensures unfolding state() in (|xs_spec| >= |xs| + |ys|);
+	ensures (\unfolding state() \in (|xs_spec| >= |xs| + |ys|));
 	ensures f();
 	void add(int x) {
 		unfold state();
-		
+
 		assert (\forall int i; 0 <= i && i < |xs|; get(xs_spec, i) == get(xs, i));
 		assert (\forall int i; 0 <= i && i < |ys|; get(xs_spec, i + |xs|) == get(ys, i));
-		
+
 		seq<int> old_xs_spec = xs_spec;
         xs_spec = seq<int> { x } + xs_spec;
-		
+
 		assert get(xs_spec, 0) == x;
-        assert tail(xs_spec) == old_xs_spec;
+        assert xs_spec.tail == old_xs_spec;
 		assert (\forall int i; 0 <= i && i < |xs|; get(xs_spec, i+1) == get(xs, i));
-		
+
 	  if (|xs| == h - 1) {
 			ys = seq<int> {x} + xs;
-            assert tail(ys) == xs;
+            assert ys.tail == xs;
 			assert (\forall int i; 0 <= i && i < |ys|; get(xs_spec, i) == get(ys, i));
 			xs = seq<int> {};
 		 	xs_len = 0;
@@ -91,15 +91,15 @@ class BufImpl {
 		else {
 			seq<int> xs_before = xs;
             xs = seq<int> {x} + xs;
-            assert tail(xs) == xs_before;
+            assert xs.tail == xs_before;
 		 	xs_len = xs_len + 1;
 			fold state();
 			assert f();
 		}
 		// fold state();
 	}
-	
-	/* 
+
+	/*
     requires state();
 	ensures \result == take(h_spec(), xs_spec);
 	seq<int> get2() {

--- a/res/universal/res/adt/pointer.pvl
+++ b/res/universal/res/adt/pointer.pvl
@@ -1,3 +1,5 @@
+adt PointerCastHelper {}
+
 adt `block` {
   pure int block_length(`block` b);
   pure ref loc(`block` b, int i);

--- a/src/col/vct/col/typerules/CoercingRewriter.scala
+++ b/src/col/vct/col/typerules/CoercingRewriter.scala
@@ -1772,12 +1772,7 @@ abstract class CoercingRewriter[Pre <: Generation]()
       case ScaleByParBlock(ref, r) => ScaleByParBlock(ref, res(r))
       case ScopedExpr(locals, body) => ScopedExpr(locals, body)
       case Select(condition, whenTrue, whenFalse) =>
-        val sharedType = Types.leastCommonSuperType(whenTrue.t, whenFalse.t)
-        Select(
-          bool(condition),
-          coerce(whenTrue, sharedType),
-          coerce(whenFalse, sharedType),
-        )
+        nonAny(e, whenTrue, whenFalse, Select(bool(condition), _, _))
       case SeqMember(x, xs) =>
         val (coercedSeq, seqType) = seq(xs)
         val sharedType = Types.leastCommonSuperType(x.t, seqType.element)

--- a/src/rewrite/vct/rewrite/Explode.scala
+++ b/src/rewrite/vct/rewrite/Explode.scala
@@ -45,6 +45,8 @@ case class Explode[Pre <: Generation](enable: Boolean) extends Rewriter[Pre] {
       adts: Seq[AxiomaticDataType[Pre]],
       fields: Seq[SilverField[Pre]],
       funcs: Seq[Function[Pre]],
+      proverTypes: Seq[ProverType[Pre]],
+      proverFuncs: Seq[ProverFunction[Pre]],
       predOutlines: Seq[Predicate[Pre]],
       predBodies: Seq[Predicate[Pre]],
       procOutlines: Seq[Procedure[Pre]],
@@ -95,11 +97,18 @@ case class Explode[Pre <: Generation](enable: Boolean) extends Rewriter[Pre] {
         case ProcedureInvocation(Ref(p), _, _, _, _, _, _) => p
       })
 
+    def proverFuncUsage: Seq[ProverFunction[Pre]] =
+      scanNodes.flatMap(_.collect { case ProverFunctionInvocation(Ref(p), _) =>
+        p
+      })
+
     def step: FocusedProgram =
       FocusedProgram(
         adts,
         (fields ++ fieldUsage).distinct,
         (funcs ++ funcUsage).distinct,
+        proverTypes,
+        (proverFuncs ++ proverFuncUsage).distinct,
         (predOutlines ++ predUsage).distinct,
         (predBodies ++ predContentUsage).distinct,
         (procOutlines ++ procUsage).distinct,
@@ -120,6 +129,8 @@ case class Explode[Pre <: Generation](enable: Boolean) extends Rewriter[Pre] {
         adts.filter(other.adts.contains),
         fields.filter(other.fields.contains),
         funcs.filter(other.funcs.contains),
+        proverTypes.filter(other.proverTypes.contains),
+        proverFuncs.filter(other.proverFuncs.contains),
         predOutlines.filter(other.predOutlines.contains),
         predBodies.filter(other.predBodies.contains),
         procOutlines.filter(other.procOutlines.contains),
@@ -132,6 +143,8 @@ case class Explode[Pre <: Generation](enable: Boolean) extends Rewriter[Pre] {
           adts.foreach(dispatch)
           fields.foreach(dispatch)
           funcs.foreach(dispatch)
+          proverTypes.foreach(dispatch)
+          proverFuncs.foreach(dispatch)
           predOutlines.foreach { pred =>
             if (predBodies.contains(pred))
               dispatch(pred)
@@ -151,6 +164,8 @@ case class Explode[Pre <: Generation](enable: Boolean) extends Rewriter[Pre] {
           adts,
           Nil,
           funcs.filter(_.contract.decreases.isEmpty),
+          proverTypes,
+          Nil,
           Nil,
           Nil,
           Seq(proc),
@@ -173,6 +188,8 @@ case class Explode[Pre <: Generation](enable: Boolean) extends Rewriter[Pre] {
     val funcs: ArrayBuffer[Function[Pre]] = ArrayBuffer()
     val preds: ArrayBuffer[Predicate[Pre]] = ArrayBuffer()
     val procs: ArrayBuffer[Procedure[Pre]] = ArrayBuffer()
+    val proverTypes: ArrayBuffer[ProverType[Pre]] = ArrayBuffer()
+    val proverFuncs: ArrayBuffer[ProverFunction[Pre]] = ArrayBuffer()
 
     program.declarations.foreach {
       case adt: AxiomaticDataType[Pre] => adts += adt
@@ -180,6 +197,8 @@ case class Explode[Pre <: Generation](enable: Boolean) extends Rewriter[Pre] {
       case func: Function[Pre] => funcs += func
       case pred: Predicate[Pre] => preds += pred
       case proc: Procedure[Pre] => procs += proc
+      case typ: ProverType[Pre] => proverTypes += typ
+      case func: ProverFunction[Pre] => proverFuncs += func
       case other => throw UnknownDeclaration(program, other)
     }
 
@@ -187,6 +206,8 @@ case class Explode[Pre <: Generation](enable: Boolean) extends Rewriter[Pre] {
       adts.toSeq,
       fields.toSeq,
       funcs.toSeq,
+      proverTypes.toSeq,
+      proverFuncs.toSeq,
       preds.toSeq,
       preds.toSeq,
       procs.toSeq,
@@ -216,7 +237,8 @@ case class Explode[Pre <: Generation](enable: Boolean) extends Rewriter[Pre] {
     make(
       context,
       globalDeclarations.dispatch(
-        program.adts ++ program.fields ++ program.funcs ++ program.predBodies
+        program.adts ++ program.fields ++ program.funcs ++
+          program.proverTypes ++ program.proverFuncs ++ program.predBodies
       ),
     ) +: program.procBodies.map(proc => make(context, program.focus(proc)))
   }

--- a/src/rewrite/vct/rewrite/ResolveScale.scala
+++ b/src/rewrite/vct/rewrite/ResolveScale.scala
@@ -101,6 +101,11 @@ case class ResolveScale[Pre <: Generation]() extends Rewriter[Pre] {
         )
       case a @ Assuming(assn, inner) =>
         a.rewrite(assn = scale(assn, amount), inner = scale(inner, amount))
+      case pd @ PolarityDependent(onInhale, onExhale) =>
+        pd.rewrite(
+          onInhale = scale(onInhale, amount),
+          onExhale = scale(onExhale, amount),
+        )
       case other => throw WrongScale(other)
     }
   }

--- a/src/rewrite/vct/rewrite/adt/ImportPointer.scala
+++ b/src/rewrite/vct/rewrite/adt/ImportPointer.scala
@@ -760,19 +760,40 @@ case class ImportPointer[Pre <: Generation](importer: ImportADTImporter)
           ref =
             toAdtFunctions.getOrElseUpdate(
               (adt, args), {
-                globalDeclarations.declare(
+                val name =
+                  "ptr_to_" + adt.o.find[SourceName].map(_.name)
+                    .getOrElse("unknown")
+                val inv = globalDeclarations.declare(
+                  function[Post](
+                    AbstractApplicable,
+                    TrueSatisfiable,
+                    TAxiomatic(pointerAdt.ref, Nil),
+                    Seq(
+                      new Variable[Post](
+                        TAxiomatic(succ(adt), args.map(dispatch))
+                      )(PointerToAdtOrigin.where(name = "a"))
+                    ),
+                  )(PointerToAdtOrigin.where(name = name + "_inv"))
+                )
+                val p =
+                  new Variable[Post](TAxiomatic(pointerAdt.ref, Nil))(
+                    PointerToAdtOrigin.where(name = "p")
+                  )
+                globalDeclarations.declare(withResult((result: Result[Post]) =>
                   function[Post](
                     AbstractApplicable,
                     TrueSatisfiable,
                     TAxiomatic(succ(adt), args.map(dispatch)),
-                    Seq(new Variable[Post](TAxiomatic(pointerAdt.ref, Nil))(
-                      PointerToAdtOrigin.where(name = "p")
-                    )),
-                  )(PointerToAdtOrigin.where(name =
-                    "ptr_to_" + adt.o.find[SourceName].map(_.name)
-                      .getOrElse("unknown")
-                  ))
-                )
+                    Seq(p),
+                    ensures = UnitAccountedPredicate(
+                      p.get === functionInvocation(
+                        TrueSatisfiable,
+                        ref = inv.ref,
+                        args = Seq(result),
+                      )
+                    ),
+                  )(PointerToAdtOrigin.where(name = name))
+                ))
               },
             ).ref,
           args = Seq(p match {

--- a/src/rewrite/vct/rewrite/adt/ImportPointer.scala
+++ b/src/rewrite/vct/rewrite/adt/ImportPointer.scala
@@ -4,7 +4,7 @@ import vct.col.ast._
 import ImportADT.typeText
 import hre.util.ScopedStack
 import vct.col.origin._
-import vct.col.ref.Ref
+import vct.col.ref.{LazyRef, Ref}
 import vct.col.rewrite.{ClassToRef, Generation}
 import vct.col.util.AstBuildHelpers.{functionInvocation, _}
 import vct.col.util.SuccessionMap
@@ -105,6 +105,10 @@ case class ImportPointer[Pre <: Generation](importer: ImportADTImporter)
     pointerFile,
     "ptr_from_address",
   )
+  private lazy val pointerCastHelperAdt = find[AxiomaticDataType[Post]](
+    pointerFile,
+    "PointerCastHelper",
+  )
 
   private val pointerField
       : mutable.Map[(Type[Post], Option[BigInt]), SilverField[Post]] = mutable
@@ -119,9 +123,44 @@ case class ImportPointer[Pre <: Generation](importer: ImportADTImporter)
       : mutable.Map[(AxiomaticDataType[Pre], Seq[Type[Pre]]), Function[Post]] =
     mutable.Map()
   private val context: ScopedStack[Context] = ScopedStack()
-  private var casts: Set[(Type[Pre], Type[Pre], Expr[Pre], Expr[Pre])] =
-    Set.empty
-  private var inMakeAsType: ScopedStack[Unit] = ScopedStack()
+  private var casts: Set[Type[Pre]] = Set.empty
+  private val inMakeAsType: ScopedStack[Unit] = ScopedStack()
+  private val fromCastHelperFunctions
+      : SuccessionMap[Type[Pre], Function[Post]] = SuccessionMap()
+  private val toCastHelperFunctions: SuccessionMap[Type[Pre], Function[Post]] =
+    SuccessionMap()
+
+  private def makeFromCastHelperFunction(t: Type[Pre]): Function[Post] = {
+    implicit val o: Origin = AsTypeOrigin
+      .where(name = "from_cast_helper_" + t.toString)
+    val value =
+      new Variable[Post](TAxiomatic(new LazyRef(pointerCastHelperAdt), Nil))(
+        AsTypeOrigin.where(name = "helper")
+      )
+    globalDeclarations.declare(function[Post](
+      AbstractApplicable,
+      TrueSatisfiable,
+      returnType = TAxiomatic(new LazyRef(pointerAdt), Nil),
+      args = Seq(value),
+    ))
+  }
+
+  private def makeToCastHelperFunction(t: Type[Pre]): Function[Post] = {
+    implicit val o: Origin = AsTypeOrigin
+      .where(name = "to_cast_helper_" + t.toString)
+    val value =
+      new Variable[Post](TAxiomatic(new LazyRef(pointerAdt), Nil))(
+        AsTypeOrigin.where(name = "ptr")
+      )
+    globalDeclarations.declare(withResult((result: Result[Post]) =>
+      function[Post](
+        AbstractApplicable,
+        TrueSatisfiable,
+        returnType = TAxiomatic(new LazyRef(pointerCastHelperAdt), Nil),
+        args = Seq(value),
+      )
+    ))
+  }
 
   private def makeAsTypeFunction(
       from: Type[Pre],
@@ -131,15 +170,6 @@ case class ImportPointer[Pre <: Generation](importer: ImportADTImporter)
   ): Function[Post] = {
     implicit val o: Origin = AsTypeOrigin
       .where(name = "as_" + to.toString + "_from_" + from.toString)
-//        val orig = new Variable[Post](TAxiomatic(pointerAdt.ref, Nil))(o.where(name = "orig"))
-//        val inv: Function[Post] = globalDeclarations.declare(
-//          function[Post](
-//            AbstractApplicable,
-//            TrueSatisfiable,
-//            returnType = TAxiomatic(pointerAdt.ref, Nil),
-//            args = Seq(orig),
-//          )(o.where(name = "as_" + toName + "_from_" + fromName + "_inv"))
-//        )
     if (inMakeAsType.isEmpty && !asTypeFunctions.contains((to, from))) {
       inMakeAsType.having(()) {
         asTypeFunctions((to, from)) = makeAsTypeFunction(
@@ -158,25 +188,26 @@ case class ImportPointer[Pre <: Generation](importer: ImportADTImporter)
       function[Post](
         AbstractApplicable,
         TrueSatisfiable,
-//        ensures = UnitAccountedPredicate(foldAnd(casts.map(t =>
-//          functionInvocation[Post](
-//            TrueSatisfiable,
-//            asTypeFunctions.ref(t),
-//            Seq(result),
-//          ) === value.get
-//        ))),
-        ensures = UnitAccountedPredicate(
-//                  And(
-//                  functionInvocation[Post](TrueSatisfiable, inv.ref, args=Seq(result)) === value.get,
+        ensures = UnitAccountedPredicate(And(
+          result === functionInvocation[Post](
+            TrueSatisfiable,
+            fromCastHelperFunctions
+              .getOrElseUpdate(to, makeFromCastHelperFunction(to)).ref,
+            Seq(functionInvocation[Post](
+              TrueSatisfiable,
+              toCastHelperFunctions
+                .getOrElseUpdate(from, makeToCastHelperFunction(from)).ref,
+              Seq(value.get),
+            )),
+          ),
           adtFunctionInvocation[Post](
             pointerAddress.ref,
             args = Seq(result, dispatch(toSize)),
           ) === adtFunctionInvocation[Post](
             pointerAddress.ref,
             args = Seq(value.get, dispatch(fromSize)),
-          )
-//                  )
-        ),
+          ),
+        )),
         returnType = TAxiomatic(pointerAdt.ref, Nil),
         args = Seq(value),
       )
@@ -286,13 +317,8 @@ case class ImportPointer[Pre <: Generation](importer: ImportADTImporter)
 
   override def postCoerce(program: Program[Pre]): Program[Post] = {
     casts =
-      program.collect { case PointerCast(from, to, fromSize, toSize) =>
-        (
-          from.t.asPointer.get.element,
-          to.asPointer.get.element,
-          fromSize,
-          toSize,
-        )
+      program.flatCollect { case PointerCast(from, to, _, _) =>
+        Seq(from.t.asPointer.get.element, to.asPointer.get.element)
       }.toSet
     super.postCoerce(program)
   }
@@ -303,13 +329,6 @@ case class ImportPointer[Pre <: Generation](importer: ImportADTImporter)
         context.having(InAxiom()) {
           allScopes.anySucceed(axiom, axiom.rewriteDefault())
         }
-//      // TODO: This is an ugly way to exempt this one bit of generated code from having ptrAdd's added
-//      case proc: Procedure[Pre]
-//          if proc.o.find[LabelContext]
-//            .exists(_.label == "classToRef cast helpers") =>
-//        context.having(InAxiom()) {
-//          allScopes.anySucceed(proc, proc.rewriteDefault())
-//        }
       case adt: AxiomaticDataType[Pre]
           if adt.o.find[SourceName].exists(_.name == "pointer") =>
         implicit val o: Origin = adt.o
@@ -325,30 +344,40 @@ case class ImportPointer[Pre <: Generation](importer: ImportADTImporter)
               }.get)
               aDTDeclarations.collect {
                 adt.decls.foreach(dispatch)
-                casts.map { case (from1, to1, _, _) =>
+                casts.map { t =>
+                  aDTDeclarations.declare(new ADTAxiom[Post](forall(
+                    TAxiomatic(new LazyRef(pointerCastHelperAdt), Nil),
+                    body = { p =>
+                      InlinePattern(functionInvocation[Post](
+                        TrueSatisfiable,
+                        toCastHelperFunctions
+                          .getOrElseUpdate(t, makeToCastHelperFunction(t)).ref,
+                        Seq(functionInvocation[Post](
+                          TrueSatisfiable,
+                          fromCastHelperFunctions
+                            .getOrElseUpdate(t, makeFromCastHelperFunction(t))
+                            .ref,
+                          Seq(p),
+                        )),
+                      )) === p
+                    },
+                  )))
                   aDTDeclarations.declare(new ADTAxiom[Post](forall(
                     TAxiomatic(adtSucc, Nil),
                     body = { p =>
-                      functionInvocation[Post](
+                      InlinePattern(functionInvocation[Post](
                         TrueSatisfiable,
-                        asTypeFunctions.ref((to1, from1)),
+                        fromCastHelperFunctions
+                          .getOrElseUpdate(t, makeFromCastHelperFunction(t))
+                          .ref,
                         Seq(functionInvocation[Post](
                           TrueSatisfiable,
-                          asTypeFunctions.ref((from1, to1)),
+                          toCastHelperFunctions
+                            .getOrElseUpdate(t, makeToCastHelperFunction(t))
+                            .ref,
                           Seq(p),
                         )),
-                      ) === p
-                    },
-                    triggers = { p =>
-                      Seq(Seq(functionInvocation[Post](
-                        TrueSatisfiable,
-                        asTypeFunctions.ref((to1, from1)),
-                        Seq(functionInvocation[Post](
-                          TrueSatisfiable,
-                          asTypeFunctions.ref((from1, to1)),
-                          Seq(p),
-                        )),
-                      )))
+                      )) === p
                     },
                   )))
                 }

--- a/test/main/vct/test/integration/examples/CSpec.scala
+++ b/test/main/vct/test/integration/examples/CSpec.scala
@@ -627,6 +627,7 @@ class CSpec extends VercorsSpec {
   vercors should verify using silicon example "concepts/c/mismatched_provenance.c"
   vercors should verify using silicon example "concepts/c/ptr_comparisons.c"
   vercors should verify using silicon flag "--target" flag "x86_64-linux-unknown" flag "--dev-no-sat" example "concepts/c/pointer_tag.c"
+  vercors should verify using silicon flags("--target", "x86_64-linux-unknown", "--dev-no-sat", "--opaque-bitwise-operators", "--dev-split-verification-by-procedure") example "concepts/c/xor_linked_list.c"
   vercors should verify using silicon in "Pointer address correctly offset based on type size" c
     """
     #include <stdint.h>

--- a/test/main/vct/test/integration/examples/VerifyThisSpec.scala
+++ b/test/main/vct/test/integration/examples/VerifyThisSpec.scala
@@ -10,7 +10,7 @@ class VerifyThisSpec extends VercorsSpec {
   // vercors should verify using silicon example "verifythis/2017/other_attempts/kadane.java"
   // vercors should verify using silicon example "verifythis/2017/other_attempts/kadane2D.java"
   // vercors should verify using silicon example "verifythis/2017/submission/VerCors_challenge3.pvl"
-  // vercors should verify using silicon example "verifythis/2017/submission/VerCors_challenge4.pvl"
+  vercors should verify using silicon example "verifythis/2017/submission/VerCors_challenge4.pvl"
   // vercors should verify using silicon example "verifythis/2017/submission/Vercors_challenge3_2D.pvl"
   // vercors should verify using silicon example "verifythis/2017/submission/challenge1.pvl"
   vercors should verify using silicon example "verifythis/2018/challenge2.pvl"

--- a/test/main/vct/test/integration/examples/WandSpec.scala
+++ b/test/main/vct/test/integration/examples/WandSpec.scala
@@ -7,8 +7,8 @@ class WandSpec extends VercorsSpec {
   vercors should verify using silicon example "concepts/wand/ListAppendASyncDef.java"
   vercors should verify using silicon example "concepts/wand/ListAppendASyncDefInline.java"
   vercors should verify using silicon example "concepts/wand/TreeRecursiveSilver.java"
-  vercors should verify using silicon example "concepts/wand/TreeWandSilver-e1.java"
-  vercors should verify using silicon example "concepts/wand/TreeWandSilver-e2.java"
-  vercors should verify using silicon example "concepts/wand/TreeWandSilver.java"
+  vercors should verify using silicon flags("--backend-option", "--moreJoins=2") example "concepts/wand/TreeWandSilver-e1.java"
+  vercors should verify using silicon flags("--backend-option", "--moreJoins=2") example "concepts/wand/TreeWandSilver-e2.java"
+  vercors should verify using silicon flags("--backend-option", "--moreJoins=2") example "concepts/wand/TreeWandSilver.java"
   vercors should verify using silicon example "concepts/wand/WandDemoSilver.java"
 }


### PR DESCRIPTION
Checklist: <!-- Please first submit your pull request, you can check the checkboxes later. Feel free to ask for help if you don't know how/where to make changes. -->

- [x] The wiki is updated in accordance with the changes in this PR. For example: syntax changes, semantics changes, VerCors flags changes, etc.

# PR description

## Additions
- XOR-linked list example

## Improvements
- New pointer cast axioms that should capture all cases
- New error when Select is coerced to any
- Use the moreJoins silicon option to make the TreeWandSilver examples more reliable
- Update Viper
- Small update to pointer_tag.c to make it verify more reliably

## Fixes
- Revive VerifyThis challenge 4 solution and update it to the new VerCors syntax
- Fix crash when using prover types with `--dev-split-verification-by-procedure`
- Fix error when scaling a `\polarity_dependent` expression
- Fix a small bug in TreeWandSilver-e1.java
