### PR TITLE
Pallas: Fix bug in type inference for literal LLVMStructs

### DIFF
--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -4272,6 +4272,7 @@ final case class LLVMTStruct[G](
     packed: Boolean,
     isLiteral: Boolean,
     elements: Seq[Type[G]],
+    sizeBytes: Int, // Number of bytes that are allocated for this type
 )(implicit val o: Origin = DiagnosticOrigin)
     extends Type[G] with LLVMTStructImpl[G]
 final case class LLVMTArray[G](numElements: Long, elementType: Type[G])(

--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -4270,6 +4270,7 @@ final case class LLVMTMetadata[G]()(implicit val o: Origin = DiagnosticOrigin)
 final case class LLVMTStruct[G](
     name: Option[String],
     packed: Boolean,
+    isLiteral: Boolean,
     elements: Seq[Type[G]],
 )(implicit val o: Origin = DiagnosticOrigin)
     extends Type[G] with LLVMTStructImpl[G]

--- a/src/col/vct/col/ast/lang/llvm/LLVMTStructImpl.scala
+++ b/src/col/vct/col/ast/lang/llvm/LLVMTStructImpl.scala
@@ -19,7 +19,5 @@ trait LLVMTStructImpl[G] extends LLVMTStructOps[G] {
       (layoutPacked(Text("{") <> Doc.args(elements) <> "}"))
   }
 
-  override def bits: TypeSize =
-    if (packed) { TypeSize.packed(elements.map(_.bits): _*) }
-    else { TypeSize.struct(elements.map(_.bits): _*) }
+  override def bits: TypeSize = { TypeSize.Exact(sizeBytes * 8) }
 }

--- a/src/col/vct/col/typerules/CoercionUtils.scala
+++ b/src/col/vct/col/typerules/CoercionUtils.scala
@@ -761,7 +761,7 @@ case object CoercionUtils {
           firstElementIsType(field.t, innerType)
         }.getOrElse(false)
       case TArray(element) => firstElementIsType(element, innerType)
-      case LLVMTStruct(_, _, _, elements) =>
+      case LLVMTStruct(_, _, _, elements, _) =>
         firstElementIsType(elements.head, innerType)
       case LLVMTArray(numElements, elementType) =>
         numElements > 0 && firstElementIsType(elementType, innerType)

--- a/src/col/vct/col/typerules/CoercionUtils.scala
+++ b/src/col/vct/col/typerules/CoercionUtils.scala
@@ -761,7 +761,7 @@ case object CoercionUtils {
           firstElementIsType(field.t, innerType)
         }.getOrElse(false)
       case TArray(element) => firstElementIsType(element, innerType)
-      case LLVMTStruct(_, _, elements) =>
+      case LLVMTStruct(_, _, _, elements) =>
         firstElementIsType(elements.head, innerType)
       case LLVMTArray(numElements, elementType) =>
         numElements > 0 && firstElementIsType(elementType, innerType)

--- a/src/llvm/include/Transform/Transform.h
+++ b/src/llvm/include/Transform/Transform.h
@@ -1,6 +1,7 @@
 #ifndef PALLAS_TRANSFORM_H
 #define PALLAS_TRANSFORM_H
 
+#include <llvm/IR/DataLayout.h>
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/Support/Casting.h>
 
