### PR TITLE
Re-add lower bound clause in \pointer expansion

### DIFF
--- a/src/rewrite/vct/rewrite/DesugarPermissionOperators.scala
+++ b/src/rewrite/vct/rewrite/DesugarPermissionOperators.scala
@@ -142,6 +142,8 @@ case class DesugarPermissionOperators[Pre <: Generation]()
         )
       case PermPointer(p, len, perm) =>
         (PointerNeq(dispatch(p), Null(), const(0))) &*
+          const(0) <=
+          PointerBlockOffset(dispatch(p))(FramedPtrOffset) + dispatch(len) &*
           PointerBlockOffset(dispatch(p))(FramedPtrBlockOffset) + dispatch(
             len
           ) <= PointerBlockLength(dispatch(p))(FramedPtrBlockLength) &* starall(


### PR DESCRIPTION
Turns out there were some cases that break when removing the lower bound clause which I hadn't found at the time #1368 was merged.

For example:
```c
//@ requires \pointer(a, n, write);
void foo(int *a,  int n) {
    // Since we do not know that n is positive this does not work, 
    // maybe it also shouldn't, but I think it's confusing if it doesn't for now
    int *b = a + n; 
}
```

(the build seems to broken for now because sosy-lab.org is down)

