### PR TITLE
Fix ceil

### DIFF
--- a/examples/concepts/c/math.c
+++ b/examples/concepts/c/math.c
@@ -4,23 +4,33 @@
 int main(){
     //@ assert(ceil(1.5) == 2.0);
     //@ assert(ceil(2.0) == 2.0);
-    /* TODO: Below test case fails, although given directly to silicon it does not fail, no clue what is going on.
-             Uncommented for now. */
-    // assert(ceil(-1.5) == -1.0);
+    //@ assert(ceil(-1.5) == -1.0);
+
+    //@ assert((int)ceil(1.5) == 2);
+    //@ assert((int)ceil(2.0) == 2);
+    //@ assert((int)ceil(-1.5) == -1);
 
     //@ assert(floor(1.5) == 1.0);
     //@ assert(floor(2.0) == 2.0);
     //@ assert(floor(-1.5) == -2.0);
 
+    //@ assert((int)floor(1.5) == 1);
+    //@ assert((int)floor(2.0) == 2);
+    //@ assert((int)floor(-1.5) == -2);
+
     //@ assert(round(1.5) == 2.0);
     //@ assert(round(1.4) == 1.0);
     //@ assert(round(2.0) == 2.0);
     //@ assert(round(-1.5) == -2.0);
-    // TODO: Below fails
-    // assert(round(-1.4) == -1.0);
+    //@ assert(round(-1.4) == -1.0);
 
-    // TODO: Below fails
-    // assert(fabs(-1.5) == 1.5);
+    //@ assert((int)round(1.5) == 2);
+    //@ assert((int)round(1.4) == 1);
+    //@ assert((int)round(2.0) == 2);
+    //@ assert((int)round(-1.5) == -2);
+    //@ assert((int)round(-1.4) == -1);
+
+    //@ assert(fabs(-1.5) == 1.5);
     //@ assert(fabs(1.5) == 1.5);
 
     //@ assert(pow(2.0, 2.0) == 4.0);

--- a/res/universal/res/c/math.h
+++ b/res/universal/res/c/math.h
@@ -110,6 +110,7 @@ float /*@ pure @*/ powf(float x, float y);
 
 /*@
   ensures \result == (float)((int)x);
+  ensures !\is_int(x) ==> ((int)\result) == ((int)x);
   decreases;
 @*/
 float /*@ pure @*/ floorf(float x);
@@ -123,6 +124,7 @@ float /*@ pure @*/ ceilf(float x);
 
 /*@
   ensures !(x < 0 && \is_int(x-0.5)) ==> \result == (float)(int)(x + 0.5);
+  ensures !(x < 0 && \is_int(x-0.5)) ==> ((int)\result) == (int)(x + 0.5);
   ensures (x < 0 && \is_int(x-0.5)) ==> \result == x-0.5;
   decreases;
 @*/
@@ -227,6 +229,7 @@ double /*@ pure @*/ pow(double x, double y);
 
 /*@
   ensures \result == (double)((int)x);
+  ensures !\is_int(x) ==> ((int)\result) == ((int)x);
   decreases;
 @*/
 double /*@ pure @*/ floor(double x);
@@ -240,6 +243,7 @@ double /*@ pure @*/ ceil(double x);
 
 /*@
   ensures !(x < 0 && \is_int(x-0.5)) ==> \result == (double)(int)(x + 0.5);
+  ensures !(x < 0 && \is_int(x-0.5)) ==> ((int)\result) == (int)(x + 0.5);
   ensures (x < 0 && \is_int(x-0.5)) ==> \result == x-0.5;
   decreases;
 @*/

--- a/res/universal/res/c/math.h
+++ b/res/universal/res/c/math.h
@@ -109,8 +109,9 @@ float /*@ pure @*/ logf(float x);
 float /*@ pure @*/ powf(float x, float y);
 
 /*@
-  ensures \result == (float)((int)x);
+  ensures !\is_int(x) ==> \result == (float)((int)x);
   ensures !\is_int(x) ==> ((int)\result) == ((int)x);
+  ensures \is_int(x) ==> \result == x;
   decreases;
 @*/
 float /*@ pure @*/ floorf(float x);
@@ -230,6 +231,7 @@ double /*@ pure @*/ pow(double x, double y);
 /*@
   ensures \result == (double)((int)x);
   ensures !\is_int(x) ==> ((int)\result) == ((int)x);
+  ensures \is_int(x) ==> \result == x;
   decreases;
 @*/
 double /*@ pure @*/ floor(double x);

--- a/res/universal/res/c/math.h
+++ b/res/universal/res/c/math.h
@@ -116,6 +116,7 @@ float /*@ pure @*/ floorf(float x);
 
 /*@
   ensures \result == (\is_int(x) ? x : (float)((int)x + 1));
+  ensures !\is_int(x) ==> ((int)\result) == ((int)x + 1);
   decreases;
 @*/
 float /*@ pure @*/ ceilf(float x);
@@ -232,6 +233,7 @@ double /*@ pure @*/ floor(double x);
 
 /*@
   ensures \result == (\is_int(x) ? x : (double)((int)x + 1));
+  ensures !\is_int(x) ==> ((int)\result) == ((int)x + 1);
   decreases;
 @*/
 double /*@ pure @*/ ceil(double x);


### PR DESCRIPTION
- [x] The wiki is updated in accordance with the changes in this PR. For example: syntax changes, semantics changes, VerCors flags changes, etc.

# PR description
See issue #1378 for more information. Essentially makes sure the ceil, round and floor functions are more complete when a integer cast happens directly after them.