@@ -15,9 +16,11 @@ namespace llvm2col {
 namespace col = vct::col::ast;
 
 // type transformers
-void transformAndSetPointerType(llvm::Type &llvmType, col::Type &colType);
+void transformAndSetPointerType(llvm::Type &llvmType, col::Type &colType,
+                                const llvm::DataLayout &dataLayout);
 
-void transformAndSetType(llvm::Type &llvmType, col::Type &colType);
+void transformAndSetType(llvm::Type &llvmType, col::Type &colType,
+                         const llvm::DataLayout &dataLayout);
 
 /**
  * ATTEMPTS to convert any integer constant to a BigInt representation.
@@ -46,7 +49,8 @@ void transformAndSetExpr(pallas::FunctionCursor &functionCursor,
  */
 void transformAndSetConstExpr(llvm::FunctionAnalysisManager &FAM,
                               col::Origin *origin, llvm::Constant &llvmConstant,
-                              col::Expr &colExpr);
+                              col::Expr &colExpr,
+                              const llvm::DataLayout &dataLayout);
 
 /**
  * Used by TransformAndSetExpr

--- a/src/llvm/lib/Passes/Function/FunctionBodyTransformer.cpp
+++ b/src/llvm/lib/Passes/Function/FunctionBodyTransformer.cpp
@@ -129,12 +129,13 @@ col::Variable &FunctionCursor::declareVariable(Instruction &llvmInstruction,
     }
     // set type of declaration
     try {
+        const auto &dataLayout = llvmInstruction.getModule()->getDataLayout();
         if (llvmPointerType == nullptr) {
             llvm2col::transformAndSetType(*llvmInstruction.getType(),
-                                          *varDecl->mutable_t());
+                                          *varDecl->mutable_t(), dataLayout);
         } else {
-            llvm2col::transformAndSetPointerType(*llvmPointerType,
-                                                 *varDecl->mutable_t());
+            llvm2col::transformAndSetPointerType(
+                *llvmPointerType, *varDecl->mutable_t(), dataLayout);
         }
     } catch (pallas::UnsupportedTypeException &e) {
         std::stringstream errorStream;

--- a/src/llvm/lib/Passes/Function/FunctionDeclarer.cpp
+++ b/src/llvm/lib/Passes/Function/FunctionDeclarer.cpp
@@ -82,6 +82,7 @@ FDResult FunctionDeclarer::run(Function &F, FunctionAnalysisManager &FAM) {
             llvm2col::generateFuncDefOrigin(F));
     }
     FDResult result = FDResult(*llvmFuncDef, funcScopedBody, functionId);
+    const auto &dataLayout = F.getParent()->getDataLayout();
     // set args (if present)
     for (llvm::Argument &llvmArg : F.args()) {
         // set in buffer
@@ -91,7 +92,7 @@ FDResult FunctionDeclarer::run(Function &F, FunctionAnalysisManager &FAM) {
         llvm2col::setColNodeId(colArg);
         try {
             llvm2col::transformAndSetType(*llvmArg.getType(),
-                                          *colArg->mutable_t());
+                                          *colArg->mutable_t(), dataLayout);
         } catch (pallas::UnsupportedTypeException &e) {
             std::stringstream errorStream;
             errorStream << e.what() << " in argument #" << llvmArg.getArgNo();
@@ -105,7 +106,8 @@ FDResult FunctionDeclarer::run(Function &F, FunctionAnalysisManager &FAM) {
     // set return type in protobuf of function
     try {
         llvm2col::transformAndSetType(*F.getReturnType(),
-                                      *llvmFuncDef->mutable_return_type());
+                                      *llvmFuncDef->mutable_return_type(),
+                                      dataLayout);
     } catch (pallas::UnsupportedTypeException &e) {
         std::stringstream errorStream;
         errorStream << e.what() << " in return signature";
@@ -130,12 +132,14 @@ FDResult FunctionDeclarer::run(Function &F, FunctionAnalysisManager &FAM) {
             auto retIdxT = llvmFuncDef->mutable_return_in_param();
             retIdxT->set_v1(0);
             llvm2col::transformAndSetPointerType(*F.getParamStructRetType(0),
-                                                 *retIdxT->mutable_v2());
+                                                 *retIdxT->mutable_v2(),
+                                                 dataLayout);
         } else if (F.getParamStructRetType(1) != nullptr) {
             auto retIdxT = llvmFuncDef->mutable_return_in_param();
             retIdxT->set_v1(1);
             llvm2col::transformAndSetPointerType(*F.getParamStructRetType(1),
-                                                 *retIdxT->mutable_v2());
+                                                 *retIdxT->mutable_v2(),
+                                                 dataLayout);
         }
     } catch (pallas::UnsupportedTypeException &e) {
         std::stringstream errorStream;

--- a/src/llvm/lib/Passes/Module/GlobalVariableDeclarer.cpp
+++ b/src/llvm/lib/Passes/Module/GlobalVariableDeclarer.cpp
@@ -18,7 +18,8 @@ PreservedAnalyses GlobalVariableDeclarerPass::run(Module &M,
             globDecl->mutable_llvm_global_variable();
 
         llvm2col::transformAndSetType(*global.getType(),
-                                      *colGlobal->mutable_variable_type());
+                                      *colGlobal->mutable_variable_type(),
+                                      M.getDataLayout());
         if (global.hasInitializer()) {
             // Skip the entry-point global from swift, as it contains currently
             // unsupported poitner-casting and is not needed for verification.
@@ -28,10 +29,12 @@ PreservedAnalyses GlobalVariableDeclarerPass::run(Module &M,
                         .getManager(),
                     llvm2col::generateGlobalVariableInitializerOrigin(
                         M, global, *global.getInitializer()),
-                    *global.getInitializer(), *colGlobal->mutable_value());
+                    *global.getInitializer(), *colGlobal->mutable_value(),
+                    M.getDataLayout());
             }
             llvm2col::transformAndSetType(*global.getInitializer()->getType(),
-                                          *colGlobal->mutable_variable_type());
+                                          *colGlobal->mutable_variable_type(),
+                                          M.getDataLayout());
         } else {
             // We don't know more about the type because we don't have an
             // initializer
@@ -39,7 +42,8 @@ PreservedAnalyses GlobalVariableDeclarerPass::run(Module &M,
             // declaration type is the inner type of the pointer. We should
             // instead set the type to be TAny maybe?
             llvm2col::transformAndSetType(*global.getType(),
-                                          *colGlobal->mutable_variable_type());
+                                          *colGlobal->mutable_variable_type(),
+                                          M.getDataLayout());
         }
         colGlobal->set_constant(global.isConstant());
         colGlobal->set_allocated_origin(

--- a/src/llvm/lib/Transform/Instruction/CastOpTransform.cpp
+++ b/src/llvm/lib/Transform/Instruction/CastOpTransform.cpp
@@ -33,6 +33,7 @@ void llvm2col::transformCastOp(llvm::Instruction &llvmInstruction,
 void llvm2col::transformSExt(llvm::SExtInst &sextInstruction,
                              col::LlvmBasicBlock &colBlock,
                              pallas::FunctionCursor &funcCursor) {
+    const auto &dataLayout = sextInstruction.getModule()->getDataLayout();
     col::Assign &assignment =
         funcCursor.createAssignmentAndDeclaration(sextInstruction, colBlock);
     col::Expr *sextExpr = assignment.mutable_value();
@@ -40,9 +41,9 @@ void llvm2col::transformSExt(llvm::SExtInst &sextInstruction,
     sext->set_allocated_origin(
         llvm2col::generateSingleStatementOrigin(sextInstruction));
     llvm2col::transformAndSetType(*sextInstruction.getSrcTy(),
-                                  *sext->mutable_input_type());
+                                  *sext->mutable_input_type(), dataLayout);
     llvm2col::transformAndSetType(*sextInstruction.getDestTy(),
-                                  *sext->mutable_output_type());
+                                  *sext->mutable_output_type(), dataLayout);
     llvm2col::transformAndSetExpr(funcCursor, sextInstruction,
                                   *sextInstruction.getOperand(0),
                                   *sext->mutable_value());
@@ -51,6 +52,7 @@ void llvm2col::transformSExt(llvm::SExtInst &sextInstruction,
 void llvm2col::transformZExt(llvm::ZExtInst &zextInstruction,
                              col::LlvmBasicBlock &colBlock,
                              pallas::FunctionCursor &funcCursor) {
+    const auto &dataLayout = zextInstruction.getModule()->getDataLayout();
     col::Assign &assignment =
         funcCursor.createAssignmentAndDeclaration(zextInstruction, colBlock);
     col::Expr *zextExpr = assignment.mutable_value();
@@ -58,9 +60,9 @@ void llvm2col::transformZExt(llvm::ZExtInst &zextInstruction,
     zext->set_allocated_origin(
         llvm2col::generateSingleStatementOrigin(zextInstruction));
     llvm2col::transformAndSetType(*zextInstruction.getSrcTy(),
-                                  *zext->mutable_input_type());
+                                  *zext->mutable_input_type(), dataLayout);
     llvm2col::transformAndSetType(*zextInstruction.getDestTy(),
-                                  *zext->mutable_output_type());
+                                  *zext->mutable_output_type(), dataLayout);
     llvm2col::transformAndSetExpr(funcCursor, zextInstruction,
                                   *zextInstruction.getOperand(0),
                                   *zext->mutable_value());
@@ -69,6 +71,7 @@ void llvm2col::transformZExt(llvm::ZExtInst &zextInstruction,
 void llvm2col::transformTrunc(llvm::TruncInst &truncInstruction,
                               col::LlvmBasicBlock &colBlock,
                               pallas::FunctionCursor &funcCursor) {
+    const auto &dataLayout = truncInstruction.getModule()->getDataLayout();
     col::Assign &assignment =
         funcCursor.createAssignmentAndDeclaration(truncInstruction, colBlock);
     col::Expr *truncExpr = assignment.mutable_value();
@@ -76,9 +79,9 @@ void llvm2col::transformTrunc(llvm::TruncInst &truncInstruction,
     trunc->set_allocated_origin(
         llvm2col::generateSingleStatementOrigin(truncInstruction));
     llvm2col::transformAndSetType(*truncInstruction.getSrcTy(),
-                                  *trunc->mutable_input_type());
+                                  *trunc->mutable_input_type(), dataLayout);
     llvm2col::transformAndSetType(*truncInstruction.getDestTy(),
-                                  *trunc->mutable_output_type());
+                                  *trunc->mutable_output_type(), dataLayout);
     llvm2col::transformAndSetExpr(funcCursor, truncInstruction,
                                   *truncInstruction.getOperand(0),
                                   *trunc->mutable_value());
@@ -87,6 +90,7 @@ void llvm2col::transformTrunc(llvm::TruncInst &truncInstruction,
 void llvm2col::transformFPExt(llvm::FPExtInst &fpextInstruction,
                               col::LlvmBasicBlock &colBlock,
                               pallas::FunctionCursor &funcCursor) {
+    const auto &dataLayout = fpextInstruction.getModule()->getDataLayout();
     col::Assign &assignment =
         funcCursor.createAssignmentAndDeclaration(fpextInstruction, colBlock);
     col::Expr *fpextExpr = assignment.mutable_value();
@@ -94,9 +98,9 @@ void llvm2col::transformFPExt(llvm::FPExtInst &fpextInstruction,
     fpext->set_allocated_origin(
         llvm2col::generateSingleStatementOrigin(fpextInstruction));
     llvm2col::transformAndSetType(*fpextInstruction.getSrcTy(),
-                                  *fpext->mutable_input_type());
+                                  *fpext->mutable_input_type(), dataLayout);
     llvm2col::transformAndSetType(*fpextInstruction.getDestTy(),
-                                  *fpext->mutable_output_type());
+                                  *fpext->mutable_output_type(), dataLayout);
     llvm2col::transformAndSetExpr(funcCursor, fpextInstruction,
                                   *fpextInstruction.getOperand(0),
                                   *fpext->mutable_value());

--- a/src/llvm/lib/Transform/Instruction/MemoryOpTransform.cpp
+++ b/src/llvm/lib/Transform/Instruction/MemoryOpTransform.cpp
@@ -43,6 +43,7 @@ void llvm2col::transformAllocA(llvm::AllocaInst &allocAInstruction,
     allocA->set_allocated_origin(
         llvm2col::generateSingleStatementOrigin(allocAInstruction));
 
+    const auto &dataLayout = allocAInstruction.getModule()->getDataLayout();
     if (allocAInstruction.getAllocatedType()->getTypeID() ==
         llvm::Type::PointerTyID) {
         // Pointers are opaque so we'll use the metadata to try and figure out
@@ -57,10 +58,12 @@ void llvm2col::transformAllocA(llvm::AllocaInst &allocAInstruction,
             // TODO: Translate this information where possible
         }
         llvm2col::transformAndSetType(*allocAInstruction.getAllocatedType(),
-                                      *allocA->mutable_allocation_type());
+                                      *allocA->mutable_allocation_type(),
+                                      dataLayout);
     } else {
         llvm2col::transformAndSetType(*allocAInstruction.getAllocatedType(),
-                                      *allocA->mutable_allocation_type());
+                                      *allocA->mutable_allocation_type(),
+                                      dataLayout);
     }
     col::Variable &varDecl = funcCursor.declareVariable(
         allocAInstruction, allocAInstruction.getAllocatedType());
@@ -119,7 +122,8 @@ void llvm2col::transformLoad(llvm::LoadInst &loadInstruction,
     col::Variable &varDecl = funcCursor.declareVariable(loadInstruction);
     load->mutable_variable()->set_id(varDecl.id());
     llvm2col::transformAndSetType(*loadInstruction.getType(),
-                                  *load->mutable_load_type());
+                                  *load->mutable_load_type(),
+                                  loadInstruction.getModule()->getDataLayout());
     llvm2col::transformAndSetExpr(funcCursor, loadInstruction,
                                   *loadInstruction.getPointerOperand(),
                                   *load->mutable_pointer());
@@ -150,6 +154,7 @@ void llvm2col::transformGetElementPtr(llvm::GetElementPtrInst &gepInstruction,
                                       col::LlvmBasicBlock &colBlock,
                                       pallas::FunctionCursor &funcCursor) {
 
+    const auto &dataLayout = gepInstruction.getModule()->getDataLayout();
     col::Assign &assignment = funcCursor.createAssignmentAndDeclaration(
         gepInstruction, colBlock, gepInstruction.getResultElementType());
     col::Expr *gepExpr = assignment.mutable_value();
@@ -158,9 +163,9 @@ void llvm2col::transformGetElementPtr(llvm::GetElementPtrInst &gepInstruction,
     gep->set_allocated_origin(
         llvm2col::generateSingleStatementOrigin(gepInstruction));
     llvm2col::transformAndSetType(*gepInstruction.getSourceElementType(),
-                                  *gep->mutable_structure_type());
+                                  *gep->mutable_structure_type(), dataLayout);
     llvm2col::transformAndSetType(*gepInstruction.getResultElementType(),
-                                  *gep->mutable_result_type());
+                                  *gep->mutable_result_type(), dataLayout);
     llvm2col::transformAndSetExpr(funcCursor, gepInstruction,
                                   *gepInstruction.getPointerOperand(),
                                   *gep->mutable_pointer());

--- a/src/llvm/lib/Transform/Instruction/OtherOpTransform.cpp
+++ b/src/llvm/lib/Transform/Instruction/OtherOpTransform.cpp
@@ -238,6 +238,7 @@ void llvm2col::transformCmpExpr(llvm::CmpInst &cmpInstruction,
 void llvm2col::transformExtractValueInst(
     llvm::ExtractValueInst &llvmInstruction, col::LlvmBasicBlock &colBlock,
     pallas::FunctionCursor &funcCursor) {
+    const auto &dataLayout = llvmInstruction.getModule()->getDataLayout();
     col::Assign &assignment =
         funcCursor.createAssignmentAndDeclaration(llvmInstruction, colBlock);
     col::LlvmExtractValue *extrVal =
@@ -247,10 +248,10 @@ void llvm2col::transformExtractValueInst(
     // Aggregate type
     llvm2col::transformAndSetType(
         *llvmInstruction.getAggregateOperand()->getType(),
-        *extrVal->mutable_aggregate_type());
+        *extrVal->mutable_aggregate_type(), dataLayout);
     // Result type
     llvm2col::transformAndSetType(*llvmInstruction.getType(),
-                                  *extrVal->mutable_result_type());
+                                  *extrVal->mutable_result_type(), dataLayout);
     // Value
     llvm2col::transformAndSetExpr(funcCursor, llvmInstruction,
                                   *llvmInstruction.getAggregateOperand(),
@@ -812,7 +813,9 @@ void llvm2col::transformPallasBoundVar(llvm::CallInst &callInstruction,
         auto strRepr = constArr->isCString() ? constArr->getAsCString()
                                              : constArr->getAsString();
         bv->set_id(strRepr.str());
-        llvm2col::transformAndSetType(*type, *bv->mutable_var_type());
+        llvm2col::transformAndSetType(
+            *type, *bv->mutable_var_type(),
+            callInstruction.getModule()->getDataLayout());
     } else {
         pallas::ErrorReporter::addError(
             SOURCE_LOC, "Unsupported use of bound variable.", callInstruction);

--- a/src/llvm/lib/Transform/Transform.cpp
+++ b/src/llvm/lib/Transform/Transform.cpp
@@ -15,13 +15,16 @@ const std::string SOURCE_LOC = "Transform::Transform";
 namespace col = vct::col::ast;
 
 void llvm2col::transformAndSetPointerType(llvm::Type &llvmType,
-                                          col::Type &colType) {
+                                          col::Type &colType,
+                                          const llvm::DataLayout &dataLayout) {
     col::LlvmtPointer *pointerType = colType.mutable_llvmt_pointer();
     pointerType->set_allocated_origin(generateTypeOrigin(llvmType));
-    llvm2col::transformAndSetType(llvmType, *pointerType->mutable_inner_type());
+    llvm2col::transformAndSetType(llvmType, *pointerType->mutable_inner_type(),
+                                  dataLayout);
 }
 
-void llvm2col::transformAndSetType(llvm::Type &llvmType, col::Type &colType) {
+void llvm2col::transformAndSetType(llvm::Type &llvmType, col::Type &colType,
+                                   const llvm::DataLayout &dataLayout) {
     switch (llvmType.getTypeID()) {
     case llvm::Type::IntegerTyID:
         if (llvmType.getIntegerBitWidth() == 1) {
@@ -106,10 +109,12 @@ void llvm2col::transformAndSetType(llvm::Type &llvmType, col::Type &colType) {
             // won't be set for literal types
             colStruct->set_name(structType.getName().str());
         }
+        colStruct->set_size_bytes(dataLayout.getTypeAllocSize(&structType));
         colStruct->set_is_literal(structType.isLiteral());
         colStruct->set_packed(structType.isPacked());
         for (llvm::Type *element : structType.elements()) {
-            llvm2col::transformAndSetType(*element, *colStruct->add_elements());
+            llvm2col::transformAndSetType(*element, *colStruct->add_elements(),
+                                          dataLayout);
         }
         break;
     }
@@ -118,7 +123,8 @@ void llvm2col::transformAndSetType(llvm::Type &llvmType, col::Type &colType) {
         col::LlvmtArray *colArray = colType.mutable_llvmt_array();
         colArray->set_allocated_origin(generateTypeOrigin(llvmType));
         llvm2col::transformAndSetType(*arrayType.getElementType(),
-                                      *colArray->mutable_element_type());
+                                      *colArray->mutable_element_type(),
+                                      dataLayout);
         colArray->set_num_elements(arrayType.getNumElements());
         break;
     }
@@ -128,7 +134,8 @@ void llvm2col::transformAndSetType(llvm::Type &llvmType, col::Type &colType) {
         col::LlvmtVector *colVector = colType.mutable_llvmt_vector();
         colVector->set_allocated_origin(generateTypeOrigin(llvmType));
         llvm2col::transformAndSetType(*vectorType.getElementType(),
-                                      *colVector->mutable_element_type());
+                                      *colVector->mutable_element_type(),
+                                      dataLayout);
         colVector->set_num_elements(
             vectorType.getElementCount().getKnownMinValue());
         break;
@@ -147,7 +154,8 @@ void llvm2col::transformAndSetExpr(pallas::FunctionCursor &functionCursor,
     if (llvm::isa<llvm::Constant>(llvmOperand)) {
         transformAndSetConstExpr(
             functionCursor.getFunctionAnalysisManager(), origin,
-            llvm::cast<llvm::Constant>(llvmOperand), colExpr);
+            llvm::cast<llvm::Constant>(llvmOperand), colExpr,
+            llvmInstruction.getModule()->getDataLayout());
     } else {
         transformAndSetVarExpr(functionCursor, origin,
                                llvmInstruction.getOpcode() ==
@@ -170,14 +178,16 @@ void llvm2col::transformAndSetVarExpr(pallas::FunctionCursor &functionCursor,
 void llvm2col::transformAndSetConstExpr(llvm::FunctionAnalysisManager &FAM,
                                         col::Origin *origin,
                                         llvm::Constant &llvmConstant,
-                                        col::Expr &colExpr) {
+                                        col::Expr &colExpr,
+                                        const llvm::DataLayout &dataLayout) {
     if (llvm::isa<llvm::ConstantAggregateZero>(llvmConstant)) {
         col::LlvmZeroedAggregateValue *colZero =
             colExpr.mutable_llvm_zeroed_aggregate_value();
 
         colZero->set_allocated_origin(origin);
         llvm2col::transformAndSetType(*llvmConstant.getType(),
-                                      *colZero->mutable_aggregate_type());
+                                      *colZero->mutable_aggregate_type(),
+                                      dataLayout);
         return;
     }
     llvm::Type *constType = llvmConstant.getType();
@@ -321,11 +331,12 @@ void llvm2col::transformAndSetConstExpr(llvm::FunctionAnalysisManager &FAM,
             llvm2col::transformAndSetConstExpr(
                 FAM, llvm2col::deepenOperandOrigin(*origin, *operand.get()),
                 llvm::cast<llvm::Constant>(*operand.get()),
-                *colStruct->add_value());
+                *colStruct->add_value(), dataLayout);
         }
         colStruct->set_allocated_origin(origin);
         llvm2col::transformAndSetType(*llvmStruct.getType(),
-                                      *colStruct->mutable_struct_type());
+                                      *colStruct->mutable_struct_type(),
+                                      dataLayout);
 
         break;
     }
@@ -339,11 +350,12 @@ void llvm2col::transformAndSetConstExpr(llvm::FunctionAnalysisManager &FAM,
                 llvm2col::transformAndSetConstExpr(
                     FAM, llvm2col::deepenOperandOrigin(*origin, *operand.get()),
                     llvm::cast<llvm::Constant>(*operand.get()),
-                    *colArray->add_value());
+                    *colArray->add_value(), dataLayout);
             }
             colArray->set_allocated_origin(origin);
             llvm2col::transformAndSetType(*llvmArray.getType(),
-                                          *colArray->mutable_array_type());
+                                          *colArray->mutable_array_type(),
+                                          dataLayout);
         } else {
             llvm::ConstantDataArray &llvmArray =
                 llvm::cast<llvm::ConstantDataArray>(llvmConstant);
@@ -358,7 +370,8 @@ void llvm2col::transformAndSetConstExpr(llvm::FunctionAnalysisManager &FAM,
             llvm::errs() << "Array constant " << llvmArray << " has type "
                          << *llvmArray.getType() << "\n";
             llvm2col::transformAndSetType(*llvmArray.getType(),
-                                          *colArray->mutable_array_type());
+                                          *colArray->mutable_array_type(),
+                                          dataLayout);
         }
 
         break;
@@ -374,11 +387,12 @@ void llvm2col::transformAndSetConstExpr(llvm::FunctionAnalysisManager &FAM,
                 llvm2col::transformAndSetConstExpr(
                     FAM, llvm2col::deepenOperandOrigin(*origin, *operand.get()),
                     llvm::cast<llvm::Constant>(*operand.get()),
-                    *colVector->add_value());
+                    *colVector->add_value(), dataLayout);
             }
             colVector->set_allocated_origin(origin);
             llvm2col::transformAndSetType(*llvmVector.getType(),
-                                          *colVector->mutable_vector_type());
+                                          *colVector->mutable_vector_type(),
+                                          dataLayout);
         } else {
             llvm::ConstantDataVector &llvmVector =
                 llvm::cast<llvm::ConstantDataVector>(llvmConstant);
@@ -391,7 +405,8 @@ void llvm2col::transformAndSetConstExpr(llvm::FunctionAnalysisManager &FAM,
             colVector->set_value(llvmVector.getRawDataValues().str());
             colVector->set_allocated_origin(origin);
             llvm2col::transformAndSetType(*llvmVector.getType(),
-                                          *colVector->mutable_vector_type());
+                                          *colVector->mutable_vector_type(),
+                                          dataLayout);
         }
 
         break;

--- a/src/llvm/lib/Transform/Transform.cpp
+++ b/src/llvm/lib/Transform/Transform.cpp
@@ -106,6 +106,7 @@ void llvm2col::transformAndSetType(llvm::Type &llvmType, col::Type &colType) {
             // won't be set for literal types
             colStruct->set_name(structType.getName().str());
         }
+        colStruct->set_is_literal(structType.isLiteral());
         colStruct->set_packed(structType.isPacked());
         for (llvm::Type *element : structType.elements()) {
             llvm2col::transformAndSetType(*element, *colStruct->add_elements());

--- a/src/llvm/lib/Util/PallasWrapperUtils.cpp
+++ b/src/llvm/lib/Util/PallasWrapperUtils.cpp
@@ -45,8 +45,9 @@ void buildArgExprFromAlloca(col::LlvmFunctionInvocation &wrapperCall,
         col::TypeValue *tVal = cast->mutable_type_value()->mutable_type_value();
         tVal->set_allocated_origin(
             llvm2col::generatePallasWrapperCallOrigin(llvmWFunc, srcLoc));
-        llvm2col::transformAndSetPointerType(*expectedTy,
-                                             *tVal->mutable_value());
+        llvm2col::transformAndSetPointerType(
+            *expectedTy, *tVal->mutable_value(),
+            llvmAlloca.getModule()->getDataLayout());
         local = cast->mutable_value()->mutable_local();
     } else {
         local = ptrDeref->mutable_pointer()->mutable_local();

--- a/src/rewrite/vct/rewrite/lang/LangCToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangCToCol.scala
@@ -1490,10 +1490,10 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
           t +: getFirstTypes(t)
         }.getOrElse(Nil)
       case TArray(element) => element +: getFirstTypes(element)
-      case LLVMTStruct(_, _, _, elements) =>
+      case LLVMTStruct(_, _, _, elements, _) =>
         elements.headOption.map { field => field +: getFirstTypes(field) }
           .getOrElse(Nil)
-      case LLVMTStruct(_, _, _, elements) =>
+      case LLVMTStruct(_, _, _, elements, _) =>
         elements.head +: getFirstTypes(elements.head)
       case LLVMTArray(_, elementType) =>
         elementType +: getFirstTypes(elementType)

--- a/src/rewrite/vct/rewrite/lang/LangCToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangCToCol.scala
@@ -1490,10 +1490,10 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
           t +: getFirstTypes(t)
         }.getOrElse(Nil)
       case TArray(element) => element +: getFirstTypes(element)
-      case LLVMTStruct(_, _, elements) =>
+      case LLVMTStruct(_, _, _, elements) =>
         elements.headOption.map { field => field +: getFirstTypes(field) }
           .getOrElse(Nil)
-      case LLVMTStruct(_, _, elements) =>
+      case LLVMTStruct(_, _, _, elements) =>
         elements.head +: getFirstTypes(elements.head)
       case LLVMTArray(_, elementType) =>
         elementType +: getFirstTypes(elementType)

--- a/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
@@ -261,9 +261,9 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
         case (s1: LLVMTStruct[Pre], s2: LLVMTStruct[Pre])
             if moreSpecificLitStruct(s2, s1) =>
           false
-        case (LLVMTStruct(_, _, _, a), LLVMTStruct(_, _, _, b)) =>
+        case (LLVMTStruct(_, _, _, a, _), LLVMTStruct(_, _, _, b, _)) =>
           a.headOption.exists(ta => b.exists(tb => moreSpecific(ta, tb)))
-        case (LLVMTStruct(_, _, _, _), _) => true
+        case (LLVMTStruct(_, _, _, _, _), _) => true
         case (LLVMTArray(_, a), LLVMTArray(_, b)) => moreSpecific(a, b)
         case (LLVMTArray(_, _), _) => true
         case _ => false
@@ -277,7 +277,7 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
         other: LLVMTStruct[Pre],
     ): Boolean = {
       !self.isLiteral && other.isLiteral && self.packed == other.packed &&
-      self.elements == other.elements
+      self.elements == other.elements && self.sizeBytes == other.sizeBytes
     }
 
     // TODO: This sorting is non-stable which might cause nondeterministic bugs if there's something wrong with moreSpecific
@@ -772,7 +772,7 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
   }
 
   def rewriteStruct(t: LLVMTStruct[Pre]): Unit = {
-    val LLVMTStruct(name, packed, literal, elements) = t
+    val LLVMTStruct(name, packed, literal, elements, size) = t
     val newStruct =
       new ByValueClass[Post](
         Seq(),
@@ -938,7 +938,7 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
         }
       }
       case LLVMTPointer(
-            Some(struct @ LLVMTStruct(name, packed, literal, elements))
+            Some(struct @ LLVMTStruct(name, packed, literal, elements, size))
           ) => {
         derefUntil(
           Deref[Post](
@@ -951,12 +951,12 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
           (
             expr,
             LLVMTPointer[Pre](Some(
-              LLVMTStruct(name, packed, literal, inner +: elements.tail)
+              LLVMTStruct(name, packed, literal, inner +: elements.tail, size)
             )),
           )
         }
       }
-      case struct @ LLVMTStruct(name, packed, literal, elements) => {
+      case struct @ LLVMTStruct(name, packed, literal, elements, size) => {
         derefUntil(
           Deref[Post](pointer, structFieldMap.ref((struct, 0)))(pointer.o),
           elements.head,
@@ -964,7 +964,13 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
         ).map { case (expr, inner) =>
           (
             expr,
-            LLVMTStruct[Pre](name, packed, literal, inner +: elements.tail),
+            LLVMTStruct[Pre](
+              name,
+              packed,
+              literal,
+              inner +: elements.tail,
+              size,
+            ),
           )
         }
       }
@@ -1143,6 +1149,7 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
                 _,
                 _,
                 Seq(res: LLVMTInt[Pre], flag: TBool[Pre]),
+                _,
               ) =>
             (res, flag)
         }
@@ -1371,13 +1378,16 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
 
   def rewriteMemset(memset: LLVMMemset[Pre]): Statement[Post] = {
     implicit val o: Origin = memset.o
+
     // Curently only memset with constant value of 0 is supported
     memset.value match {
       case LLVMIntegerValue(v, _) if v.intValue == 0 =>
       case _ => throw UnsupportedMemset(memset)
     }
     // TODO: Make this more more generic
-    //  Currently, only very basic type-wrapper structs are supported (i.e. a packed struct with one integer value)
+    // Currently only structs where all fields are integers are supported.
+    // Also, the number of bytes of the memset must exactly match the size
+    // of the struct type.
     val numBytes =
       memset.len match {
         case LLVMIntegerValue(bytes, _) => bytes
@@ -1388,10 +1398,39 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
         case Local(Ref(v)) =>
           v.t match {
             case LLVMTPointer(Some(s: LLVMTStruct[Pre])) => s
-            case _ => throw throw UnsupportedMemset(memset)
+            case _ => throw UnsupportedMemset(memset)
           }
         case _ => throw UnsupportedMemset(memset)
       }
+
+    if (structType.sizeBytes != numBytes.intValue) {
+      throw UnsupportedMemset(memset)
+    }
+
+    // TODO: Slap a block here to put the assignments in
+    // val fieldAssignments = mutable.Seq[Assign[Post]]
+
+    // Set all fields of the struct to 0
+    structType.elements.zipWithIndex.foreach { case (fieldT, idx) =>
+      val intT =
+        fieldT match {
+          case t: LLVMTInt[Pre] => t
+          case _ => throw UnsupportedMemset(memset)
+        }
+      val structField = structFieldMap((structType, idx))
+      Assign[Post](
+        Deref[Post](
+          DerefPointer(rw.dispatch(memset.dest))(memset.blame),
+          structField.ref,
+        )(memset.blame),
+        // TODO: Change this to the correct integer type
+        rw.dispatch(LLVMIntegerValue[Pre](0, intT)),
+        // rw.dispatch(memset.value),
+      )(memset.blame)
+
+    }
+
+    /*
     if (!structType.packed || !(structType.elements.size == 1)) {
       throw UnsupportedMemset(memset)
     }
@@ -1409,6 +1448,7 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
       )(memset.blame),
       rw.dispatch(memset.value),
     )(memset.blame)
+     */
   }
 
   def rewritePointerValue(pointer: LLVMPointerValue[Pre]): Expr[Post] = {

--- a/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
@@ -239,6 +239,7 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
 
   def gatherTypeHints(program: Program[Pre]): Unit = {
     // TODO: We also need to do something where we only keep structurally distinct types
+    // Returns if self is more specific than other
     def moreSpecific(self: Type[Pre], other: Type[Pre]): Boolean = {
       (self, other) match {
         case (a, b) if a == b => false
@@ -253,13 +254,30 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
         case (LLVMTPointer(Some(a)), TPointer(b, _)) => moreSpecific(a, b)
         case (TPointer(a, _), LLVMTPointer(Some(b))) => moreSpecific(a, b)
         case (TPointer(a, _), TPointer(b, _)) => moreSpecific(a, b)
-        case (LLVMTStruct(_, _, a), LLVMTStruct(_, _, b)) =>
+        // Define a named struct to be more specific than a structurally equivalent literal struct.
+        case (s1: LLVMTStruct[Pre], s2: LLVMTStruct[Pre])
+            if moreSpecificLitStruct(s1, s2) =>
+          true
+        case (s1: LLVMTStruct[Pre], s2: LLVMTStruct[Pre])
+            if moreSpecificLitStruct(s2, s1) =>
+          false
+        case (LLVMTStruct(_, _, _, a), LLVMTStruct(_, _, _, b)) =>
           a.headOption.exists(ta => b.exists(tb => moreSpecific(ta, tb)))
-        case (LLVMTStruct(_, _, _), _) => true
+        case (LLVMTStruct(_, _, _, _), _) => true
         case (LLVMTArray(_, a), LLVMTArray(_, b)) => moreSpecific(a, b)
         case (LLVMTArray(_, _), _) => true
         case _ => false
       }
+    }
+
+    // Returns true if other is a literal struct type and self if a structurally
+    // equivalent non-literal struct.
+    def moreSpecificLitStruct(
+        self: LLVMTStruct[Pre],
+        other: LLVMTStruct[Pre],
+    ): Boolean = {
+      !self.isLiteral && other.isLiteral && self.packed == other.packed &&
+      self.elements == other.elements
     }
 
     // TODO: This sorting is non-stable which might cause nondeterministic bugs if there's something wrong with moreSpecific
@@ -754,7 +772,7 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
   }
 
   def rewriteStruct(t: LLVMTStruct[Pre]): Unit = {
-    val LLVMTStruct(name, packed, elements) = t
+    val LLVMTStruct(name, packed, literal, elements) = t
     val newStruct =
       new ByValueClass[Post](
         Seq(),
@@ -919,7 +937,9 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
           (expr, LLVMTVector[Pre](numElements, inner))
         }
       }
-      case LLVMTPointer(Some(struct @ LLVMTStruct(name, packed, elements))) => {
+      case LLVMTPointer(
+            Some(struct @ LLVMTStruct(name, packed, literal, elements))
+          ) => {
         derefUntil(
           Deref[Post](
             DerefPointer(pointer)(pointer.o),
@@ -931,18 +951,21 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
           (
             expr,
             LLVMTPointer[Pre](Some(
-              LLVMTStruct(name, packed, inner +: elements.tail)
+              LLVMTStruct(name, packed, literal, inner +: elements.tail)
             )),
           )
         }
       }
-      case struct @ LLVMTStruct(name, packed, elements) => {
+      case struct @ LLVMTStruct(name, packed, literal, elements) => {
         derefUntil(
           Deref[Post](pointer, structFieldMap.ref((struct, 0)))(pointer.o),
           elements.head,
           untilType,
         ).map { case (expr, inner) =>
-          (expr, LLVMTStruct[Pre](name, packed, inner +: elements.tail))
+          (
+            expr,
+            LLVMTStruct[Pre](name, packed, literal, inner +: elements.tail),
+          )
         }
       }
       // Save the expensive check for last. This check is for when we're mixing PVL and LLVM types
@@ -1115,7 +1138,12 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
       implicit val o: Origin = overflowOpInitializerOrigin
       val (resT, flagT) =
         structT match {
-          case LLVMTStruct(_, _, Seq(res: LLVMTInt[Pre], flag: TBool[Pre])) =>
+          case LLVMTStruct(
+                _,
+                _,
+                _,
+                Seq(res: LLVMTInt[Pre], flag: TBool[Pre]),
+              ) =>
             (res, flag)
         }
       val resArg =

--- a/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
@@ -11,6 +11,7 @@ import vct.col.util.AstBuildHelpers._
 import vct.col.util.{CurrentProgramContext, SubstituteReferences, SuccessionMap}
 import vct.result.VerificationError.{SystemError, Unreachable, UserError}
 
+import scala.:+
 import scala.collection.mutable
 
 case object LangLLVMToCol {
@@ -1407,48 +1408,24 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
       throw UnsupportedMemset(memset)
     }
 
-    // TODO: Slap a block here to put the assignments in
-    // val fieldAssignments = mutable.Seq[Assign[Post]]
-
     // Set all fields of the struct to 0
-    structType.elements.zipWithIndex.foreach { case (fieldT, idx) =>
-      val intT =
-        fieldT match {
-          case t: LLVMTInt[Pre] => t
-          case _ => throw UnsupportedMemset(memset)
-        }
-      val structField = structFieldMap((structType, idx))
-      Assign[Post](
-        Deref[Post](
-          DerefPointer(rw.dispatch(memset.dest))(memset.blame),
-          structField.ref,
-        )(memset.blame),
-        // TODO: Change this to the correct integer type
-        rw.dispatch(LLVMIntegerValue[Pre](0, intT)),
-        // rw.dispatch(memset.value),
-      )(memset.blame)
-
+    val fieldAssignments = structType.elements.zipWithIndex.map {
+      case (fieldT, idx) =>
+        val intT =
+          fieldT match {
+            case t: LLVMTInt[Pre] => t
+            case _ => throw UnsupportedMemset(memset)
+          }
+        val structField = structFieldMap((structType, idx))
+        Assign[Post](
+          Deref[Post](
+            DerefPointer(rw.dispatch(memset.dest))(memset.blame),
+            structField.ref,
+          )(memset.blame),
+          rw.dispatch(LLVMIntegerValue[Pre](0, intT))
+        )(memset.blame)
     }
-
-    /*
-    if (!structType.packed || !(structType.elements.size == 1)) {
-      throw UnsupportedMemset(memset)
-    }
-    structType.elements.head match {
-      case LLVMTInt(bits) if (bits / 8) == numBytes =>
-      case _ => throw UnsupportedMemset(memset)
-    }
-
-    // Set field of the struct to 0
-    val structField = structFieldMap((structType, 0))
-    Assign[Post](
-      Deref[Post](
-        DerefPointer(rw.dispatch(memset.dest))(memset.blame),
-        structField.ref,
-      )(memset.blame),
-      rw.dispatch(memset.value),
-    )(memset.blame)
-     */
+    Block(fieldAssignments)
   }
 
   def rewritePointerValue(pointer: LLVMPointerValue[Pre]): Expr[Post] = {

--- a/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
@@ -1397,7 +1397,7 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
     val structType =
       memset.dest match {
         case Local(Ref(v)) =>
-          v.t match {
+          getLocalVarType(v) match {
             case LLVMTPointer(Some(s: LLVMTStruct[Pre])) => s
             case _ => throw UnsupportedMemset(memset)
           }
@@ -1422,7 +1422,7 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
             DerefPointer(rw.dispatch(memset.dest))(memset.blame),
             structField.ref,
           )(memset.blame),
-          rw.dispatch(LLVMIntegerValue[Pre](0, intT))
+          rw.dispatch(LLVMIntegerValue[Pre](0, intT)),
         )(memset.blame)
     }
     Block(fieldAssignments)

--- a/src/rewrite/vct/rewrite/pallas/ResolvePallasQuantifiers.scala
+++ b/src/rewrite/vct/rewrite/pallas/ResolvePallasQuantifiers.scala
@@ -68,7 +68,7 @@ case class ResolvePallasQuantifiers[Pre <: Generation]() extends Rewriter[Pre] {
           Exists[Post](
             newBindings,
             Seq.empty,
-            Implies(dispatch(bindingExpr), dispatch(bodyExpr)),
+            And(dispatch(bindingExpr), dispatch(bodyExpr)),
           )
         }
       case bv @ LLVMBoundVar(id, varType) =>
@@ -82,18 +82,17 @@ case class ResolvePallasQuantifiers[Pre <: Generation]() extends Rewriter[Pre] {
   }
 
   /** Gathers the bound variables that are available in a quantifier with the
-    * given binding expression.
-    * Returns the new mapping an the variables that are newly declared in the
-    * given quantifier.
+    * given binding expression. Returns the new mapping an the variables that
+    * are newly declared in the given quantifier.
     */
   private def gatherBoundVars(
       q: LLVMQuantifier[Pre]
   ): (Map[(String, Type[Pre]), Variable[Post]], Seq[Variable[Post]]) = {
     val oldBVMap = boundVars.topOption.getOrElse(Map.empty)
     // Gather all new bound variables from the binding expression
-    val bVars = q.bindingExpr.collect { case LLVMBoundVar(id, vType) =>
-      (id, vType)
-    }.filterNot(t => oldBVMap.contains(t)).distinct
+    val bVars =
+      q.bindingExpr.collect { case LLVMBoundVar(id, vType) => (id, vType) }
+        .filterNot(t => oldBVMap.contains(t)).distinct
 
     // Declare variables for new BVs & update stack
     var newBVMap = oldBVMap

--- a/src/rewrite/vct/rewrite/pallas/ResolvePallasQuantifiers.scala
+++ b/src/rewrite/vct/rewrite/pallas/ResolvePallasQuantifiers.scala
@@ -43,8 +43,7 @@ case class ResolvePallasQuantifiers[Pre <: Generation]() extends Rewriter[Pre] {
     expr match {
       case q @ LLVMForall(bindingExpr, bodyExpr) =>
         implicit val o: Origin = expr.o
-        val newBVMap = gatherBoundVars(q)
-        val newBindings = newBVMap.values.toSeq
+        val (newBVMap, newBindings) = gatherBoundVars(q)
         boundVars.having(newBVMap) {
           Forall[Post](
             newBindings,
@@ -54,8 +53,7 @@ case class ResolvePallasQuantifiers[Pre <: Generation]() extends Rewriter[Pre] {
         }
       case q @ LLVMSepForall(bindingExpr, bodyExpr) =>
         implicit val o: Origin = expr.o
-        val newBVMap = gatherBoundVars(q)
-        val newBindings = newBVMap.values.toSeq
+        val (newBVMap, newBindings) = gatherBoundVars(q)
         boundVars.having(newBVMap) {
           Starall[Post](
             newBindings,
@@ -65,8 +63,7 @@ case class ResolvePallasQuantifiers[Pre <: Generation]() extends Rewriter[Pre] {
         }
       case q @ LLVMExists(bindingExpr, bodyExpr) =>
         implicit val o: Origin = expr.o
-        val newBVMap = gatherBoundVars(q)
-        val newBindings = newBVMap.values.toSeq
+        val (newBVMap, newBindings) = gatherBoundVars(q)
         boundVars.having(newBVMap) {
           Exists[Post](
             newBindings,
@@ -86,29 +83,33 @@ case class ResolvePallasQuantifiers[Pre <: Generation]() extends Rewriter[Pre] {
 
   /** Gathers the bound variables that are available in a quantifier with the
     * given binding expression.
+    * Returns the new mapping an the variables that are newly declared in the
+    * given quantifier.
     */
   private def gatherBoundVars(
       q: LLVMQuantifier[Pre]
-  ): Map[(String, Type[Pre]), Variable[Post]] = {
+  ): (Map[(String, Type[Pre]), Variable[Post]], Seq[Variable[Post]]) = {
     val oldBVMap = boundVars.topOption.getOrElse(Map.empty)
     // Gather all new bound variables from the binding expression
     val bVars = q.bindingExpr.collect { case LLVMBoundVar(id, vType) =>
       (id, vType)
-    }.filterNot(t => oldBVMap.contains(t))
+    }.filterNot(t => oldBVMap.contains(t)).distinct
 
     // Declare variables for new BVs & update stack
     var newBVMap = oldBVMap
+    var newVars = Seq[Variable[Post]]()
     variables.scope {
       localHeapVariables.scope {
         bVars.foreach { case (id, vType) =>
           val v = new Variable[Post](dispatch(vType))(q.o.where(name = id))
+          newVars = newVars :+ v
           newBVMap = newBVMap.updated((id, vType), v)
         }
       }
     }
 
-    if (newBVMap.isEmpty) { throw MissingBoundVariable(q) }
-    newBVMap
+    if (newVars.isEmpty) { throw MissingBoundVariable(q) }
+    (newBVMap, newVars)
   }
 
 }


### PR DESCRIPTION
Fix some things in the Pallas specifications: 
- Type inference did not work when literal structs are used
- 