### PR TITLE
Fix several small bugs

### DIFF
--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -3526,6 +3526,7 @@ final class JavaAnnotationInterface[G](
 
 sealed trait JavaClassDeclaration[G]
     extends ClassDeclaration[G] with JavaClassDeclarationImpl[G]
+@scopes[LabelDecl]
 final class JavaSharedInitialization[G](
     val isStatic: Boolean,
     val initialization: Statement[G],

--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -3026,7 +3026,6 @@ final case class CInit[G](decl: CDeclarator[G], init: Option[Expr[G]])(
 @family
 final case class CDeclaration[G](
     contract: ApplicableContract[G],
-    kernelInvariant: Expr[G],
     specs: Seq[CDeclarationSpecifier[G]],
     inits: Seq[CInit[G]],
 )(implicit val o: Origin)

--- a/src/col/vct/col/ast/declaration/global/ByReferenceClassImpl.scala
+++ b/src/col/vct/col/ast/declaration/global/ByReferenceClassImpl.scala
@@ -2,13 +2,15 @@ package vct.col.ast.declaration.global
 
 import vct.col.ast.{ByReferenceClass, TByReferenceClass, Type}
 import vct.col.ast.ops.ByReferenceClassOps
+import vct.col.origin.Origin
 import vct.col.print._
 import vct.col.util.AstBuildHelpers.tt
 
 trait ByReferenceClassImpl[G] extends ByReferenceClassOps[G] {
   this: ByReferenceClass[G] =>
-  override def classType(typeArgs: Seq[Type[G]]): TByReferenceClass[G] =
-    TByReferenceClass[G](this.ref, typeArgs)
+  override def classType(typeArgs: Seq[Type[G]])(
+      implicit o: Origin = this.o
+  ): TByReferenceClass[G] = TByReferenceClass[G](this.ref, typeArgs)(o)
 
   override def layoutLockInvariant(implicit ctx: Ctx): Doc =
     if (intrinsicLockInvariant == tt) { Empty }

--- a/src/col/vct/col/ast/declaration/global/ByValueClassImpl.scala
+++ b/src/col/vct/col/ast/declaration/global/ByValueClassImpl.scala
@@ -2,12 +2,14 @@ package vct.col.ast.declaration.global
 
 import vct.col.ast.{ByValueClass, TByValueClass, Type}
 import vct.col.ast.ops.ByValueClassOps
+import vct.col.origin.Origin
 import vct.col.print._
 
 trait ByValueClassImpl[G] extends ByValueClassOps[G] {
   this: ByValueClass[G] =>
   override def supports: Seq[Type[G]] = Nil
-  override def classType(typeArgs: Seq[Type[G]]): TByValueClass[G] =
-    TByValueClass[G](this.ref, typeArgs)
+  override def classType(typeArgs: Seq[Type[G]])(
+      implicit o: Origin = this.o
+  ): TByValueClass[G] = TByValueClass[G](this.ref, typeArgs)(o)
   override def layoutLockInvariant(implicit ctx: Ctx): Doc = Empty
 }

--- a/src/col/vct/col/ast/declaration/global/ClassImpl.scala
+++ b/src/col/vct/col/ast/declaration/global/ClassImpl.scala
@@ -13,6 +13,7 @@ import vct.col.ast.{
   Variable,
 }
 import vct.col.ast.util.Declarator
+import vct.col.origin.Origin
 import vct.col.print._
 import vct.col.util.AstBuildHelpers.tt
 
@@ -22,7 +23,7 @@ trait ClassImpl[G] extends Declarator[G] {
   def decls: Seq[ClassDeclaration[G]]
   def supports: Seq[Type[G]]
 
-  def classType(typeArgs: Seq[Type[G]]): TClass[G]
+  def classType(typeArgs: Seq[Type[G]])(implicit o: Origin = this.o): TClass[G]
 
   def transSupportArrowsHelper(
       seen: Set[TClass[G]]

--- a/src/col/vct/col/ast/family/contract/ApplicableContractImpl.scala
+++ b/src/col/vct/col/ast/family/contract/ApplicableContractImpl.scala
@@ -4,18 +4,32 @@ import vct.col.ast.{
   ApplicableContract,
   BooleanValue,
   Node,
+  TResource,
   UnitAccountedPredicate,
 }
 import vct.col.ast.node.NodeFamilyImpl
-import vct.col.check.{CheckContext, CheckError}
+import vct.col.check.{CheckContext, CheckError, TypeError}
 import vct.col.print._
-import vct.col.ast.ops.{ApplicableContractOps, ApplicableContractFamilyOps}
+import vct.col.ast.ops.{ApplicableContractFamilyOps, ApplicableContractOps}
+import vct.col.typerules.CoercionUtils
 
 trait ApplicableContractImpl[G]
     extends NodeFamilyImpl[G]
     with ApplicableContractOps[G]
     with ApplicableContractFamilyOps[G] {
   this: ApplicableContract[G] =>
+
+  // Requires and ensures are checked in UnitAccountedPredicate
+  override def check(context: CheckContext[G]): Seq[CheckError] =
+    (CoercionUtils.getCoercion(contextEverywhere.t, TResource()) match {
+      case Some(_) => Nil
+      case None => Seq(TypeError(contextEverywhere, TResource()))
+    }) ++
+      (CoercionUtils.getCoercion(kernelInvariant.t, TResource()) match {
+        case Some(_) => Nil
+        case None => Seq(TypeError(kernelInvariant, TResource()))
+      })
+
   override def checkContextRecursor[T](
       context: CheckContext[G],
       f: (CheckContext[G], Node[G]) => T,

--- a/src/col/vct/col/ast/family/contract/ApplicableContractImpl.scala
+++ b/src/col/vct/col/ast/family/contract/ApplicableContractImpl.scala
@@ -8,10 +8,9 @@ import vct.col.ast.{
   UnitAccountedPredicate,
 }
 import vct.col.ast.node.NodeFamilyImpl
-import vct.col.check.{CheckContext, CheckError, TypeError}
+import vct.col.check.{CheckContext, CheckError}
 import vct.col.print._
 import vct.col.ast.ops.{ApplicableContractFamilyOps, ApplicableContractOps}
-import vct.col.typerules.CoercionUtils
 
 trait ApplicableContractImpl[G]
     extends NodeFamilyImpl[G]
@@ -21,14 +20,8 @@ trait ApplicableContractImpl[G]
 
   // Requires and ensures are checked in UnitAccountedPredicate
   override def check(context: CheckContext[G]): Seq[CheckError] =
-    (CoercionUtils.getCoercion(contextEverywhere.t, TResource()) match {
-      case Some(_) => Nil
-      case None => Seq(TypeError(contextEverywhere, TResource()))
-    }) ++
-      (CoercionUtils.getCoercion(kernelInvariant.t, TResource()) match {
-        case Some(_) => Nil
-        case None => Seq(TypeError(kernelInvariant, TResource()))
-      })
+    contextEverywhere.checkSubType(TResource()) ++
+      kernelInvariant.checkSubType(TResource())
 
   override def checkContextRecursor[T](
       context: CheckContext[G],

--- a/src/col/vct/col/ast/family/signals/SignalsClauseImpl.scala
+++ b/src/col/vct/col/ast/family/signals/SignalsClauseImpl.scala
@@ -1,9 +1,11 @@
 package vct.col.ast.family.signals
 
-import vct.col.ast.{Declaration, SignalsClause}
+import vct.col.ast.{Declaration, SignalsClause, TResource}
 import vct.col.ast.util.Declarator
-import vct.col.print.{Ctx, Doc, Text, Group}
-import vct.col.ast.ops.{SignalsClauseOps, SignalsClauseFamilyOps}
+import vct.col.print.{Ctx, Doc, Group, Text}
+import vct.col.ast.ops.{SignalsClauseFamilyOps, SignalsClauseOps}
+import vct.col.check.{CheckContext, CheckError, TypeError}
+import vct.col.typerules.CoercionUtils
 
 trait SignalsClauseImpl[G]
     extends Declarator[G]
@@ -11,6 +13,12 @@ trait SignalsClauseImpl[G]
     with SignalsClauseFamilyOps[G] {
   this: SignalsClause[G] =>
   override def declarations: Seq[Declaration[G]] = Seq(binding)
+
+  override def check(context: CheckContext[G]): Seq[CheckError] =
+    CoercionUtils.getCoercion(assn.t, TResource()) match {
+      case Some(_) => Nil
+      case None => Seq(TypeError(assn, TResource()))
+    }
 
   override def layout(implicit ctx: Ctx): Doc =
     Group(Text("signals") <+> "(" <> binding <> ")" <>> assn)

--- a/src/col/vct/col/ast/lang/c/CDeclarationImpl.scala
+++ b/src/col/vct/col/ast/lang/c/CDeclarationImpl.scala
@@ -9,14 +9,14 @@ trait CDeclarationImpl[G]
     extends CDeclarationOps[G] with CDeclarationFamilyOps[G] {
   this: CDeclaration[G] =>
   override def check(context: CheckContext[G]): Seq[CheckError] =
-    kernelInvariant.checkSubType(TResource())
+    contract.kernelInvariant.checkSubType(TResource())
 
   // PB: Please keep in sync with ApplicableContractImpl
   def layoutContract(implicit ctx: Ctx): Doc =
     Doc.stack(Seq(
       Doc.stack(contract.givenArgs.map(Text("given") <+> _.show <> ";")),
       Doc.stack(contract.yieldsArgs.map(Text("yields") <+> _.show <> ";")),
-      DocUtil.clauses("kernel_invariant", kernelInvariant),
+      DocUtil.clauses("kernel_invariant", contract.kernelInvariant),
       DocUtil.clauses("context_everywhere", contract.contextEverywhere),
       DocUtil.clauses("requires", contract.requires),
       Doc.stack(contract.decreases.toSeq),

--- a/src/col/vct/col/ast/lang/c/CDeclarationImpl.scala
+++ b/src/col/vct/col/ast/lang/c/CDeclarationImpl.scala
@@ -8,8 +8,6 @@ import vct.col.print._
 trait CDeclarationImpl[G]
     extends CDeclarationOps[G] with CDeclarationFamilyOps[G] {
   this: CDeclaration[G] =>
-  override def check(context: CheckContext[G]): Seq[CheckError] =
-    contract.kernelInvariant.checkSubType(TResource())
 
   // PB: Please keep in sync with ApplicableContractImpl
   def layoutContract(implicit ctx: Ctx): Doc =

--- a/src/col/vct/col/ast/lang/c/CTStructImpl.scala
+++ b/src/col/vct/col/ast/lang/c/CTStructImpl.scala
@@ -35,7 +35,6 @@ trait CTStructImpl[G] extends CTStructOps[G] {
         ref.decl.decl match {
           case CDeclaration(
                 _,
-                _,
                 Seq(CStructDeclaration(Some(_), decls)),
                 Seq(),
               ) =>

--- a/src/col/vct/col/ast/type/TClassImpl.scala
+++ b/src/col/vct/col/ast/type/TClassImpl.scala
@@ -1,19 +1,21 @@
 package vct.col.ast.`type`
 
+import vct.col.ast.node.NodeImpl
 import vct.col.ast.{
   Class,
   InstanceField,
   TByReferenceClass,
   TByValueClass,
-  TClassUnique,
   TClass,
+  TClassUnique,
   Type,
   Variable,
 }
+import vct.col.check.{CheckContext, CheckError, TypeErrorExplanation}
 import vct.col.print._
 import vct.col.ref.Ref
 
-trait TClassImpl[G] {
+trait TClassImpl[G] extends NodeImpl[G] {
   this: TClass[G] =>
   def cls: Ref[G, Class[G]]
 
@@ -28,6 +30,15 @@ trait TClassImpl[G] {
 
   def transSupportArrows(): Seq[(TClass[G], TClass[G])] =
     transSupportArrowsHelper(Set.empty)
+
+  override def check(context: CheckContext[G]): Seq[CheckError] =
+    if (cls.decl.typeArgs.length == typeArgs.length) { Nil }
+    else
+      Seq(TypeErrorExplanation(
+        this,
+        s"type has ${typeArgs.length} type arguments, but class definition has ${cls
+            .decl.typeArgs.length} type arguments",
+      ))
 
   override def layout(implicit ctx: Ctx): Doc =
     Group(
@@ -46,8 +57,7 @@ trait TClassImpl[G] {
         t.particularize(cls.typeArgs.zip(typeArgs).toMap)
       case TByValueClass(Ref(cls), typeArgs) if typeArgs.nonEmpty =>
         t.particularize(cls.typeArgs.zip(typeArgs).toMap)
-      case t: TClassUnique[G] if t.typeArgs.nonEmpty =>
-        ??? // TODO
+      case t: TClassUnique[G] if t.typeArgs.nonEmpty => ??? // TODO
       case _ => t
     }
 

--- a/src/col/vct/col/resolve/ctx/Referrable.scala
+++ b/src/col/vct/col/resolve/ctx/Referrable.scala
@@ -40,7 +40,7 @@ sealed trait Referrable[G] {
       case RefUnloadedJavaNamespace(_) => ""
       case RefCStruct(decl: CGlobalDeclaration[_]) =>
         decl.decl match {
-          case CDeclaration(_, _, Seq(defn: CStructDeclaration[G]), Seq()) =>
+          case CDeclaration(_, Seq(defn: CStructDeclaration[G]), Seq()) =>
             defn.name.getOrElse("")
           case _ => ???
         }
@@ -140,9 +140,9 @@ case object Referrable {
         return decl.decls.indices.map(RefCStructField(decl, _))
       case decl: CGlobalDeclaration[G] =>
         decl.decl match {
-          case CDeclaration(_, _, Seq(_: CStructDeclaration[G]), Seq()) =>
+          case CDeclaration(_, Seq(_: CStructDeclaration[G]), Seq()) =>
             RefCStruct(decl)
-          case CDeclaration(_, _, CTypedef() +: _, _) => RefTypeDef(decl)
+          case CDeclaration(_, CTypedef() +: _, _) => RefTypeDef(decl)
           case _ =>
             return decl.decl.inits.indices.map(RefCGlobalDeclaration(decl, _))
         }

--- a/src/col/vct/col/resolve/lang/C.scala
+++ b/src/col/vct/col/resolve/lang/C.scala
@@ -450,7 +450,7 @@ case object C {
       name: String,
   ): Option[RefCStructField[G]] =
     decl.decl match {
-      case CDeclaration(_, _, Seq(CStructDeclaration(_, decls)), Seq()) =>
+      case CDeclaration(_, Seq(CStructDeclaration(_, decls)), Seq()) =>
         decls.flatMap(Referrable.from).collectFirst {
           case ref: RefCStructField[G] if ref.name == name => ref
         }

--- a/src/col/vct/col/typerules/CoercingRewriter.scala
+++ b/src/col/vct/col/typerules/CoercingRewriter.scala
@@ -2932,8 +2932,8 @@ abstract class CoercingRewriter[Pre <: Generation]()
 
   def coerce(node: CDeclaration[Pre]): CDeclaration[Pre] = {
     implicit val o: Origin = node.o
-    val CDeclaration(contract, kernelInvariant, specs, init) = node
-    CDeclaration(contract, res(kernelInvariant), specs, init)
+    val CDeclaration(contract, specs, init) = node
+    CDeclaration(contract, specs, init)
   }
 
   def coerce(node: GpuMemoryFence[Pre]): GpuMemoryFence[Pre] = {

--- a/src/parsers/vct/parsers/transform/CToCol.scala
+++ b/src/parsers/vct/parsers/transform/CToCol.scala
@@ -125,8 +125,6 @@ case class CToCol[G](
           contract =>
             new CDeclaration[G](
               contract.consumeApplicableContract(blame(decl)),
-              AstBuildHelpers
-                .foldStar[G](contract.consume(contract.kernel_invariant)),
               specs = convert(declSpecs),
               inits = maybeInits.map(convert(_)) getOrElse Nil,
             ),

--- a/src/rewrite/vct/rewrite/EncodeResourceValues.scala
+++ b/src/rewrite/vct/rewrite/EncodeResourceValues.scala
@@ -60,7 +60,7 @@ case class EncodeResourceValues[Pre <: Generation]()
     extends Rewriter[Pre] with LazyLogging {
   sealed trait ResourcePattern
 
-  object ResourcePattern {
+  private object ResourcePattern {
     import vct.col.{ast => col}
     object Bool extends ResourcePattern
     case class Perm(loc: ResourcePatternLoc) extends ResourcePattern
@@ -89,7 +89,7 @@ case class EncodeResourceValues[Pre <: Generation]()
     final case class InstancePredicateLocation(ref: col.InstancePredicate[Pre])
         extends ResourcePatternLoc
 
-    def scan(loc: col.Location[Pre]): ResourcePatternLoc =
+    private def scan(loc: col.Location[Pre]): ResourcePatternLoc =
       loc match {
         case col.HeapVariableLocation(ref) => HeapVariableLocation(ref.decl)
         case col.FieldLocation(_, field) => FieldLocation(field.decl)
@@ -137,26 +137,32 @@ case class EncodeResourceValues[Pre <: Generation]()
       fromValue: Expr[Post] => Expr[Post],
   )
 
-  val patternBuilders: ScopedStack[Map[ResourcePattern, PatternBuilder]] =
+  private val patternBuilders
+      : ScopedStack[Map[ResourcePattern, PatternBuilder]] = ScopedStack()
+  private val valAdt: ScopedStack[AxiomaticDataType[Post]] = ScopedStack()
+  private val kindFunc: ScopedStack[ADTFunction[Post]] = ScopedStack()
+  private val arbitraryResourceValue: ScopedStack[Predicate[Post]] =
     ScopedStack()
-  val valAdt: ScopedStack[AxiomaticDataType[Post]] = ScopedStack()
-  val kindFunc: ScopedStack[ADTFunction[Post]] = ScopedStack()
-  val arbitraryResourceValue: ScopedStack[Predicate[Post]] = ScopedStack()
 
-  def isGeneric(cls: Class[Pre]): Boolean = !cls.typeArgs.isEmpty
-  def nonGeneric(cls: Class[Pre]): Unit =
+  private def isGeneric(cls: Class[Pre]): Boolean = cls.typeArgs.nonEmpty
+  private def nonGeneric(cls: Class[Pre]): Unit =
     if (isGeneric(cls))
       throw GenericsNotSupported(cls)
 
   override def dispatch(program: Program[Pre]): Program[Post] = {
     implicit val o: Origin = program.o
 
+    val shouldCreateAdt =
+      program.collectFirst {
+        case _: ResourceValue[Pre] | _: ResourceOfResourceValue[Pre] |
+            _: TResourceVal[Pre] =>
+      }.isDefined
     val patterns =
       program.collect { case ResourceValue(res) => ResourcePattern.scan(res) }
         .toIndexedSeq
 
-    if (patterns.isEmpty) {
-      return patternBuilders.having(Map.empty) { rewriteDefault(program) }
+    if (!shouldCreateAdt) {
+      return patternBuilders.having(Map.empty) { super.dispatch(program) }
     }
 
     val fieldOwner =
@@ -459,19 +465,19 @@ case class EncodeResourceValues[Pre <: Generation]()
 
         Let(binding, dispatch(resourceValue), select)
 
-      case other => rewriteDefault(other)
+      case other => super.dispatch(other)
     }
 
   override def dispatch(t: Type[Pre]): Type[Post] =
     t match {
       case TResourceVal() => TAxiomatic(valAdt.top.ref, Nil)
-      case other => rewriteDefault(other)
+      case other => super.dispatch(other)
     }
 
   override def dispatch(decl: Declaration[Pre]): Unit =
     decl match {
       case m: AbstractMethod[Pre] if m.returnType == TResourceVal[Pre]() =>
-        throw new ResourceValueReturnType(m)
+        throw ResourceValueReturnType(m)
       case _ => super.dispatch(decl)
     }
 }

--- a/src/rewrite/vct/rewrite/exc/SpecifyImplicitLabels.scala
+++ b/src/rewrite/vct/rewrite/exc/SpecifyImplicitLabels.scala
@@ -43,7 +43,7 @@ case class SpecifyImplicitLabels[Pre <: Generation]() extends Rewriter[Pre] {
       case Label(decl, impl) if isBreakable(impl) =>
         val newLabel = decl.rewrite()
         labelDecls.succeedOnly(decl, newLabel)
-        val newImpl = labelStack.having(newLabel) { dispatch(impl) }
+        val newImpl = labelStack.having(newLabel) { impl.rewriteDefault() }
         Label(newLabel, newImpl)(stat.o)
       case stat if isBreakable(stat) =>
         implicit val o: Origin = stat.o

--- a/src/rewrite/vct/rewrite/exc/SpecifyImplicitLabels.scala
+++ b/src/rewrite/vct/rewrite/exc/SpecifyImplicitLabels.scala
@@ -5,19 +5,33 @@ import vct.col.ast.RewriteHelpers._
 import vct.col.ast._
 import vct.col.origin.Origin
 import vct.col.rewrite.{Generation, Rewriter, RewriterBuilder}
+import vct.result.VerificationError.UserError
 
 case object SpecifyImplicitLabels extends RewriterBuilder {
   override def key: String = "implicitLabels"
   override def desc: String =
     "Give loops and switches a label if it needs one for a break or continue statement."
+
+  private case class UnexpectedControlFlow(node: Statement[_])
+      extends UserError {
+    override def code: String = "unexpectedControlFlow"
+
+    override def text: String =
+      node.o.messageInContext(
+        "This statement is only allowed inside of a loop and switch statements"
+      )
+  }
+
+  private def ImplicitLabelOrigin(inner: Origin): Origin =
+    inner.where(name = "loop")
 }
 
 case class SpecifyImplicitLabels[Pre <: Generation]() extends Rewriter[Pre] {
-  def ImplicitLabelOrigin(inner: Origin): Origin = inner.where(name = "loop")
+  import SpecifyImplicitLabels._
 
   val labelStack = new ScopedStack[LabelDecl[Post]]()
 
-  def isBreakable(s: Statement[_]): Boolean =
+  private def isBreakable(s: Statement[_]): Boolean =
     s match {
       case _: Loop[_] => true
       case _: Switch[_] => true
@@ -29,15 +43,18 @@ case class SpecifyImplicitLabels[Pre <: Generation]() extends Rewriter[Pre] {
       case Label(decl, impl) if isBreakable(impl) =>
         val newLabel = decl.rewrite()
         labelDecls.succeedOnly(decl, newLabel)
-        val newImpl = labelStack.having(newLabel) { rewriteDefault(impl) }
+        val newImpl = labelStack.having(newLabel) { dispatch(impl) }
         Label(newLabel, newImpl)(stat.o)
       case stat if isBreakable(stat) =>
         implicit val o: Origin = stat.o
         val labelDecl = new LabelDecl[Post]()(ImplicitLabelOrigin(o))
-        labelStack.having(labelDecl) { Label(labelDecl, rewriteDefault(stat)) }
+        labelStack.having(labelDecl) { Label(labelDecl, stat.rewriteDefault()) }
+      case Continue(None) if labelStack.isEmpty =>
+        throw UnexpectedControlFlow(stat)
       case c @ Continue(None) => c.rewrite(Some(labelStack.top.ref))
+      case Break(None) if labelStack.isEmpty =>
+        throw UnexpectedControlFlow(stat)
       case b @ Break(None) => b.rewrite(Some(labelStack.top.ref))
-
-      case other => rewriteDefault(other)
+      case other => super.dispatch(other)
     }
 }

--- a/src/rewrite/vct/rewrite/lang/LangCToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangCToCol.scala
@@ -1465,7 +1465,6 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
           struct.ref.decl.decl match {
             case CDeclaration(
                   _,
-                  _,
                   Seq(CStructDeclaration(Some(_), decls)),
                   Seq(),
                 ) =>
@@ -1501,7 +1500,6 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
     val (decls, sdecl) =
       decl.decl match {
         case CDeclaration(
-              _,
               _,
               Seq(sdecl @ CStructDeclaration(Some(_), decls)),
               Seq(),

--- a/src/rewrite/vct/rewrite/lang/LangJavaToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangJavaToCol.scala
@@ -756,9 +756,9 @@ case class LangJavaToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
   def classType(t: JavaTClass[Pre]): Type[Post] =
     t.ref.decl match {
       case classOrInterface: JavaClassOrInterface[Pre] =>
-        TByReferenceClass(
+        TByReferenceClass[Post](
           javaInstanceClassSuccessor.ref(classOrInterface),
           t.typeArgs.map(rw.dispatch),
-        )
+        )(t.o)
     }
 }

--- a/src/rewrite/vct/rewrite/lang/LangPVLToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangPVLToCol.scala
@@ -230,11 +230,14 @@ case class LangPVLToCol[Pre <: Generation](
   def rewriteMainMethod(main: VeSUVMainMethod[Pre]): Unit = {
     implicit val o: Origin = main.o
     main.drop()
-    val body: Option[Statement[Post]] =
-      main.body match {
-        case None => None
-        case Some(s) => Some(s.rewriteDefault())
+    val body: Option[Statement[Post]] = {
+      rw.labelDecls.scope {
+        main.body match {
+          case None => None
+          case Some(s) => Some(s.rewriteDefault())
+        }
       }
+    }
     val empty_pred: AccountedPredicate[Post] = UnitAccountedPredicate(
       BooleanValue(value = true)
     )

--- a/src/rewrite/vct/rewrite/lang/LangTypesToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangTypesToCol.scala
@@ -9,7 +9,6 @@ import vct.col.rewrite.{Generation, Rewriter, RewriterBuilderArg, Rewritten}
 import vct.col.typerules.PlatformContext
 import vct.col.util.SuccessionMap
 import vct.result.VerificationError.UserError
-import vct.rewrite.lang.LangTypesToCol.{EmptyInlineDecl, IncompleteTypeArgs}
 
 import scala.reflect.ClassTag
 
@@ -33,10 +32,27 @@ case object LangTypesToCol extends RewriterBuilderArg[PlatformContext] {
     override def text: String =
       d.o.messageInContext(" ‘inline’ in empty declaration.")
   }
+
+  case class ContractOnMultiInitialiser(d: CDeclaration[_]) extends UserError {
+    override def code: String = "contractMultipleInit"
+    override def text: String =
+      d.o.messageInContext(
+        "A contract cannot be placed on a declaration with more than one initialiser"
+      )
+  }
+
+  case class ContractOnVariable(n: Node[_]) extends UserError {
+    override def code: String = "contractOnVariable"
+    override def text: String =
+      n.o.messageInContext(
+        "A contract cannot be placed on a variable declaration"
+      )
+  }
 }
 
 case class LangTypesToCol[Pre <: Generation](platformContext: PlatformContext)
     extends Rewriter[Pre] {
+  import LangTypesToCol._
 
   val cStructFieldsSuccessor: SuccessionMap[(CStructMemberDeclarator[
     Pre
@@ -145,6 +161,7 @@ case class LangTypesToCol[Pre <: Generation](platformContext: PlatformContext)
       specifiers: Seq[CDeclarationSpecifier[Pre]],
       declarator: CDeclarator[Pre],
       context: Option[Node[Pre]] = None,
+      hasNonTrivialContract: Boolean = false,
   )(
       implicit o: Origin
   ): (Seq[CDeclarationSpecifier[Post]], CDeclarator[Post]) = {
@@ -168,6 +185,8 @@ case class LangTypesToCol[Pre <: Generation](platformContext: PlatformContext)
             varargs = false,
             CName(info.name),
           )
+        case None if hasNonTrivialContract =>
+          throw ContractOnVariable(context.getOrElse(declarator))
         case None => CName[Post](info.name)
       }
 
@@ -237,11 +256,10 @@ case class LangTypesToCol[Pre <: Generation](platformContext: PlatformContext)
         })
       case declaration: CGlobalDeclaration[Pre] =>
         declaration.decl match {
-          case CDeclaration(_, _, Seq(_: CStructDeclaration[Pre]), Seq()) =>
+          case CDeclaration(_, Seq(_: CStructDeclaration[Pre]), Seq()) =>
             globalDeclarations
               .succeed(declaration, declaration.rewriteDefault())
           case decl @ CDeclaration(
-                _,
                 _,
                 Seq(td: CTypedef[Pre], struct: CStructDeclaration[Pre]),
                 Seq(init),
@@ -250,7 +268,6 @@ case class LangTypesToCol[Pre <: Generation](platformContext: PlatformContext)
               new CGlobalDeclaration[Post](
                 CDeclaration[Post](
                   dispatch(decl.contract),
-                  dispatch(decl.kernelInvariant),
                   Seq(dispatch(struct)),
                   Seq(),
                 )(decl.o)
@@ -260,12 +277,16 @@ case class LangTypesToCol[Pre <: Generation](platformContext: PlatformContext)
 
             globalDeclarations.succeed(declaration, structDecl)
           case decl =>
+            val hasNonTrivialContract = decl.contract.nonEmpty
+            if (hasNonTrivialContract && decl.inits.length > 1)
+              throw ContractOnMultiInitialiser(decl)
             decl.inits.foreach(init => {
               implicit val o: Origin = init.o
               val (specs, decl1) = normalizeCDeclaration(
                 decl.specs,
                 init.decl,
                 context = Some(declaration),
+                hasNonTrivialContract,
               )
               globalDeclarations.declare(declaration.rewrite(decl =
                 declaration.decl.rewrite(


### PR DESCRIPTION
Checklist: <!-- Please first submit your pull request, you can check the checkboxes later. Feel free to ask for help if you don't know how/where to make changes. -->

- [ ] The wiki is updated in accordance with the changes in this PR. For example: syntax changes, semantics changes, VerCors flags changes, etc.

# PR description
These were all bugs found by @wandernauta's AValAnCHE fuzzing tool
- Fix #1306 
- Add error when a contract is given for C variables or if there are multiple initialisers
- Add missing LabelDecl scope for vesuv_run and Java (static initialisers) (fix #1313)
- Replace crash by UserError for `continue` and `break` outside of loops and switch statements
- Check for invalid signals clause type early to prevent crash
- Check for type-arg arity for class types earlier to prevent crashes (also made the origin for the type stick around a bit better so that this error looks nicer)
<!-- Describe the motivation of the PR and the changes it introduces. Why is it needed, and what does it change? -->
