### PR TITLE
Fix #1123 and #1366

### DIFF
--- a/src/col/vct/col/origin/Blame.scala
+++ b/src/col/vct/col/origin/Blame.scala
@@ -1607,10 +1607,6 @@ object DerefAssignTarget
     extends PanicBlame(
       "Assigning to a field should trigger an error on the assignment, and not on the dereference."
     )
-object SubscriptAssignTarget
-    extends PanicBlame(
-      "Assigning to a subscript should trigger an error on the assignment, and not on the subscript."
-    )
 object DerefPerm
     extends PanicBlame(
       "Dereferencing a field in a permission should trigger an error on the permission, not on the dereference."

--- a/src/rewrite/vct/rewrite/ResolveExpressionSideEffects.scala
+++ b/src/rewrite/vct/rewrite/ResolveExpressionSideEffects.scala
@@ -11,7 +11,6 @@ import vct.col.origin.{
   LabelContext,
   Origin,
   PreferredName,
-  SubscriptAssignTarget,
 }
 import vct.col.ref.Ref
 import vct.col.rewrite.{
@@ -515,17 +514,17 @@ case class ResolveExpressionSideEffects[Pre <: Generation]()
           SilverDeref[Post](notInlined(obj), succ(f))(DerefAssignTarget)(
             target.o
           )
-        case ArraySubscript(arr, index) =>
-          ArraySubscript[Post](notInlined(arr), notInlined(index))(
-            SubscriptAssignTarget
-          )(target.o)
+        case sub @ ArraySubscript(arr, index) =>
+          ArraySubscript[Post](notInlined(arr), notInlined(index))(sub.blame)(
+            target.o
+          )
         case PointerSubscript(arr, index)
             if arr.t.isInstanceOf[TConstPointer[_]] =>
           throw DisallowedAssignmentTarget(target)
-        case PointerSubscript(arr, index) =>
-          PointerSubscript[Post](notInlined(arr), notInlined(index))(
-            SubscriptAssignTarget
-          )(target.o)
+        case sub @ PointerSubscript(arr, index) =>
+          PointerSubscript[Post](notInlined(arr), notInlined(index))(sub.blame)(
+            target.o
+          )
         case deref @ DerefPointer(ptr) =>
           DerefPointer[Post](notInlined(ptr))(deref.blame)(target.o)
         case VectorSubscript(_, _) => throw DisallowedAssignmentTarget(target)


### PR DESCRIPTION
Checklist: <!-- Please first submit your pull request, you can check the checkboxes later. Feel free to ask for help if you don't know how/where to make changes. -->

- [x] The wiki is updated in accordance with the changes in this PR. For example: syntax changes, semantics changes, VerCors flags changes, etc.

# PR description

<!-- Describe the motivation of the PR and the changes it introduces. Why is it needed, and what does it change? -->
- Replace the PanicBlame with the actual blame. I believe it is actually fine for these bounds and null checks to be reported on the subscripts.