### PR TITLE
Comment out part of XOR linked list to make CI more stable

### DIFF
--- a/examples/concepts/c/xor_linked_list.c
+++ b/examples/concepts/c/xor_linked_list.c
@@ -242,6 +242,8 @@ int delete(struct List *list, size_t index) {
 }
 
 
+#if 0
+// Commented out for performance reasons
 int main(void) {
     //@ ghost seq<struct Node *> nodes;
     struct List *list = new() /*@ yields {nodes=nodes} */;
@@ -284,5 +286,6 @@ int main(void) {
     //@ assert 0 == list->length;
     return 0;
 }
+#endif
 
 


### PR DESCRIPTION
Verification used to take around 4.5 minutes locally which was dangerously close to the 5 minute limit in CI, therefore commenting out one function so that we are less likely to hit this limit in CI.