### PR TITLE
Bring C improvements to LLVM frontend

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  CompilationDatabase: out/vercors/pallas/cMakeSetupBuild.dest

--- a/.github/workflows/scalatest.yml
+++ b/.github/workflows/scalatest.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Enable Pallas compilation
         run: touch .include-pallas
       - name: Compile
-        run: ./mill -j 0 vercors.allTests.assembly + vercors.pallas.compile
+        run: ./mill -j 0 vercors.allTests.assembly + vercors.pallas.cMakeBuild
       - name: Upload VerCors
         uses: actions/upload-artifact@v4
         with:
@@ -45,8 +45,8 @@ jobs:
       - name: Upload Pallas
         uses: actions/upload-artifact@v4
         with:
-          name: pallas
-          path: out/vercors/pallas/compile.dest/pallas
+          name: libPallas.so
+          path: out/vercors/pallas/cMakeSetupBuild.dest/lib/libPallas.so
       - name: Delete Uncached Files
         run: |
           find out -type f -name upstreamAssembly.json -print -exec rm -rf {} +
@@ -136,7 +136,7 @@ jobs:
       - name: Download Pallas
         uses: actions/download-artifact@v4
         with:
-          name: pallas
+          name: libPallas.so
           path: '.'
       - name: ls
         run: ls -lasFhR

--- a/build.sc
+++ b/build.sc
@@ -10,31 +10,11 @@ import contrib.buildinfo.BuildInfo
 import me.pieterbos.mill.cpp.options.implicits._
 import me.pieterbos.mill.cpp.options.{CppCompileOptions, CppExecutableOptions}
 import me.pieterbos.mill.cpp.{CMakeModule, LinkableModule}
-import me.pieterbos.mill.cpp.toolchain.GccCompatible
 import mill.util.Jvm
 import vct.col.ast.structure
 import vct.col.ast.structure.{AllFamilies, FamilyDefinition, Name, NodeDefinition}
 
 import scala.util.control.NonFatal
-
-trait CppSharedModule extends CppModule {
-  def executableOptions: T[CppExecutableOptions] = T {
-    CppExecutableOptions(
-      transitiveDynamicObjects().map(_.path),
-      transitiveSystemLibraryDeps(),
-      Seq("-shared", "-fPIC"),
-      Nil,
-    )
-  }
-
-  def compile: T[PathRef] = T {
-    PathRef(toolchain.linkExecutable((compileOnly() ++ T.traverse(moduleDeps){
-      case it: CppModule => it.compileOnly
-      case it: LinkableModule => it.staticObjects
-      case _ => T.task { Result.Success(Seq.empty) }
-    }().flatten).map(_.path), T.dest, name(), executableOptions()))
-  }
-}
 
 object external extends Module {
   object z3 extends Module {
@@ -438,7 +418,7 @@ object vercors extends Module {
 
     val includePallasCross = interp.watchValue {
       if(os.exists(settings.root / ".include-pallas")) {
-        Seq("pallas")
+        Seq("libPallas.so")
       } else {
         Seq.empty[String]
       }
@@ -447,7 +427,7 @@ object vercors extends Module {
     object pallasDep extends Cross[PallasDep](includePallasCross)
     trait PallasDep extends Cross.Module[String] {
       def path = T {
-        pallas.compile().path / os.up
+        pallas.cMakeBuild().path / "lib"
       }
     }
 
@@ -665,139 +645,41 @@ object vercors extends Module {
     }
   }
 
-  object pallas extends CppSharedModule { outer =>
-    def root: T[os.Path] = T { settings.src / "llvm" }
+  object pallas extends CMakeModule { outer =>
+    def root: T[PathRef] = T { PathRef(settings.src / "llvm") }
 
-    object llvm extends LinkableModule {
-      def moduleDeps = Nil
-      def systemLibraryDeps = T { Seq("LLVM-17") }
-      def staticObjects = T { Seq.empty[PathRef] }
-      def dynamicObjects = T { Seq.empty[PathRef] }
-      def exportIncludePaths = T.sources(
-        os.Path("/usr/include/llvm-17"),
-        os.Path("/usr/include/llvm-c-17"),
-      )
+    object protobufGit extends GitModule {
+      override def url: T[String] = "https://github.com/protocolbuffers/protobuf"
+      override def commitish: T[String] = "v25.2"
+      override def fetchSubmodulesRecursively = true
     }
 
-    object origin extends CppModule {
-      override def moduleDeps = Seq(llvm, proto, proto.protobuf.libprotobuf)
-      override def sources = T.sources(pallas.root() / "lib" / "Origin")
-      override def includePaths = T.sources(pallas.root() / "include")
-      override def compileOptions: T[Seq[String]] = Seq("-fPIC")
-    }
-    object passes extends CppModule {
-      override def moduleDeps = Seq(llvm, proto, util, origin, transform, proto.protobuf.libprotobuf)
-      override def sources = T.sources(pallas.root() / "lib" / "Passes")
-      override def includePaths = T.sources(pallas.root() / "include")
-      override def compileOptions: T[Seq[String]] = Seq("-fPIC")
-    }
-    object transform extends CppModule {
-      override def moduleDeps = Seq(llvm, proto, util, origin, proto.protobuf.libprotobuf)
-      override def sources = T.sources(pallas.root() / "lib" / "Transform")
-      override def includePaths = T.sources(pallas.root() / "include")
-      override def compileOptions: T[Seq[String]] = Seq("-fPIC")
-    }
-    object util extends CppModule {
-      override def moduleDeps = Seq(llvm, proto, origin, proto.protobuf.libprotobuf)
-      override def sources = T.sources(pallas.root() / "lib" / "Util")
-      override def includePaths = T.sources(pallas.root() / "include")
-      override def compileOptions: T[Seq[String]] = Seq("-fPIC")
-    }
-    object plugin extends CppModule {
-      override def moduleDeps = Seq(llvm, proto, passes, transform, proto.protobuf.libprotobuf)
-      override def sources = T.sources(pallas.root() / "lib" / "Plugin.cpp")
-      override def includePaths = T.sources(pallas.root() / "include")
-      override def compileOptions: T[Seq[String]] = Seq("-fPIC")
+    object plugin extends CMakeLibrary {
+      def target = T { "Pallas" }
     }
 
-    object proto extends CppModule {
-      object protobuf extends CMakeModule {
-        object protobufGit extends GitModule {
-          override def url: T[String] = "https://github.com/protocolbuffers/protobuf"
-          override def commitish: T[String] = "v25.2"
-          override def fetchSubmodulesRecursively = true
-        }
-        override def root = T.source(protobufGit.repo())
-        override def jobs = T { 2 }
-
-      override def cMakeSetupBuild: T[os.Path] = T {
-        val apiDir = T.dest / ".cmake" / "api" / "v1"
-        os.makeDir.all(apiDir / "query")
+    override def cMakeSetupBuild: T[os.Path] = T.persistent {
+      val apiDir = T.dest / ".cmake" / "api" / "v1"
+      os.makeDir.all(apiDir / "query")
+      if (!os.exists(apiDir / "query" / "codemodel-v2")) {
         os.write(apiDir / "query" / "codemodel-v2", "")
-        os.proc("cmake", "-B", T.dest, "-Dprotobuf_BUILD_TESTS=OFF", "-DABSL_PROPAGATE_CXX_STD=ON","-D", "CMAKE_POSITION_INDEPENDENT_CODE=ON", "-D", "CMAKE_CXX_FLAGS=-fPIC", "-D", "CMAKE_C_FLAGS=-fPIC", "-S", root().path).call(cwd = T.dest)
-        T.dest
       }
-
-        object libprotobuf extends CMakeLibrary {
-          def target = T { "libprotobuf" }
-        }
-
-        object protoc extends CMakeExecutable {
-          def target = T { "protoc" }
-        }
-      }
-
-      def protoPath = T.sources(
-        vercors.col.helpers.megacol().path / os.up / os.up / os.up / os.up,
-        settings.src / "serialize",
-        serialize.scalaPBUnpackProto().path
-      )
-      def generate = T {
-        os.proc(protobuf.protoc.executable().path,
-          protoPath().map(p => "-I=" + p.path.toString),
-          "--cpp_out=" + T.dest.toString,
-          (Seq(vercors.col.helpers.megacol()) ++
-            os.walk(serialize.scalaPBUnpackProto().path).filter(path => !path.startsWith(serialize.scalaPBUnpackProto().path / "google") && path.ext == "proto").map(PathRef(_)) ++
-            os.walk(settings.src / "serialize").filter(_.ext == "proto").map(PathRef(_))).map(_.path)
-        ).call()
-        T.dest
-      }
-      override def moduleDeps = Seq(protobuf.libprotobuf)
-      override def sources = T { Seq(PathRef(generate())) }
-      override def includePaths = T { Seq(PathRef(generate())) }
-      override def compileOptions: T[Seq[String]] = T { Seq("-fPIC") }
-
-      def precompileHeaders: T[PathRef] = T {
-        def isHiddenFile(path: os.Path): Boolean = path.last.startsWith(".")
-
-        val headers = for {
-          root <- allSources()
-          if os.exists(root.path)
-          path <- if(os.isDir(root.path)) os.walk(root.path) else Seq(root.path)
-          if os.isFile(path)
-          if !isHiddenFile(path)
-          if Seq("h", "hpp").contains(path.ext.toLowerCase)
-        } yield (root.path, path.relativeTo(root.path))
-
-        val options = CppCompileOptions(
-          allIncludePaths().map(_.path),
-          defines(),
-          includes().map(_.path),
-          standard(),
-          optimization(),
-          compileOptions(),
-          compileEarlyOptions(),
-        )
-
-        for((base, header) <- headers) {
-          val compileOut = toolchain.compile(base / header, T.dest, options)
-          val outDir = T.dest / header / os.up
-          val out = outDir / (header.last + ".gch")
-          os.makeDir.all(outDir)
-          os.move(compileOut, out)
-          os.copy(base / header, T.dest / header)
-        }
-
-        PathRef(T.dest)
-      }
-
-      override def exportIncludePaths: T[Seq[PathRef]] = T {
-        Seq(precompileHeaders())
-      }
+      os.proc("cmake",
+        "-B", T.dest,
+        "-DSCALA_PB_DIR=" + serialize.scalaPBUnpackProto().path,
+        "-DMEGACOL_DIR=" + (vercors.col.helpers.megacol().path / os.up / os.up / os.up / os.up),
+        "-DSERIALIZE_DIR=" + (settings.src / "serialize"),
+        "-DPROTOBUF_DIR=" + protobufGit.repo(),
+        "-G", "Ninja",
+        "-S", root().path).call(cwd = T.dest)
+      T.dest
     }
 
-    override def moduleDeps = Seq(origin, passes, transform, util, llvm, plugin, proto, proto.protobuf.libprotobuf)
-    override def compileOptions: T[Seq[String]] = T { Seq("-fPIC") }
+    def cMakeBuild: T[PathRef] = T.command {
+      val build = cMakeSetupBuild()
+      os.proc("cmake", "--build", build, "--parallel", jobs().max(8)).call()
+      PathRef(build)
+    }
   }
 
   object allTests extends ScalaModule with ReleaseModule {

--- a/examples/concepts/c/pointer_relations.c
+++ b/examples/concepts/c/pointer_relations.c
@@ -1,16 +1,16 @@
 #include <stdint.h>
 
+struct B {
+    int e;
+    float f;
+    char g;
+};
+
 struct A {
     struct B a;
     char b;
     int c;
     float d;
-};
-
-struct B {
-    int e;
-    float f;
-    char g;
 };
 
 

--- a/examples/concepts/c/pointer_relations.c
+++ b/examples/concepts/c/pointer_relations.c
@@ -3,8 +3,10 @@
 struct B {
     int e;
     float f;
-    char g;
+   char g;
 };
+
+typedef struct B B;
 
 struct A {
     struct B a;
@@ -13,44 +15,46 @@ struct A {
     float d;
 };
 
+typedef struct A A;
 
-//@ requires s != NULL;
+
+/*@ requires s != NULL;@*/
 void test1(struct A *s) {
-    //@ assert (uintptr_t)s == (uintptr_t)&s->a;
+    /*@ assert (uintptr_t)s == (uintptr_t)&s->a;@*/
 }
 
-//@ requires s != NULL;
+/*@ requires s != NULL;@*/
 void test2(struct A *s) {
-    //@ assert (uintptr_t)&s->a < (uintptr_t)&s->b;
+    /*@ assert (uintptr_t)&s->a < (uintptr_t)&s->b; @*/
 }
 
-//@ requires s != NULL;
+/*@ requires s != NULL;@*/
 void test3(struct A *s) {
-    //@ assert (uintptr_t)&s->b < (uintptr_t)&s->c;
+    /*@ assert (uintptr_t)&s->b < (uintptr_t)&s->c; @*/
 }
 
-//@ requires s != NULL;
+/*@ requires s != NULL;@*/
 void test4(struct A *s) {
-    //@ assert (uintptr_t)&s->c < (uintptr_t)&s->d;
+    /*@ assert (uintptr_t)&s->c < (uintptr_t)&s->d; @*/
 }
 
-//@ requires s != NULL;
+/*@ requires s != NULL;@*/
 void test5(struct A *s) {
-    //@ assert (uintptr_t)&s->a == (uintptr_t)&s->a.e;
+    /*@ assert (uintptr_t)&s->a == (uintptr_t)&s->a.e; @*/
 }
 
-//@ requires s != NULL;
+/*@ requires s != NULL;@*/
 void test6(struct A *s) {
-    //@ assert (uintptr_t)&s->a.e < (uintptr_t)&s->b;
+    /*@ assert (uintptr_t)&s->a.e < (uintptr_t)&s->b; @*/
 }
 
-//@ requires s != NULL;
+/*@ requires s != NULL;@*/
 void test7(struct A *s) {
-    //@ assert (uintptr_t)&s->a.f < (uintptr_t)&s->c;
+    /*@ assert (uintptr_t)&s->a.f < (uintptr_t)&s->c; @*/
 }
 
-//@ requires s != NULL;
+/*@ requires s != NULL;@*/
 void test8(struct A *s) {
-    //@ assert (uintptr_t)&s->a.g < (uintptr_t)&s->d;
+    /*@ assert (uintptr_t)&s->a.g < (uintptr_t)&s->d; @*/
 }
 

--- a/examples/concepts/llvm/pointer_casts.c
+++ b/examples/concepts/llvm/pointer_casts.c
@@ -1,0 +1,76 @@
+#include <stdbool.h>
+
+struct A {
+    int integer;
+    bool boolean;
+};
+
+struct B {
+    struct A struct_a;
+};
+
+typedef struct A A;
+typedef struct B B;
+
+/*@
+declare DEF_OLD(int);
+@*/
+
+void canCastToInteger() {
+    struct B struct_b;
+    struct_b.struct_a.integer = 5;
+    int *pointer_to_integer = (int *)&struct_b;
+    /*@ assert *pointer_to_integer == 5;
+     assert pointer_to_integer == &struct_b.struct_a.integer;
+     assert pointer_to_integer == (int *)&struct_b.struct_a; @*/
+    *pointer_to_integer = 10;
+    /*@ assert struct_b.struct_a.integer == 10; @*/
+}
+
+
+void castRemainsValidInLoop() {
+    struct B struct_b;
+    struct_b.struct_a.integer = 10;
+
+    int *pointer_to_integer = (int *)&struct_b;
+
+    /*@ loop_invariant 0 <= i && i <= 10;
+        loop_invariant pointer_to_integer == (int *)&struct_b;
+        loop_invariant _Perm(&struct_b.struct_a.integer, _fracOf(1, 1));
+        loop_invariant *pointer_to_integer == 10 - i; @*/
+    for (int i = 0; i < 10; i++) {
+        *pointer_to_integer = *pointer_to_integer - 1;
+    }
+
+    /*@ assert struct_b.struct_a.integer == 0; @*/
+    struct_b.struct_a.integer = 10;
+
+    // We can also specify the permission through the pointer
+    /*@ loop_invariant 0 <= j && j <= 10;
+        loop_invariant pointer_to_integer == (int *)&struct_b;
+        loop_invariant _Perm(pointer_to_integer, _fracOf(1, 1));
+        loop_invariant *pointer_to_integer == 10 - j; @*/
+    for (int j = 0; j < 10; j++) {
+        *pointer_to_integer = *pointer_to_integer - 1;
+    }
+
+    /*@ assert struct_b.struct_a.integer == 0; @*/
+}
+
+/*@ requires a != NULL;
+requires _Perm(a, _fracOf(1,1));
+ensures _Perm(a, _fracOf(1,1));
+ensures *a == _old(int)(*a) + 1; @*/
+void increaseByOne(int *a) {
+    *a += 1;
+}
+
+void callWithCast() {
+    struct B struct_b;
+    struct_b.struct_a.integer = 15;
+
+    int *pointer_to_integer = (int *)&struct_b;
+    increaseByOne(pointer_to_integer);
+
+    /*@ assert struct_b.struct_a.integer == 16; @*/
+}

--- a/examples/concepts/llvm/pointer_casts.ll
+++ b/examples/concepts/llvm/pointer_casts.ll
@@ -1,0 +1,715 @@
+; ModuleID = 'tmp_ir_source0.ll'
+source_filename = "examples/concepts/llvm/pointer_casts.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+%struct.B = type { %struct.A }
+%struct.A = type { i32, i8 }
+%pallas.fracT = type { i64, i64, i64, i64 }
+
+@llvm.used = appending global [19 x ptr] [ptr @PALLAS_SPEC_0, ptr @PALLAS_SPEC_1, ptr @PALLAS_SPEC_2, ptr @PALLAS_SPEC_3, ptr @PALLAS_SPEC_4, ptr @PALLAS_SPEC_5, ptr @PALLAS_SPEC_6, ptr @PALLAS_SPEC_7, ptr @PALLAS_SPEC_8, ptr @PALLAS_SPEC_9, ptr @PALLAS_SPEC_10, ptr @PALLAS_SPEC_11, ptr @PALLAS_SPEC_12, ptr @PALLAS_SPEC_13, ptr @PALLAS_SPEC_14, ptr @PALLAS_SPEC_15, ptr @PALLAS_SPEC_16, ptr @PALLAS_SPEC_17, ptr @PALLAS_SPEC_18], section "llvm.metadata"
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local void @canCastToInteger() #0 !dbg !17 {
+  %1 = alloca %struct.B, align 4
+  %2 = alloca ptr, align 8
+  call void @llvm.dbg.declare(metadata ptr %1, metadata !21, metadata !DIExpression()), !dbg !30
+  %3 = getelementptr inbounds %struct.B, ptr %1, i32 0, i32 0, !dbg !31
+  %4 = getelementptr inbounds %struct.A, ptr %3, i32 0, i32 0, !dbg !32
+  store i32 5, ptr %4, align 4, !dbg !33
+  call void @llvm.dbg.declare(metadata ptr %2, metadata !34, metadata !DIExpression()), !dbg !35
+  store ptr %1, ptr %2, align 8, !dbg !35
+  %5 = load ptr, ptr %2, align 8, !dbg !36, !pallas.stmntBlock !37
+  store i32 10, ptr %5, align 4, !dbg !45
+  ret void, !dbg !46, !pallas.stmntBlock !47
+}
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local void @castRemainsValidInLoop() #0 !dbg !51 {
+  %1 = alloca %struct.B, align 4
+  %2 = alloca ptr, align 8
+  %3 = alloca i32, align 4
+  %4 = alloca i32, align 4
+  call void @llvm.dbg.declare(metadata ptr %1, metadata !52, metadata !DIExpression()), !dbg !53
+  %5 = getelementptr inbounds %struct.B, ptr %1, i32 0, i32 0, !dbg !54
+  %6 = getelementptr inbounds %struct.A, ptr %5, i32 0, i32 0, !dbg !55
+  store i32 10, ptr %6, align 4, !dbg !56
+  call void @llvm.dbg.declare(metadata ptr %2, metadata !57, metadata !DIExpression()), !dbg !58
+  store ptr %1, ptr %2, align 8, !dbg !58
+  call void @llvm.dbg.declare(metadata ptr %3, metadata !59, metadata !DIExpression()), !dbg !61
+  store i32 0, ptr %3, align 4, !dbg !61
+  br label %7, !dbg !62
+
+7:                                                ; preds = %15, %0
+  %8 = load i32, ptr %3, align 4, !dbg !63
+  %9 = icmp slt i32 %8, 10, !dbg !65
+  br i1 %9, label %10, label %18, !dbg !66
+
+10:                                               ; preds = %7
+  %11 = load ptr, ptr %2, align 8, !dbg !67
+  %12 = load i32, ptr %11, align 4, !dbg !69
+  %13 = sub nsw i32 %12, 1, !dbg !70
+  %14 = load ptr, ptr %2, align 8, !dbg !71
+  store i32 %13, ptr %14, align 4, !dbg !72
+  br label %15, !dbg !73
+
+15:                                               ; preds = %10
+  %16 = load i32, ptr %3, align 4, !dbg !74
+  %17 = add nsw i32 %16, 1, !dbg !74
+  store i32 %17, ptr %3, align 4, !dbg !74
+  br label %7, !dbg !75, !llvm.loop !76
+
+18:                                               ; preds = %7
+  %19 = getelementptr inbounds %struct.B, ptr %1, i32 0, i32 0, !dbg !89, !pallas.stmntBlock !90
+  %20 = getelementptr inbounds %struct.A, ptr %19, i32 0, i32 0, !dbg !94
+  store i32 10, ptr %20, align 4, !dbg !95
+  call void @llvm.dbg.declare(metadata ptr %4, metadata !96, metadata !DIExpression()), !dbg !98
+  store i32 0, ptr %4, align 4, !dbg !98
+  br label %21, !dbg !99
+
+21:                                               ; preds = %29, %18
+  %22 = load i32, ptr %4, align 4, !dbg !100
+  %23 = icmp slt i32 %22, 10, !dbg !102
+  br i1 %23, label %24, label %32, !dbg !103
+
+24:                                               ; preds = %21
+  %25 = load ptr, ptr %2, align 8, !dbg !104
+  %26 = load i32, ptr %25, align 4, !dbg !106
+  %27 = sub nsw i32 %26, 1, !dbg !107
+  %28 = load ptr, ptr %2, align 8, !dbg !108
+  store i32 %27, ptr %28, align 4, !dbg !109
+  br label %29, !dbg !110
+
+29:                                               ; preds = %24
+  %30 = load i32, ptr %4, align 4, !dbg !111
+  %31 = add nsw i32 %30, 1, !dbg !111
+  store i32 %31, ptr %4, align 4, !dbg !111
+  br label %21, !dbg !112, !llvm.loop !113
+
+32:                                               ; preds = %21
+  ret void, !dbg !125, !pallas.stmntBlock !126
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local void @increaseByOne(ptr noundef %0) #0 !dbg !130 !pallas.fcontract !133 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  call void @llvm.dbg.declare(metadata ptr %2, metadata !137, metadata !DIExpression()), !dbg !144
+  %3 = load ptr, ptr %2, align 8, !dbg !145
+  %4 = load i32, ptr %3, align 4, !dbg !146
+  %5 = add nsw i32 %4, 1, !dbg !146
+  store i32 %5, ptr %3, align 4, !dbg !146
+  ret void, !dbg !147
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local void @callWithCast() #0 !dbg !148 {
+  %1 = alloca %struct.B, align 4
+  %2 = alloca ptr, align 8
+  call void @llvm.dbg.declare(metadata ptr %1, metadata !149, metadata !DIExpression()), !dbg !150
+  %3 = getelementptr inbounds %struct.B, ptr %1, i32 0, i32 0, !dbg !151
+  %4 = getelementptr inbounds %struct.A, ptr %3, i32 0, i32 0, !dbg !152
+  store i32 15, ptr %4, align 4, !dbg !153
+  call void @llvm.dbg.declare(metadata ptr %2, metadata !154, metadata !DIExpression()), !dbg !155
+  store ptr %1, ptr %2, align 8, !dbg !155
+  %5 = load ptr, ptr %2, align 8, !dbg !156
+  call void @increaseByOne(ptr noundef %5), !dbg !157
+  ret void, !dbg !158, !pallas.stmntBlock !159
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_0(ptr noundef %0) #0 !dbg !163 !pallas.exprWrapper !166 {
+  call void @llvm.dbg.value(metadata ptr %0, metadata !167, metadata !DIExpression()), !dbg !168
+  %2 = icmp ne ptr %0, null, !dbg !169
+  ret i1 %2, !dbg !168
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_1(ptr noundef %0) #0 !dbg !170 !pallas.exprWrapper !166 {
+  %2 = alloca %pallas.fracT, align 8
+  call void @llvm.dbg.value(metadata ptr %0, metadata !171, metadata !DIExpression()), !dbg !172
+  call void @pallas.fracOf(ptr sret(%pallas.fracT) %2, i32 noundef 1, i32 noundef 1), !dbg !173
+  %3 = call i1 @pallas.perm(ptr noundef %0, ptr noundef byval(%pallas.fracT) %2), !dbg !174
+  ret i1 %3, !dbg !172
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_2(ptr noundef %0) #0 !dbg !175 !pallas.exprWrapper !166 {
+  %2 = alloca %pallas.fracT, align 8
+  call void @llvm.dbg.value(metadata ptr %0, metadata !176, metadata !DIExpression()), !dbg !177
+  call void @pallas.fracOf(ptr sret(%pallas.fracT) %2, i32 noundef 1, i32 noundef 1), !dbg !178
+  %3 = call i1 @pallas.perm(ptr noundef %0, ptr noundef byval(%pallas.fracT) %2), !dbg !179
+  ret i1 %3, !dbg !177
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_3(ptr noundef %0) #0 !dbg !180 !pallas.exprWrapper !166 {
+  call void @llvm.dbg.value(metadata ptr %0, metadata !181, metadata !DIExpression()), !dbg !182
+  %2 = load i32, ptr %0, align 4, !dbg !183
+  %3 = load i32, ptr %0, align 4, !dbg !184
+  %4 = call i32 @pallas.old.0(i32 noundef %3), !dbg !185
+  %5 = add nsw i32 %4, 1, !dbg !186
+  %6 = icmp eq i32 %2, %5, !dbg !187
+  ret i1 %6, !dbg !182
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_4(i64 %0, ptr noundef %1, i32 noundef %2) #0 !dbg !188 !pallas.exprWrapper !166 {
+  %4 = alloca %struct.B, align 4
+  %5 = getelementptr inbounds %struct.B, ptr %4, i32 0, i32 0
+  store i64 %0, ptr %5, align 4
+  call void @llvm.dbg.declare(metadata ptr %4, metadata !199, metadata !DIExpression()), !dbg !200
+  call void @llvm.dbg.value(metadata ptr %1, metadata !201, metadata !DIExpression()), !dbg !200
+  call void @llvm.dbg.value(metadata i32 %2, metadata !202, metadata !DIExpression()), !dbg !200
+  %6 = icmp sle i32 0, %2, !dbg !203
+  br i1 %6, label %7, label %9, !dbg !204
+
+7:                                                ; preds = %3
+  %8 = icmp sle i32 %2, 10, !dbg !205
+  br label %9
+
+9:                                                ; preds = %7, %3
+  %10 = phi i1 [ false, %3 ], [ %8, %7 ], !dbg !200
+  ret i1 %10, !dbg !200
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_5(i64 %0, ptr noundef %1, i32 noundef %2) #0 !dbg !206 !pallas.exprWrapper !166 {
+  %4 = alloca %struct.B, align 4
+  %5 = getelementptr inbounds %struct.B, ptr %4, i32 0, i32 0
+  store i64 %0, ptr %5, align 4
+  call void @llvm.dbg.declare(metadata ptr %4, metadata !207, metadata !DIExpression()), !dbg !208
+  call void @llvm.dbg.value(metadata ptr %1, metadata !209, metadata !DIExpression()), !dbg !208
+  call void @llvm.dbg.value(metadata i32 %2, metadata !210, metadata !DIExpression()), !dbg !208
+  %6 = icmp eq ptr %1, %4, !dbg !211
+  ret i1 %6, !dbg !208
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_6(i64 %0, ptr noundef %1, i32 noundef %2) #0 !dbg !212 !pallas.exprWrapper !166 {
+  %4 = alloca %struct.B, align 4
+  %5 = alloca %pallas.fracT, align 8
+  %6 = getelementptr inbounds %struct.B, ptr %4, i32 0, i32 0
+  store i64 %0, ptr %6, align 4
+  call void @llvm.dbg.declare(metadata ptr %4, metadata !213, metadata !DIExpression()), !dbg !214
+  call void @llvm.dbg.value(metadata ptr %1, metadata !215, metadata !DIExpression()), !dbg !214
+  call void @llvm.dbg.value(metadata i32 %2, metadata !216, metadata !DIExpression()), !dbg !214
+  %7 = getelementptr inbounds %struct.B, ptr %4, i32 0, i32 0, !dbg !217
+  %8 = getelementptr inbounds %struct.A, ptr %7, i32 0, i32 0, !dbg !218
+  call void @pallas.fracOf(ptr sret(%pallas.fracT) %5, i32 noundef 1, i32 noundef 1), !dbg !219
+  %9 = call i1 @pallas.perm(ptr noundef %8, ptr noundef byval(%pallas.fracT) %5), !dbg !220
+  ret i1 %9, !dbg !214
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_7(i64 %0, ptr noundef %1, i32 noundef %2) #0 !dbg !221 !pallas.exprWrapper !166 {
+  %4 = alloca %struct.B, align 4
+  %5 = getelementptr inbounds %struct.B, ptr %4, i32 0, i32 0
+  store i64 %0, ptr %5, align 4
+  call void @llvm.dbg.declare(metadata ptr %4, metadata !222, metadata !DIExpression()), !dbg !223
+  call void @llvm.dbg.value(metadata ptr %1, metadata !224, metadata !DIExpression()), !dbg !223
+  call void @llvm.dbg.value(metadata i32 %2, metadata !225, metadata !DIExpression()), !dbg !223
+  %6 = load i32, ptr %1, align 4, !dbg !226
+  %7 = sub nsw i32 10, %2, !dbg !227
+  %8 = icmp eq i32 %6, %7, !dbg !228
+  ret i1 %8, !dbg !223
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_8(i64 %0, ptr noundef %1, i32 noundef %2, i32 noundef %3) #0 !dbg !229 !pallas.exprWrapper !166 {
+  %5 = alloca %struct.B, align 4
+  %6 = getelementptr inbounds %struct.B, ptr %5, i32 0, i32 0
+  store i64 %0, ptr %6, align 4
+  call void @llvm.dbg.declare(metadata ptr %5, metadata !232, metadata !DIExpression()), !dbg !233
+  call void @llvm.dbg.value(metadata ptr %1, metadata !234, metadata !DIExpression()), !dbg !233
+  call void @llvm.dbg.value(metadata i32 %2, metadata !235, metadata !DIExpression()), !dbg !233
+  call void @llvm.dbg.value(metadata i32 %3, metadata !236, metadata !DIExpression()), !dbg !233
+  %7 = icmp sle i32 0, %3, !dbg !237
+  br i1 %7, label %8, label %10, !dbg !238
+
+8:                                                ; preds = %4
+  %9 = icmp sle i32 %3, 10, !dbg !239
+  br label %10
+
+10:                                               ; preds = %8, %4
+  %11 = phi i1 [ false, %4 ], [ %9, %8 ], !dbg !233
+  ret i1 %11, !dbg !233
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_9(i64 %0, ptr noundef %1, i32 noundef %2, i32 noundef %3) #0 !dbg !240 !pallas.exprWrapper !166 {
+  %5 = alloca %struct.B, align 4
+  %6 = getelementptr inbounds %struct.B, ptr %5, i32 0, i32 0
+  store i64 %0, ptr %6, align 4
+  call void @llvm.dbg.declare(metadata ptr %5, metadata !241, metadata !DIExpression()), !dbg !242
+  call void @llvm.dbg.value(metadata ptr %1, metadata !243, metadata !DIExpression()), !dbg !242
+  call void @llvm.dbg.value(metadata i32 %2, metadata !244, metadata !DIExpression()), !dbg !242
+  call void @llvm.dbg.value(metadata i32 %3, metadata !245, metadata !DIExpression()), !dbg !242
+  %7 = icmp eq ptr %1, %5, !dbg !246
+  ret i1 %7, !dbg !242
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_10(i64 %0, ptr noundef %1, i32 noundef %2, i32 noundef %3) #0 !dbg !247 !pallas.exprWrapper !166 {
+  %5 = alloca %struct.B, align 4
+  %6 = alloca %pallas.fracT, align 8
+  %7 = getelementptr inbounds %struct.B, ptr %5, i32 0, i32 0
+  store i64 %0, ptr %7, align 4
+  call void @llvm.dbg.declare(metadata ptr %5, metadata !248, metadata !DIExpression()), !dbg !249
+  call void @llvm.dbg.value(metadata ptr %1, metadata !250, metadata !DIExpression()), !dbg !249
+  call void @llvm.dbg.value(metadata i32 %2, metadata !251, metadata !DIExpression()), !dbg !249
+  call void @llvm.dbg.value(metadata i32 %3, metadata !252, metadata !DIExpression()), !dbg !249
+  call void @pallas.fracOf(ptr sret(%pallas.fracT) %6, i32 noundef 1, i32 noundef 1), !dbg !253
+  %8 = call i1 @pallas.perm(ptr noundef %1, ptr noundef byval(%pallas.fracT) %6), !dbg !254
+  ret i1 %8, !dbg !249
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_11(i64 %0, ptr noundef %1, i32 noundef %2, i32 noundef %3) #0 !dbg !255 !pallas.exprWrapper !166 {
+  %5 = alloca %struct.B, align 4
+  %6 = getelementptr inbounds %struct.B, ptr %5, i32 0, i32 0
+  store i64 %0, ptr %6, align 4
+  call void @llvm.dbg.declare(metadata ptr %5, metadata !256, metadata !DIExpression()), !dbg !257
+  call void @llvm.dbg.value(metadata ptr %1, metadata !258, metadata !DIExpression()), !dbg !257
+  call void @llvm.dbg.value(metadata i32 %2, metadata !259, metadata !DIExpression()), !dbg !257
+  call void @llvm.dbg.value(metadata i32 %3, metadata !260, metadata !DIExpression()), !dbg !257
+  %7 = load i32, ptr %1, align 4, !dbg !261
+  %8 = sub nsw i32 10, %3, !dbg !262
+  %9 = icmp eq i32 %7, %8, !dbg !263
+  ret i1 %9, !dbg !257
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_12(i64 %0, ptr noundef %1) #0 !dbg !264 !pallas.exprWrapper !166 {
+  %3 = alloca %struct.B, align 4
+  %4 = getelementptr inbounds %struct.B, ptr %3, i32 0, i32 0
+  store i64 %0, ptr %4, align 4
+  call void @llvm.dbg.declare(metadata ptr %3, metadata !267, metadata !DIExpression()), !dbg !268
+  call void @llvm.dbg.value(metadata ptr %1, metadata !269, metadata !DIExpression()), !dbg !268
+  %5 = load i32, ptr %1, align 4, !dbg !270
+  %6 = icmp eq i32 %5, 5, !dbg !271
+  ret i1 %6, !dbg !268
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_13(i64 %0, ptr noundef %1) #0 !dbg !272 !pallas.exprWrapper !166 {
+  %3 = alloca %struct.B, align 4
+  %4 = getelementptr inbounds %struct.B, ptr %3, i32 0, i32 0
+  store i64 %0, ptr %4, align 4
+  call void @llvm.dbg.declare(metadata ptr %3, metadata !273, metadata !DIExpression()), !dbg !274
+  call void @llvm.dbg.value(metadata ptr %1, metadata !275, metadata !DIExpression()), !dbg !274
+  %5 = getelementptr inbounds %struct.B, ptr %3, i32 0, i32 0, !dbg !276
+  %6 = getelementptr inbounds %struct.A, ptr %5, i32 0, i32 0, !dbg !277
+  %7 = icmp eq ptr %1, %6, !dbg !278
+  ret i1 %7, !dbg !274
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_14(i64 %0, ptr noundef %1) #0 !dbg !279 !pallas.exprWrapper !166 {
+  %3 = alloca %struct.B, align 4
+  %4 = getelementptr inbounds %struct.B, ptr %3, i32 0, i32 0
+  store i64 %0, ptr %4, align 4
+  call void @llvm.dbg.declare(metadata ptr %3, metadata !280, metadata !DIExpression()), !dbg !281
+  call void @llvm.dbg.value(metadata ptr %1, metadata !282, metadata !DIExpression()), !dbg !281
+  %5 = getelementptr inbounds %struct.B, ptr %3, i32 0, i32 0, !dbg !283
+  %6 = icmp eq ptr %1, %5, !dbg !284
+  ret i1 %6, !dbg !281
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_15(i64 %0, ptr noundef %1) #0 !dbg !285 !pallas.exprWrapper !166 {
+  %3 = alloca %struct.B, align 4
+  %4 = getelementptr inbounds %struct.B, ptr %3, i32 0, i32 0
+  store i64 %0, ptr %4, align 4
+  call void @llvm.dbg.declare(metadata ptr %3, metadata !286, metadata !DIExpression()), !dbg !287
+  call void @llvm.dbg.value(metadata ptr %1, metadata !288, metadata !DIExpression()), !dbg !287
+  %5 = getelementptr inbounds %struct.B, ptr %3, i32 0, i32 0, !dbg !289
+  %6 = getelementptr inbounds %struct.A, ptr %5, i32 0, i32 0, !dbg !290
+  %7 = load i32, ptr %6, align 4, !dbg !290
+  %8 = icmp eq i32 %7, 10, !dbg !291
+  ret i1 %8, !dbg !287
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_16(i64 %0, ptr noundef %1, i32 noundef %2) #0 !dbg !292 !pallas.exprWrapper !166 {
+  %4 = alloca %struct.B, align 4
+  %5 = getelementptr inbounds %struct.B, ptr %4, i32 0, i32 0
+  store i64 %0, ptr %5, align 4
+  call void @llvm.dbg.declare(metadata ptr %4, metadata !293, metadata !DIExpression()), !dbg !294
+  call void @llvm.dbg.value(metadata ptr %1, metadata !295, metadata !DIExpression()), !dbg !294
+  call void @llvm.dbg.value(metadata i32 %2, metadata !296, metadata !DIExpression()), !dbg !294
+  %6 = getelementptr inbounds %struct.B, ptr %4, i32 0, i32 0, !dbg !297
+  %7 = getelementptr inbounds %struct.A, ptr %6, i32 0, i32 0, !dbg !298
+  %8 = load i32, ptr %7, align 4, !dbg !298
+  %9 = icmp eq i32 %8, 0, !dbg !299
+  ret i1 %9, !dbg !294
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_17(i64 %0, ptr noundef %1, i32 noundef %2, i32 noundef %3) #0 !dbg !300 !pallas.exprWrapper !166 {
+  %5 = alloca %struct.B, align 4
+  %6 = getelementptr inbounds %struct.B, ptr %5, i32 0, i32 0
+  store i64 %0, ptr %6, align 4
+  call void @llvm.dbg.declare(metadata ptr %5, metadata !301, metadata !DIExpression()), !dbg !302
+  call void @llvm.dbg.value(metadata ptr %1, metadata !303, metadata !DIExpression()), !dbg !302
+  call void @llvm.dbg.value(metadata i32 %2, metadata !304, metadata !DIExpression()), !dbg !302
+  call void @llvm.dbg.value(metadata i32 %3, metadata !305, metadata !DIExpression()), !dbg !302
+  %7 = getelementptr inbounds %struct.B, ptr %5, i32 0, i32 0, !dbg !306
+  %8 = getelementptr inbounds %struct.A, ptr %7, i32 0, i32 0, !dbg !307
+  %9 = load i32, ptr %8, align 4, !dbg !307
+  %10 = icmp eq i32 %9, 0, !dbg !308
+  ret i1 %10, !dbg !302
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_18(i64 %0, ptr noundef %1) #0 !dbg !309 !pallas.exprWrapper !166 {
+  %3 = alloca %struct.B, align 4
+  %4 = getelementptr inbounds %struct.B, ptr %3, i32 0, i32 0
+  store i64 %0, ptr %4, align 4
+  call void @llvm.dbg.declare(metadata ptr %3, metadata !310, metadata !DIExpression()), !dbg !311
+  call void @llvm.dbg.value(metadata ptr %1, metadata !312, metadata !DIExpression()), !dbg !311
+  %5 = getelementptr inbounds %struct.B, ptr %3, i32 0, i32 0, !dbg !313
+  %6 = getelementptr inbounds %struct.A, ptr %5, i32 0, i32 0, !dbg !314
+  %7 = load i32, ptr %6, align 4, !dbg !314
+  %8 = icmp eq i32 %7, 16, !dbg !315
+  ret i1 %8, !dbg !311
+}
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare void @llvm.dbg.value(metadata, metadata, metadata) #1
+
+declare !pallas.specLib !316 i32 @pallas.old.0(i32 noundef)
+
+declare !pallas.specLib !317 i1 @pallas.perm(ptr noundef, ptr noundef byval(%pallas.fracT))
+
+declare !pallas.specLib !318 void @pallas.fracOf(ptr sret(%pallas.fracT), i32 noundef, i32 noundef)
+
+attributes #0 = { noinline nounwind uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+
+!llvm.dbg.cu = !{!0, !5}
+!llvm.module.flags = !{!9, !10, !11, !12, !13, !14, !15}
+!llvm.ident = !{!16, !16}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang version 17.0.0 (https://github.com/swiftlang/llvm-project.git 73500bf55acff5fa97b56dcdeb013f288efd084f)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, retainedTypes: !2, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "examples/concepts/llvm/pointer_casts.c", directory: ".", checksumkind: CSK_MD5, checksum: "5f415ed5499174e0d5081bbc2cd18cf0")
+!2 = !{!3}
+!3 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!4 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!5 = distinct !DICompileUnit(language: DW_LANG_C11, file: !6, producer: "clang version 17.0.0 (https://github.com/swiftlang/llvm-project.git 73500bf55acff5fa97b56dcdeb013f288efd084f)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, retainedTypes: !7, splitDebugInlining: false, nameTableKind: None)
+!6 = !DIFile(filename: "source_wrappers.c", directory: ".", checksumkind: CSK_MD5, checksum: "cc5ba85943b8a87e6518ae7bb3b23b2d")
+!7 = !{!3, !8}
+!8 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
+!9 = !{i32 7, !"Dwarf Version", i32 5}
+!10 = !{i32 2, !"Debug Info Version", i32 3}
+!11 = !{i32 1, !"wchar_size", i32 4}
+!12 = !{i32 8, !"PIC Level", i32 2}
+!13 = !{i32 7, !"PIE Level", i32 2}
+!14 = !{i32 7, !"uwtable", i32 2}
+!15 = !{i32 7, !"frame-pointer", i32 2}
+!16 = !{!"clang version 17.0.0 (https://github.com/swiftlang/llvm-project.git 73500bf55acff5fa97b56dcdeb013f288efd084f)"}
+!17 = distinct !DISubprogram(name: "canCastToInteger", scope: !1, file: !1, line: 19, type: !18, scopeLine: 19, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+!18 = !DISubroutineType(types: !19)
+!19 = !{null}
+!20 = !{}
+!21 = !DILocalVariable(name: "struct_b", scope: !17, file: !1, line: 20, type: !22)
+!22 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "B", file: !1, line: 8, size: 64, elements: !23)
+!23 = !{!24}
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "struct_a", scope: !22, file: !1, line: 9, baseType: !25, size: 64)
+!25 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "A", file: !1, line: 3, size: 64, elements: !26)
+!26 = !{!27, !28}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "integer", scope: !25, file: !1, line: 4, baseType: !4, size: 32)
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "boolean", scope: !25, file: !1, line: 5, baseType: !29, size: 8, offset: 32)
+!29 = !DIBasicType(name: "_Bool", size: 8, encoding: DW_ATE_boolean)
+!30 = !DILocation(line: 20, column: 14, scope: !17)
+!31 = !DILocation(line: 21, column: 14, scope: !17)
+!32 = !DILocation(line: 21, column: 23, scope: !17)
+!33 = !DILocation(line: 21, column: 31, scope: !17)
+!34 = !DILocalVariable(name: "pointer_to_integer", scope: !17, file: !1, line: 22, type: !3)
+!35 = !DILocation(line: 22, column: 10, scope: !17)
+!36 = !DILocation(line: 26, column: 6, scope: !17)
+!37 = !{!38, !39, !41, !43}
+!38 = !{!"pallas.srcLoc", i64 23, i64 5, i64 25, i64 62}
+!39 = !{!"pallas.assert", !40, ptr @PALLAS_SPEC_12, !21, !34}
+!40 = !{!"pallas.srcLoc", i64 23, i64 9, i64 23, i64 40}
+!41 = !{!"pallas.assert", !42, ptr @PALLAS_SPEC_13, !21, !34}
+!42 = !{!"pallas.srcLoc", i64 24, i64 6, i64 24, i64 61}
+!43 = !{!"pallas.assert", !44, ptr @PALLAS_SPEC_14, !21, !34}
+!44 = !{!"pallas.srcLoc", i64 25, i64 6, i64 25, i64 60}
+!45 = !DILocation(line: 26, column: 25, scope: !17)
+!46 = !DILocation(line: 28, column: 1, scope: !17)
+!47 = !{!48, !49}
+!48 = !{!"pallas.srcLoc", i64 27, i64 5, i64 27, i64 49}
+!49 = !{!"pallas.assert", !50, ptr @PALLAS_SPEC_15, !21, !34}
+!50 = !{!"pallas.srcLoc", i64 27, i64 9, i64 27, i64 47}
+!51 = distinct !DISubprogram(name: "castRemainsValidInLoop", scope: !1, file: !1, line: 31, type: !18, scopeLine: 31, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+!52 = !DILocalVariable(name: "struct_b", scope: !51, file: !1, line: 32, type: !22)
+!53 = !DILocation(line: 32, column: 14, scope: !51)
+!54 = !DILocation(line: 33, column: 14, scope: !51)
+!55 = !DILocation(line: 33, column: 23, scope: !51)
+!56 = !DILocation(line: 33, column: 31, scope: !51)
+!57 = !DILocalVariable(name: "pointer_to_integer", scope: !51, file: !1, line: 35, type: !3)
+!58 = !DILocation(line: 35, column: 10, scope: !51)
+!59 = !DILocalVariable(name: "i", scope: !60, file: !1, line: 41, type: !4)
+!60 = distinct !DILexicalBlock(scope: !51, file: !1, line: 41, column: 5)
+!61 = !DILocation(line: 41, column: 14, scope: !60)
+!62 = !DILocation(line: 41, column: 10, scope: !60)
+!63 = !DILocation(line: 41, column: 21, scope: !64)
+!64 = distinct !DILexicalBlock(scope: !60, file: !1, line: 41, column: 5)
+!65 = !DILocation(line: 41, column: 23, scope: !64)
+!66 = !DILocation(line: 41, column: 5, scope: !60)
+!67 = !DILocation(line: 42, column: 32, scope: !68)
+!68 = distinct !DILexicalBlock(scope: !64, file: !1, line: 41, column: 34)
+!69 = !DILocation(line: 42, column: 31, scope: !68)
+!70 = !DILocation(line: 42, column: 51, scope: !68)
+!71 = !DILocation(line: 42, column: 10, scope: !68)
+!72 = !DILocation(line: 42, column: 29, scope: !68)
+!73 = !DILocation(line: 43, column: 5, scope: !68)
+!74 = !DILocation(line: 41, column: 30, scope: !64)
+!75 = !DILocation(line: 41, column: 5, scope: !64)
+!76 = distinct !{!76, !66, !77, !78, !79}
+!77 = !DILocation(line: 43, column: 5, scope: !60)
+!78 = !{!"llvm.loop.mustprogress"}
+!79 = !{!"pallas.loopInv", !80, !81, !83, !85, !87}
+!80 = !{!"pallas.srcLoc", i64 37, i64 5, i64 40, i64 55}
+!81 = !{!82, ptr @PALLAS_SPEC_4, !52, !57, !59}
+!82 = !{!"pallas.srcLoc", i64 37, i64 9, i64 37, i64 41}
+!83 = !{!84, ptr @PALLAS_SPEC_5, !52, !57, !59}
+!84 = !{!"pallas.srcLoc", i64 38, i64 9, i64 38, i64 62}
+!85 = !{!86, ptr @PALLAS_SPEC_6, !52, !57, !59}
+!86 = !{!"pallas.srcLoc", i64 39, i64 9, i64 39, i64 72}
+!87 = !{!88, ptr @PALLAS_SPEC_7, !52, !57, !59}
+!88 = !{!"pallas.srcLoc", i64 40, i64 9, i64 40, i64 53}
+!89 = !DILocation(line: 46, column: 14, scope: !51)
+!90 = !{!91, !92}
+!91 = !{!"pallas.srcLoc", i64 45, i64 5, i64 45, i64 48}
+!92 = !{!"pallas.assert", !93, ptr @PALLAS_SPEC_16, !52, !57, !59}
+!93 = !{!"pallas.srcLoc", i64 45, i64 9, i64 45, i64 46}
+!94 = !DILocation(line: 46, column: 23, scope: !51)
+!95 = !DILocation(line: 46, column: 31, scope: !51)
+!96 = !DILocalVariable(name: "j", scope: !97, file: !1, line: 53, type: !4)
+!97 = distinct !DILexicalBlock(scope: !51, file: !1, line: 53, column: 5)
+!98 = !DILocation(line: 53, column: 14, scope: !97)
+!99 = !DILocation(line: 53, column: 10, scope: !97)
+!100 = !DILocation(line: 53, column: 21, scope: !101)
+!101 = distinct !DILexicalBlock(scope: !97, file: !1, line: 53, column: 5)
+!102 = !DILocation(line: 53, column: 23, scope: !101)
+!103 = !DILocation(line: 53, column: 5, scope: !97)
+!104 = !DILocation(line: 54, column: 32, scope: !105)
+!105 = distinct !DILexicalBlock(scope: !101, file: !1, line: 53, column: 34)
+!106 = !DILocation(line: 54, column: 31, scope: !105)
+!107 = !DILocation(line: 54, column: 51, scope: !105)
+!108 = !DILocation(line: 54, column: 10, scope: !105)
+!109 = !DILocation(line: 54, column: 29, scope: !105)
+!110 = !DILocation(line: 55, column: 5, scope: !105)
+!111 = !DILocation(line: 53, column: 30, scope: !101)
+!112 = !DILocation(line: 53, column: 5, scope: !101)
+!113 = distinct !{!113, !103, !114, !78, !115}
+!114 = !DILocation(line: 55, column: 5, scope: !97)
+!115 = !{!"pallas.loopInv", !116, !117, !119, !121, !123}
+!116 = !{!"pallas.srcLoc", i64 49, i64 5, i64 52, i64 55}
+!117 = !{!118, ptr @PALLAS_SPEC_8, !52, !57, !59, !96}
+!118 = !{!"pallas.srcLoc", i64 49, i64 9, i64 49, i64 41}
+!119 = !{!120, ptr @PALLAS_SPEC_9, !52, !57, !59, !96}
+!120 = !{!"pallas.srcLoc", i64 50, i64 9, i64 50, i64 62}
+!121 = !{!122, ptr @PALLAS_SPEC_10, !52, !57, !59, !96}
+!122 = !{!"pallas.srcLoc", i64 51, i64 9, i64 51, i64 64}
+!123 = !{!124, ptr @PALLAS_SPEC_11, !52, !57, !59, !96}
+!124 = !{!"pallas.srcLoc", i64 52, i64 9, i64 52, i64 53}
+!125 = !DILocation(line: 58, column: 1, scope: !51)
+!126 = !{!127, !128}
+!127 = !{!"pallas.srcLoc", i64 57, i64 5, i64 57, i64 48}
+!128 = !{!"pallas.assert", !129, ptr @PALLAS_SPEC_17, !52, !57, !59, !96}
+!129 = !{!"pallas.srcLoc", i64 57, i64 9, i64 57, i64 46}
+!130 = distinct !DISubprogram(name: "increaseByOne", scope: !1, file: !1, line: 64, type: !131, scopeLine: 64, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+!131 = !DISubroutineType(types: !132)
+!132 = !{null, !3}
+!133 = !{!134, i1 false, !135, !138, !140, !142}
+!134 = !{!"pallas.srcLoc", i64 60, i64 1, i64 63, i64 34}
+!135 = !{!"pallas.requires", !136, ptr @PALLAS_SPEC_0, !137}
+!136 = !{!"pallas.srcLoc", i64 60, i64 5, i64 60, i64 23}
+!137 = !DILocalVariable(name: "a", arg: 1, scope: !130, file: !1, line: 64, type: !3)
+!138 = !{!"pallas.requires", !139, ptr @PALLAS_SPEC_1, !137}
+!139 = !{!"pallas.srcLoc", i64 61, i64 1, i64 61, i64 32}
+!140 = !{!"pallas.ensures", !141, ptr @PALLAS_SPEC_2, !137}
+!141 = !{!"pallas.srcLoc", i64 62, i64 1, i64 62, i64 31}
+!142 = !{!"pallas.ensures", !143, ptr @PALLAS_SPEC_3, !137}
+!143 = !{!"pallas.srcLoc", i64 63, i64 1, i64 63, i64 32}
+!144 = !DILocation(line: 64, column: 25, scope: !130)
+!145 = !DILocation(line: 65, column: 6, scope: !130)
+!146 = !DILocation(line: 65, column: 8, scope: !130)
+!147 = !DILocation(line: 66, column: 1, scope: !130)
+!148 = distinct !DISubprogram(name: "callWithCast", scope: !1, file: !1, line: 68, type: !18, scopeLine: 68, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+!149 = !DILocalVariable(name: "struct_b", scope: !148, file: !1, line: 69, type: !22)
+!150 = !DILocation(line: 69, column: 14, scope: !148)
+!151 = !DILocation(line: 70, column: 14, scope: !148)
+!152 = !DILocation(line: 70, column: 23, scope: !148)
+!153 = !DILocation(line: 70, column: 31, scope: !148)
+!154 = !DILocalVariable(name: "pointer_to_integer", scope: !148, file: !1, line: 72, type: !3)
+!155 = !DILocation(line: 72, column: 10, scope: !148)
+!156 = !DILocation(line: 73, column: 19, scope: !148)
+!157 = !DILocation(line: 73, column: 5, scope: !148)
+!158 = !DILocation(line: 76, column: 1, scope: !148)
+!159 = !{!160, !161}
+!160 = !{!"pallas.srcLoc", i64 75, i64 5, i64 75, i64 49}
+!161 = !{!"pallas.assert", !162, ptr @PALLAS_SPEC_18, !149, !154}
+!162 = !{!"pallas.srcLoc", i64 75, i64 9, i64 75, i64 47}
+!163 = distinct !DISubprogram(name: "PALLAS_SPEC_0", scope: !1, file: !1, line: 60, type: !164, scopeLine: 60, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+!164 = !DISubroutineType(types: !165)
+!165 = !{!29, !3}
+!166 = !{!""}
+!167 = !DILocalVariable(name: "a", arg: 1, scope: !163, file: !1, line: 60, type: !3)
+!168 = !DILocation(line: 0, scope: !163)
+!169 = !DILocation(line: 60, column: 16, scope: !163)
+!170 = distinct !DISubprogram(name: "PALLAS_SPEC_1", scope: !1, file: !1, line: 61, type: !164, scopeLine: 61, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+!171 = !DILocalVariable(name: "a", arg: 1, scope: !170, file: !1, line: 61, type: !3)
+!172 = !DILocation(line: 0, scope: !170)
+!173 = !DILocation(line: 61, column: 19, scope: !170)
+!174 = !DILocation(line: 61, column: 10, scope: !170)
+!175 = distinct !DISubprogram(name: "PALLAS_SPEC_2", scope: !1, file: !1, line: 62, type: !164, scopeLine: 62, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+!176 = !DILocalVariable(name: "a", arg: 1, scope: !175, file: !1, line: 62, type: !3)
+!177 = !DILocation(line: 0, scope: !175)
+!178 = !DILocation(line: 62, column: 18, scope: !175)
+!179 = !DILocation(line: 62, column: 9, scope: !175)
+!180 = distinct !DISubprogram(name: "PALLAS_SPEC_3", scope: !1, file: !1, line: 63, type: !164, scopeLine: 63, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+!181 = !DILocalVariable(name: "a", arg: 1, scope: !180, file: !1, line: 63, type: !3)
+!182 = !DILocation(line: 0, scope: !180)
+!183 = !DILocation(line: 63, column: 9, scope: !180)
+!184 = !DILocation(line: 63, column: 25, scope: !180)
+!185 = !DILocation(line: 63, column: 15, scope: !180)
+!186 = !DILocation(line: 63, column: 29, scope: !180)
+!187 = !DILocation(line: 63, column: 12, scope: !180)
+!188 = distinct !DISubprogram(name: "PALLAS_SPEC_4", scope: !1, file: !1, line: 37, type: !189, scopeLine: 37, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+!189 = !DISubroutineType(types: !190)
+!190 = !{!29, !191, !3, !4}
+!191 = !DIDerivedType(tag: DW_TAG_typedef, name: "B", file: !6, line: 14, baseType: !192)
+!192 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "B", file: !6, line: 9, size: 64, elements: !193)
+!193 = !{!194}
+!194 = !DIDerivedType(tag: DW_TAG_member, name: "struct_a", scope: !192, file: !6, line: 10, baseType: !195, size: 64)
+!195 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "A", file: !6, line: 4, size: 64, elements: !196)
+!196 = !{!197, !198}
+!197 = !DIDerivedType(tag: DW_TAG_member, name: "integer", scope: !195, file: !6, line: 5, baseType: !4, size: 32)
+!198 = !DIDerivedType(tag: DW_TAG_member, name: "boolean", scope: !195, file: !6, line: 6, baseType: !29, size: 8, offset: 32)
+!199 = !DILocalVariable(name: "struct_b", arg: 1, scope: !188, file: !1, line: 37, type: !191)
+!200 = !DILocation(line: 0, scope: !188)
+!201 = !DILocalVariable(name: "pointer_to_integer", arg: 2, scope: !188, file: !1, line: 37, type: !3)
+!202 = !DILocalVariable(name: "i", arg: 3, scope: !188, file: !1, line: 37, type: !4)
+!203 = !DILocation(line: 37, column: 26, scope: !188)
+!204 = !DILocation(line: 37, column: 31, scope: !188)
+!205 = !DILocation(line: 37, column: 36, scope: !188)
+!206 = distinct !DISubprogram(name: "PALLAS_SPEC_5", scope: !1, file: !1, line: 38, type: !189, scopeLine: 38, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+!207 = !DILocalVariable(name: "struct_b", arg: 1, scope: !206, file: !1, line: 38, type: !191)
+!208 = !DILocation(line: 0, scope: !206)
+!209 = !DILocalVariable(name: "pointer_to_integer", arg: 2, scope: !206, file: !1, line: 38, type: !3)
+!210 = !DILocalVariable(name: "i", arg: 3, scope: !206, file: !1, line: 38, type: !4)
+!211 = !DILocation(line: 38, column: 43, scope: !206)
+!212 = distinct !DISubprogram(name: "PALLAS_SPEC_6", scope: !1, file: !1, line: 39, type: !189, scopeLine: 39, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+!213 = !DILocalVariable(name: "struct_b", arg: 1, scope: !212, file: !1, line: 39, type: !191)
+!214 = !DILocation(line: 0, scope: !212)
+!215 = !DILocalVariable(name: "pointer_to_integer", arg: 2, scope: !212, file: !1, line: 39, type: !3)
+!216 = !DILocalVariable(name: "i", arg: 3, scope: !212, file: !1, line: 39, type: !4)
+!217 = !DILocation(line: 39, column: 40, scope: !212)
+!218 = !DILocation(line: 39, column: 49, scope: !212)
+!219 = !DILocation(line: 39, column: 58, scope: !212)
+!220 = !DILocation(line: 39, column: 24, scope: !212)
+!221 = distinct !DISubprogram(name: "PALLAS_SPEC_7", scope: !1, file: !1, line: 40, type: !189, scopeLine: 40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+!222 = !DILocalVariable(name: "struct_b", arg: 1, scope: !221, file: !1, line: 40, type: !191)
+!223 = !DILocation(line: 0, scope: !221)
+!224 = !DILocalVariable(name: "pointer_to_integer", arg: 2, scope: !221, file: !1, line: 40, type: !3)
+!225 = !DILocalVariable(name: "i", arg: 3, scope: !221, file: !1, line: 40, type: !4)
+!226 = !DILocation(line: 40, column: 24, scope: !221)
+!227 = !DILocation(line: 40, column: 50, scope: !221)
+!228 = !DILocation(line: 40, column: 44, scope: !221)
+!229 = distinct !DISubprogram(name: "PALLAS_SPEC_8", scope: !1, file: !1, line: 49, type: !230, scopeLine: 49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+!230 = !DISubroutineType(types: !231)
+!231 = !{!29, !191, !3, !4, !4}
+!232 = !DILocalVariable(name: "struct_b", arg: 1, scope: !229, file: !1, line: 49, type: !191)
+!233 = !DILocation(line: 0, scope: !229)
+!234 = !DILocalVariable(name: "pointer_to_integer", arg: 2, scope: !229, file: !1, line: 49, type: !3)
+!235 = !DILocalVariable(name: "i", arg: 3, scope: !229, file: !1, line: 49, type: !4)
+!236 = !DILocalVariable(name: "j", arg: 4, scope: !229, file: !1, line: 49, type: !4)
+!237 = !DILocation(line: 49, column: 26, scope: !229)
+!238 = !DILocation(line: 49, column: 31, scope: !229)
+!239 = !DILocation(line: 49, column: 36, scope: !229)
+!240 = distinct !DISubprogram(name: "PALLAS_SPEC_9", scope: !1, file: !1, line: 50, type: !230, scopeLine: 50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+!241 = !DILocalVariable(name: "struct_b", arg: 1, scope: !240, file: !1, line: 50, type: !191)
+!242 = !DILocation(line: 0, scope: !240)
+!243 = !DILocalVariable(name: "pointer_to_integer", arg: 2, scope: !240, file: !1, line: 50, type: !3)
+!244 = !DILocalVariable(name: "i", arg: 3, scope: !240, file: !1, line: 50, type: !4)
+!245 = !DILocalVariable(name: "j", arg: 4, scope: !240, file: !1, line: 50, type: !4)
+!246 = !DILocation(line: 50, column: 43, scope: !240)
+!247 = distinct !DISubprogram(name: "PALLAS_SPEC_10", scope: !1, file: !1, line: 51, type: !230, scopeLine: 51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+!248 = !DILocalVariable(name: "struct_b", arg: 1, scope: !247, file: !1, line: 51, type: !191)
+!249 = !DILocation(line: 0, scope: !247)
+!250 = !DILocalVariable(name: "pointer_to_integer", arg: 2, scope: !247, file: !1, line: 51, type: !3)
+!251 = !DILocalVariable(name: "i", arg: 3, scope: !247, file: !1, line: 51, type: !4)
+!252 = !DILocalVariable(name: "j", arg: 4, scope: !247, file: !1, line: 51, type: !4)
+!253 = !DILocation(line: 51, column: 50, scope: !247)
+!254 = !DILocation(line: 51, column: 24, scope: !247)
+!255 = distinct !DISubprogram(name: "PALLAS_SPEC_11", scope: !1, file: !1, line: 52, type: !230, scopeLine: 52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+!256 = !DILocalVariable(name: "struct_b", arg: 1, scope: !255, file: !1, line: 52, type: !191)
+!257 = !DILocation(line: 0, scope: !255)
+!258 = !DILocalVariable(name: "pointer_to_integer", arg: 2, scope: !255, file: !1, line: 52, type: !3)
+!259 = !DILocalVariable(name: "i", arg: 3, scope: !255, file: !1, line: 52, type: !4)
+!260 = !DILocalVariable(name: "j", arg: 4, scope: !255, file: !1, line: 52, type: !4)
+!261 = !DILocation(line: 52, column: 24, scope: !255)
+!262 = !DILocation(line: 52, column: 50, scope: !255)
+!263 = !DILocation(line: 52, column: 44, scope: !255)
+!264 = distinct !DISubprogram(name: "PALLAS_SPEC_12", scope: !1, file: !1, line: 23, type: !265, scopeLine: 23, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+!265 = !DISubroutineType(types: !266)
+!266 = !{!29, !191, !3}
+!267 = !DILocalVariable(name: "struct_b", arg: 1, scope: !264, file: !1, line: 23, type: !191)
+!268 = !DILocation(line: 0, scope: !264)
+!269 = !DILocalVariable(name: "pointer_to_integer", arg: 2, scope: !264, file: !1, line: 23, type: !3)
+!270 = !DILocation(line: 23, column: 16, scope: !264)
+!271 = !DILocation(line: 23, column: 36, scope: !264)
+!272 = distinct !DISubprogram(name: "PALLAS_SPEC_13", scope: !1, file: !1, line: 24, type: !265, scopeLine: 24, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+!273 = !DILocalVariable(name: "struct_b", arg: 1, scope: !272, file: !1, line: 24, type: !191)
+!274 = !DILocation(line: 0, scope: !272)
+!275 = !DILocalVariable(name: "pointer_to_integer", arg: 2, scope: !272, file: !1, line: 24, type: !3)
+!276 = !DILocation(line: 24, column: 45, scope: !272)
+!277 = !DILocation(line: 24, column: 54, scope: !272)
+!278 = !DILocation(line: 24, column: 32, scope: !272)
+!279 = distinct !DISubprogram(name: "PALLAS_SPEC_14", scope: !1, file: !1, line: 25, type: !265, scopeLine: 25, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+!280 = !DILocalVariable(name: "struct_b", arg: 1, scope: !279, file: !1, line: 25, type: !191)
+!281 = !DILocation(line: 0, scope: !279)
+!282 = !DILocalVariable(name: "pointer_to_integer", arg: 2, scope: !279, file: !1, line: 25, type: !3)
+!283 = !DILocation(line: 25, column: 52, scope: !279)
+!284 = !DILocation(line: 25, column: 32, scope: !279)
+!285 = distinct !DISubprogram(name: "PALLAS_SPEC_15", scope: !1, file: !1, line: 27, type: !265, scopeLine: 27, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+!286 = !DILocalVariable(name: "struct_b", arg: 1, scope: !285, file: !1, line: 27, type: !191)
+!287 = !DILocation(line: 0, scope: !285)
+!288 = !DILocalVariable(name: "pointer_to_integer", arg: 2, scope: !285, file: !1, line: 27, type: !3)
+!289 = !DILocation(line: 27, column: 25, scope: !285)
+!290 = !DILocation(line: 27, column: 34, scope: !285)
+!291 = !DILocation(line: 27, column: 42, scope: !285)
+!292 = distinct !DISubprogram(name: "PALLAS_SPEC_16", scope: !1, file: !1, line: 45, type: !189, scopeLine: 45, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+!293 = !DILocalVariable(name: "struct_b", arg: 1, scope: !292, file: !1, line: 45, type: !191)
+!294 = !DILocation(line: 0, scope: !292)
+!295 = !DILocalVariable(name: "pointer_to_integer", arg: 2, scope: !292, file: !1, line: 45, type: !3)
+!296 = !DILocalVariable(name: "i", arg: 3, scope: !292, file: !1, line: 45, type: !4)
+!297 = !DILocation(line: 45, column: 25, scope: !292)
+!298 = !DILocation(line: 45, column: 34, scope: !292)
+!299 = !DILocation(line: 45, column: 42, scope: !292)
+!300 = distinct !DISubprogram(name: "PALLAS_SPEC_17", scope: !1, file: !1, line: 57, type: !230, scopeLine: 57, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+!301 = !DILocalVariable(name: "struct_b", arg: 1, scope: !300, file: !1, line: 57, type: !191)
+!302 = !DILocation(line: 0, scope: !300)
+!303 = !DILocalVariable(name: "pointer_to_integer", arg: 2, scope: !300, file: !1, line: 57, type: !3)
+!304 = !DILocalVariable(name: "i", arg: 3, scope: !300, file: !1, line: 57, type: !4)
+!305 = !DILocalVariable(name: "j", arg: 4, scope: !300, file: !1, line: 57, type: !4)
+!306 = !DILocation(line: 57, column: 25, scope: !300)
+!307 = !DILocation(line: 57, column: 34, scope: !300)
+!308 = !DILocation(line: 57, column: 42, scope: !300)
+!309 = distinct !DISubprogram(name: "PALLAS_SPEC_18", scope: !1, file: !1, line: 75, type: !265, scopeLine: 75, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !20)
+!310 = !DILocalVariable(name: "struct_b", arg: 1, scope: !309, file: !1, line: 75, type: !191)
+!311 = !DILocation(line: 0, scope: !309)
+!312 = !DILocalVariable(name: "pointer_to_integer", arg: 2, scope: !309, file: !1, line: 75, type: !3)
+!313 = !DILocation(line: 75, column: 25, scope: !309)
+!314 = !DILocation(line: 75, column: 34, scope: !309)
+!315 = !DILocation(line: 75, column: 42, scope: !309)
+!316 = !{!"pallas.old"}
+!317 = !{!"pallas.perm"}
+!318 = !{!"pallas.fracOf"}

--- a/examples/concepts/llvm/pointer_relations.ll
+++ b/examples/concepts/llvm/pointer_relations.ll
@@ -1,0 +1,481 @@
+; ModuleID = 'tmp_ir_source0.ll'
+source_filename = "examples/concepts/c/pointer_relations.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+%struct.A = type { %struct.B, i8, i32, float }
+%struct.B = type { i32, float, i8 }
+
+@llvm.used = appending global [16 x ptr] [ptr @PALLAS_SPEC_0, ptr @PALLAS_SPEC_1, ptr @PALLAS_SPEC_2, ptr @PALLAS_SPEC_3, ptr @PALLAS_SPEC_4, ptr @PALLAS_SPEC_5, ptr @PALLAS_SPEC_6, ptr @PALLAS_SPEC_7, ptr @PALLAS_SPEC_8, ptr @PALLAS_SPEC_9, ptr @PALLAS_SPEC_10, ptr @PALLAS_SPEC_11, ptr @PALLAS_SPEC_12, ptr @PALLAS_SPEC_13, ptr @PALLAS_SPEC_14, ptr @PALLAS_SPEC_15], section "llvm.metadata"
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local void @test1(ptr noundef %0) #0 !dbg !17 !pallas.fcontract !36 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  call void @llvm.dbg.declare(metadata ptr %2, metadata !40, metadata !DIExpression()), !dbg !41
+  ret void, !dbg !42, !pallas.stmntBlock !43
+}
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #1
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local void @test2(ptr noundef %0) #0 !dbg !47 !pallas.fcontract !48 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  call void @llvm.dbg.declare(metadata ptr %2, metadata !52, metadata !DIExpression()), !dbg !53
+  ret void, !dbg !54, !pallas.stmntBlock !55
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local void @test3(ptr noundef %0) #0 !dbg !59 !pallas.fcontract !60 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  call void @llvm.dbg.declare(metadata ptr %2, metadata !64, metadata !DIExpression()), !dbg !65
+  ret void, !dbg !66, !pallas.stmntBlock !67
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local void @test4(ptr noundef %0) #0 !dbg !71 !pallas.fcontract !72 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  call void @llvm.dbg.declare(metadata ptr %2, metadata !76, metadata !DIExpression()), !dbg !77
+  ret void, !dbg !78, !pallas.stmntBlock !79
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local void @test5(ptr noundef %0) #0 !dbg !83 !pallas.fcontract !84 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  call void @llvm.dbg.declare(metadata ptr %2, metadata !88, metadata !DIExpression()), !dbg !89
+  ret void, !dbg !90, !pallas.stmntBlock !91
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local void @test6(ptr noundef %0) #0 !dbg !95 !pallas.fcontract !96 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  call void @llvm.dbg.declare(metadata ptr %2, metadata !100, metadata !DIExpression()), !dbg !101
+  ret void, !dbg !102, !pallas.stmntBlock !103
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local void @test7(ptr noundef %0) #0 !dbg !107 !pallas.fcontract !108 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  call void @llvm.dbg.declare(metadata ptr %2, metadata !112, metadata !DIExpression()), !dbg !113
+  ret void, !dbg !114, !pallas.stmntBlock !115
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local void @test8(ptr noundef %0) #0 !dbg !119 !pallas.fcontract !120 {
+  %2 = alloca ptr, align 8
+  store ptr %0, ptr %2, align 8
+  call void @llvm.dbg.declare(metadata ptr %2, metadata !124, metadata !DIExpression()), !dbg !125
+  ret void, !dbg !126, !pallas.stmntBlock !127
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_0(ptr noundef %0) #0 !dbg !131 !pallas.exprWrapper !148 {
+  call void @llvm.dbg.value(metadata ptr %0, metadata !149, metadata !DIExpression()), !dbg !150
+  %2 = icmp ne ptr %0, null, !dbg !151
+  ret i1 %2, !dbg !150
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_1(ptr noundef %0) #0 !dbg !152 !pallas.exprWrapper !148 {
+  call void @llvm.dbg.value(metadata ptr %0, metadata !153, metadata !DIExpression()), !dbg !154
+  %2 = icmp ne ptr %0, null, !dbg !155
+  ret i1 %2, !dbg !154
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_2(ptr noundef %0) #0 !dbg !156 !pallas.exprWrapper !148 {
+  call void @llvm.dbg.value(metadata ptr %0, metadata !157, metadata !DIExpression()), !dbg !158
+  %2 = icmp ne ptr %0, null, !dbg !159
+  ret i1 %2, !dbg !158
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_3(ptr noundef %0) #0 !dbg !160 !pallas.exprWrapper !148 {
+  call void @llvm.dbg.value(metadata ptr %0, metadata !161, metadata !DIExpression()), !dbg !162
+  %2 = icmp ne ptr %0, null, !dbg !163
+  ret i1 %2, !dbg !162
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_4(ptr noundef %0) #0 !dbg !164 !pallas.exprWrapper !148 {
+  call void @llvm.dbg.value(metadata ptr %0, metadata !165, metadata !DIExpression()), !dbg !166
+  %2 = icmp ne ptr %0, null, !dbg !167
+  ret i1 %2, !dbg !166
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_5(ptr noundef %0) #0 !dbg !168 !pallas.exprWrapper !148 {
+  call void @llvm.dbg.value(metadata ptr %0, metadata !169, metadata !DIExpression()), !dbg !170
+  %2 = icmp ne ptr %0, null, !dbg !171
+  ret i1 %2, !dbg !170
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_6(ptr noundef %0) #0 !dbg !172 !pallas.exprWrapper !148 {
+  call void @llvm.dbg.value(metadata ptr %0, metadata !173, metadata !DIExpression()), !dbg !174
+  %2 = icmp ne ptr %0, null, !dbg !175
+  ret i1 %2, !dbg !174
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_7(ptr noundef %0) #0 !dbg !176 !pallas.exprWrapper !148 {
+  call void @llvm.dbg.value(metadata ptr %0, metadata !177, metadata !DIExpression()), !dbg !178
+  %2 = icmp ne ptr %0, null, !dbg !179
+  ret i1 %2, !dbg !178
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_8(ptr noundef %0) #0 !dbg !180 !pallas.exprWrapper !148 {
+  call void @llvm.dbg.value(metadata ptr %0, metadata !181, metadata !DIExpression()), !dbg !182
+  %2 = ptrtoint ptr %0 to i64, !dbg !183
+  %3 = getelementptr inbounds %struct.A, ptr %0, i32 0, i32 0, !dbg !184
+  %4 = ptrtoint ptr %3 to i64, !dbg !185
+  %5 = icmp eq i64 %2, %4, !dbg !186
+  ret i1 %5, !dbg !182
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_9(ptr noundef %0) #0 !dbg !187 !pallas.exprWrapper !148 {
+  call void @llvm.dbg.value(metadata ptr %0, metadata !188, metadata !DIExpression()), !dbg !189
+  %2 = getelementptr inbounds %struct.A, ptr %0, i32 0, i32 0, !dbg !190
+  %3 = ptrtoint ptr %2 to i64, !dbg !191
+  %4 = getelementptr inbounds %struct.A, ptr %0, i32 0, i32 1, !dbg !192
+  %5 = ptrtoint ptr %4 to i64, !dbg !193
+  %6 = icmp ult i64 %3, %5, !dbg !194
+  ret i1 %6, !dbg !189
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_10(ptr noundef %0) #0 !dbg !195 !pallas.exprWrapper !148 {
+  call void @llvm.dbg.value(metadata ptr %0, metadata !196, metadata !DIExpression()), !dbg !197
+  %2 = getelementptr inbounds %struct.A, ptr %0, i32 0, i32 1, !dbg !198
+  %3 = ptrtoint ptr %2 to i64, !dbg !199
+  %4 = getelementptr inbounds %struct.A, ptr %0, i32 0, i32 2, !dbg !200
+  %5 = ptrtoint ptr %4 to i64, !dbg !201
+  %6 = icmp ult i64 %3, %5, !dbg !202
+  ret i1 %6, !dbg !197
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_11(ptr noundef %0) #0 !dbg !203 !pallas.exprWrapper !148 {
+  call void @llvm.dbg.value(metadata ptr %0, metadata !204, metadata !DIExpression()), !dbg !205
+  %2 = getelementptr inbounds %struct.A, ptr %0, i32 0, i32 2, !dbg !206
+  %3 = ptrtoint ptr %2 to i64, !dbg !207
+  %4 = getelementptr inbounds %struct.A, ptr %0, i32 0, i32 3, !dbg !208
+  %5 = ptrtoint ptr %4 to i64, !dbg !209
+  %6 = icmp ult i64 %3, %5, !dbg !210
+  ret i1 %6, !dbg !205
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_12(ptr noundef %0) #0 !dbg !211 !pallas.exprWrapper !148 {
+  call void @llvm.dbg.value(metadata ptr %0, metadata !212, metadata !DIExpression()), !dbg !213
+  %2 = getelementptr inbounds %struct.A, ptr %0, i32 0, i32 0, !dbg !214
+  %3 = ptrtoint ptr %2 to i64, !dbg !215
+  %4 = getelementptr inbounds %struct.A, ptr %0, i32 0, i32 0, !dbg !216
+  %5 = getelementptr inbounds %struct.B, ptr %4, i32 0, i32 0, !dbg !217
+  %6 = ptrtoint ptr %5 to i64, !dbg !218
+  %7 = icmp eq i64 %3, %6, !dbg !219
+  ret i1 %7, !dbg !213
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_13(ptr noundef %0) #0 !dbg !220 !pallas.exprWrapper !148 {
+  call void @llvm.dbg.value(metadata ptr %0, metadata !221, metadata !DIExpression()), !dbg !222
+  %2 = getelementptr inbounds %struct.A, ptr %0, i32 0, i32 0, !dbg !223
+  %3 = getelementptr inbounds %struct.B, ptr %2, i32 0, i32 0, !dbg !224
+  %4 = ptrtoint ptr %3 to i64, !dbg !225
+  %5 = getelementptr inbounds %struct.A, ptr %0, i32 0, i32 1, !dbg !226
+  %6 = ptrtoint ptr %5 to i64, !dbg !227
+  %7 = icmp ult i64 %4, %6, !dbg !228
+  ret i1 %7, !dbg !222
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_14(ptr noundef %0) #0 !dbg !229 !pallas.exprWrapper !148 {
+  call void @llvm.dbg.value(metadata ptr %0, metadata !230, metadata !DIExpression()), !dbg !231
+  %2 = getelementptr inbounds %struct.A, ptr %0, i32 0, i32 0, !dbg !232
+  %3 = getelementptr inbounds %struct.B, ptr %2, i32 0, i32 1, !dbg !233
+  %4 = ptrtoint ptr %3 to i64, !dbg !234
+  %5 = getelementptr inbounds %struct.A, ptr %0, i32 0, i32 2, !dbg !235
+  %6 = ptrtoint ptr %5 to i64, !dbg !236
+  %7 = icmp ult i64 %4, %6, !dbg !237
+  ret i1 %7, !dbg !231
+}
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local zeroext i1 @PALLAS_SPEC_15(ptr noundef %0) #0 !dbg !238 !pallas.exprWrapper !148 {
+  call void @llvm.dbg.value(metadata ptr %0, metadata !239, metadata !DIExpression()), !dbg !240
+  %2 = getelementptr inbounds %struct.A, ptr %0, i32 0, i32 0, !dbg !241
+  %3 = getelementptr inbounds %struct.B, ptr %2, i32 0, i32 2, !dbg !242
+  %4 = ptrtoint ptr %3 to i64, !dbg !243
+  %5 = getelementptr inbounds %struct.A, ptr %0, i32 0, i32 3, !dbg !244
+  %6 = ptrtoint ptr %5 to i64, !dbg !245
+  %7 = icmp ult i64 %4, %6, !dbg !246
+  ret i1 %7, !dbg !240
+}
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare void @llvm.dbg.value(metadata, metadata, metadata) #1
+
+attributes #0 = { noinline nounwind uwtable "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+
+!llvm.dbg.cu = !{!0, !2}
+!llvm.module.flags = !{!9, !10, !11, !12, !13, !14, !15}
+!llvm.ident = !{!16, !16}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang version 17.0.0 (https://github.com/swiftlang/llvm-project.git 73500bf55acff5fa97b56dcdeb013f288efd084f)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "pointer_relations.c", directory: ".", checksumkind: CSK_MD5, checksum: "6d634623b3efb2fa906e17a0980f974d")
+!2 = distinct !DICompileUnit(language: DW_LANG_C11, file: !3, producer: "clang version 17.0.0 (https://github.com/swiftlang/llvm-project.git 73500bf55acff5fa97b56dcdeb013f288efd084f)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, retainedTypes: !4, splitDebugInlining: false, nameTableKind: None)
+!3 = !DIFile(filename: "source_wrappers.c", directory: ".", checksumkind: CSK_MD5, checksum: "5967dc9ce63807dabdd0aa72ebf4cd4d")
+!4 = !{!5, !6}
+!5 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_typedef, name: "uintptr_t", file: !7, line: 79, baseType: !8)
+!7 = !DIFile(filename: "/usr/include/stdint.h", directory: "", checksumkind: CSK_MD5, checksum: "bfb03fa9c46a839e35c32b929fbdbb8e")
+!8 = !DIBasicType(name: "unsigned long", size: 64, encoding: DW_ATE_unsigned)
+!9 = !{i32 7, !"Dwarf Version", i32 5}
+!10 = !{i32 2, !"Debug Info Version", i32 3}
+!11 = !{i32 1, !"wchar_size", i32 4}
+!12 = !{i32 8, !"PIC Level", i32 2}
+!13 = !{i32 7, !"PIE Level", i32 2}
+!14 = !{i32 7, !"uwtable", i32 2}
+!15 = !{i32 7, !"frame-pointer", i32 2}
+!16 = !{!"clang version 17.0.0 (https://github.com/swiftlang/llvm-project.git 73500bf55acff5fa97b56dcdeb013f288efd084f)"}
+!17 = distinct !DISubprogram(name: "test1", scope: !1, file: !1, line: 22, type: !18, scopeLine: 22, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !35)
+!18 = !DISubroutineType(types: !19)
+!19 = !{null, !20}
+!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
+!21 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "A", file: !1, line: 11, size: 192, elements: !22)
+!22 = !{!23, !32, !33, !34}
+!23 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !21, file: !1, line: 12, baseType: !24, size: 96)
+!24 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "B", file: !1, line: 3, size: 96, elements: !25)
+!25 = !{!26, !28, !30}
+!26 = !DIDerivedType(tag: DW_TAG_member, name: "e", scope: !24, file: !1, line: 4, baseType: !27, size: 32)
+!27 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "f", scope: !24, file: !1, line: 5, baseType: !29, size: 32, offset: 32)
+!29 = !DIBasicType(name: "float", size: 32, encoding: DW_ATE_float)
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "g", scope: !24, file: !1, line: 6, baseType: !31, size: 8, offset: 64)
+!31 = !DIBasicType(name: "char", size: 8, encoding: DW_ATE_signed_char)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !21, file: !1, line: 13, baseType: !31, size: 8, offset: 96)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "c", scope: !21, file: !1, line: 14, baseType: !27, size: 32, offset: 128)
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "d", scope: !21, file: !1, line: 15, baseType: !29, size: 32, offset: 160)
+!35 = !{}
+!36 = !{!37, i1 false, !38}
+!37 = !{!"pallas.srcLoc", i64 21, i64 1, i64 21, i64 24}
+!38 = !{!"pallas.requires", !39, ptr @PALLAS_SPEC_0, !40}
+!39 = !{!"pallas.srcLoc", i64 21, i64 5, i64 21, i64 23}
+!40 = !DILocalVariable(name: "s", arg: 1, scope: !17, file: !1, line: 22, type: !20)
+!41 = !DILocation(line: 22, column: 22, scope: !17)
+!42 = !DILocation(line: 24, column: 1, scope: !17)
+!43 = !{!44, !45}
+!44 = !{!"pallas.srcLoc", i64 23, i64 5, i64 23, i64 49}
+!45 = !{!"pallas.assert", !46, ptr @PALLAS_SPEC_8, !40}
+!46 = !{!"pallas.srcLoc", i64 23, i64 9, i64 23, i64 48}
+!47 = distinct !DISubprogram(name: "test2", scope: !1, file: !1, line: 27, type: !18, scopeLine: 27, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !35)
+!48 = !{!49, i1 false, !50}
+!49 = !{!"pallas.srcLoc", i64 26, i64 1, i64 26, i64 24}
+!50 = !{!"pallas.requires", !51, ptr @PALLAS_SPEC_1, !52}
+!51 = !{!"pallas.srcLoc", i64 26, i64 5, i64 26, i64 23}
+!52 = !DILocalVariable(name: "s", arg: 1, scope: !47, file: !1, line: 27, type: !20)
+!53 = !DILocation(line: 27, column: 22, scope: !47)
+!54 = !DILocation(line: 29, column: 1, scope: !47)
+!55 = !{!56, !57}
+!56 = !{!"pallas.srcLoc", i64 28, i64 5, i64 28, i64 53}
+!57 = !{!"pallas.assert", !58, ptr @PALLAS_SPEC_9, !52}
+!58 = !{!"pallas.srcLoc", i64 28, i64 9, i64 28, i64 51}
+!59 = distinct !DISubprogram(name: "test3", scope: !1, file: !1, line: 32, type: !18, scopeLine: 32, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !35)
+!60 = !{!61, i1 false, !62}
+!61 = !{!"pallas.srcLoc", i64 31, i64 1, i64 31, i64 24}
+!62 = !{!"pallas.requires", !63, ptr @PALLAS_SPEC_2, !64}
+!63 = !{!"pallas.srcLoc", i64 31, i64 5, i64 31, i64 23}
+!64 = !DILocalVariable(name: "s", arg: 1, scope: !59, file: !1, line: 32, type: !20)
+!65 = !DILocation(line: 32, column: 22, scope: !59)
+!66 = !DILocation(line: 34, column: 1, scope: !59)
+!67 = !{!68, !69}
+!68 = !{!"pallas.srcLoc", i64 33, i64 5, i64 33, i64 53}
+!69 = !{!"pallas.assert", !70, ptr @PALLAS_SPEC_10, !64}
+!70 = !{!"pallas.srcLoc", i64 33, i64 9, i64 33, i64 51}
+!71 = distinct !DISubprogram(name: "test4", scope: !1, file: !1, line: 37, type: !18, scopeLine: 37, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !35)
+!72 = !{!73, i1 false, !74}
+!73 = !{!"pallas.srcLoc", i64 36, i64 1, i64 36, i64 24}
+!74 = !{!"pallas.requires", !75, ptr @PALLAS_SPEC_3, !76}
+!75 = !{!"pallas.srcLoc", i64 36, i64 5, i64 36, i64 23}
+!76 = !DILocalVariable(name: "s", arg: 1, scope: !71, file: !1, line: 37, type: !20)
+!77 = !DILocation(line: 37, column: 22, scope: !71)
+!78 = !DILocation(line: 39, column: 1, scope: !71)
+!79 = !{!80, !81}
+!80 = !{!"pallas.srcLoc", i64 38, i64 5, i64 38, i64 53}
+!81 = !{!"pallas.assert", !82, ptr @PALLAS_SPEC_11, !76}
+!82 = !{!"pallas.srcLoc", i64 38, i64 9, i64 38, i64 51}
+!83 = distinct !DISubprogram(name: "test5", scope: !1, file: !1, line: 42, type: !18, scopeLine: 42, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !35)
+!84 = !{!85, i1 false, !86}
+!85 = !{!"pallas.srcLoc", i64 41, i64 1, i64 41, i64 24}
+!86 = !{!"pallas.requires", !87, ptr @PALLAS_SPEC_4, !88}
+!87 = !{!"pallas.srcLoc", i64 41, i64 5, i64 41, i64 23}
+!88 = !DILocalVariable(name: "s", arg: 1, scope: !83, file: !1, line: 42, type: !20)
+!89 = !DILocation(line: 42, column: 22, scope: !83)
+!90 = !DILocation(line: 44, column: 1, scope: !83)
+!91 = !{!92, !93}
+!92 = !{!"pallas.srcLoc", i64 43, i64 5, i64 43, i64 56}
+!93 = !{!"pallas.assert", !94, ptr @PALLAS_SPEC_12, !88}
+!94 = !{!"pallas.srcLoc", i64 43, i64 9, i64 43, i64 54}
+!95 = distinct !DISubprogram(name: "test6", scope: !1, file: !1, line: 47, type: !18, scopeLine: 47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !35)
+!96 = !{!97, i1 false, !98}
+!97 = !{!"pallas.srcLoc", i64 46, i64 1, i64 46, i64 24}
+!98 = !{!"pallas.requires", !99, ptr @PALLAS_SPEC_5, !100}
+!99 = !{!"pallas.srcLoc", i64 46, i64 5, i64 46, i64 23}
+!100 = !DILocalVariable(name: "s", arg: 1, scope: !95, file: !1, line: 47, type: !20)
+!101 = !DILocation(line: 47, column: 22, scope: !95)
+!102 = !DILocation(line: 49, column: 1, scope: !95)
+!103 = !{!104, !105}
+!104 = !{!"pallas.srcLoc", i64 48, i64 5, i64 48, i64 55}
+!105 = !{!"pallas.assert", !106, ptr @PALLAS_SPEC_13, !100}
+!106 = !{!"pallas.srcLoc", i64 48, i64 9, i64 48, i64 53}
+!107 = distinct !DISubprogram(name: "test7", scope: !1, file: !1, line: 52, type: !18, scopeLine: 52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !35)
+!108 = !{!109, i1 false, !110}
+!109 = !{!"pallas.srcLoc", i64 51, i64 1, i64 51, i64 24}
+!110 = !{!"pallas.requires", !111, ptr @PALLAS_SPEC_6, !112}
+!111 = !{!"pallas.srcLoc", i64 51, i64 5, i64 51, i64 23}
+!112 = !DILocalVariable(name: "s", arg: 1, scope: !107, file: !1, line: 52, type: !20)
+!113 = !DILocation(line: 52, column: 22, scope: !107)
+!114 = !DILocation(line: 54, column: 1, scope: !107)
+!115 = !{!116, !117}
+!116 = !{!"pallas.srcLoc", i64 53, i64 5, i64 53, i64 55}
+!117 = !{!"pallas.assert", !118, ptr @PALLAS_SPEC_14, !112}
+!118 = !{!"pallas.srcLoc", i64 53, i64 9, i64 53, i64 53}
+!119 = distinct !DISubprogram(name: "test8", scope: !1, file: !1, line: 57, type: !18, scopeLine: 57, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !35)
+!120 = !{!121, i1 false, !122}
+!121 = !{!"pallas.srcLoc", i64 56, i64 1, i64 56, i64 24}
+!122 = !{!"pallas.requires", !123, ptr @PALLAS_SPEC_7, !124}
+!123 = !{!"pallas.srcLoc", i64 56, i64 5, i64 56, i64 23}
+!124 = !DILocalVariable(name: "s", arg: 1, scope: !119, file: !1, line: 57, type: !20)
+!125 = !DILocation(line: 57, column: 22, scope: !119)
+!126 = !DILocation(line: 59, column: 1, scope: !119)
+!127 = !{!128, !129}
+!128 = !{!"pallas.srcLoc", i64 58, i64 5, i64 58, i64 55}
+!129 = !{!"pallas.assert", !130, ptr @PALLAS_SPEC_15, !124}
+!130 = !{!"pallas.srcLoc", i64 58, i64 9, i64 58, i64 53}
+!131 = distinct !DISubprogram(name: "PALLAS_SPEC_0", scope: !1, file: !1, line: 21, type: !132, scopeLine: 21, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !35)
+!132 = !DISubroutineType(types: !133)
+!133 = !{!134, !135}
+!134 = !DIBasicType(name: "_Bool", size: 8, encoding: DW_ATE_boolean)
+!135 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !136, size: 64)
+!136 = !DIDerivedType(tag: DW_TAG_typedef, name: "A", file: !3, line: 19, baseType: !137)
+!137 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "A", file: !3, line: 12, size: 192, elements: !138)
+!138 = !{!139, !145, !146, !147}
+!139 = !DIDerivedType(tag: DW_TAG_member, name: "a", scope: !137, file: !3, line: 13, baseType: !140, size: 96)
+!140 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "B", file: !3, line: 4, size: 96, elements: !141)
+!141 = !{!142, !143, !144}
+!142 = !DIDerivedType(tag: DW_TAG_member, name: "e", scope: !140, file: !3, line: 5, baseType: !27, size: 32)
+!143 = !DIDerivedType(tag: DW_TAG_member, name: "f", scope: !140, file: !3, line: 6, baseType: !29, size: 32, offset: 32)
+!144 = !DIDerivedType(tag: DW_TAG_member, name: "g", scope: !140, file: !3, line: 7, baseType: !31, size: 8, offset: 64)
+!145 = !DIDerivedType(tag: DW_TAG_member, name: "b", scope: !137, file: !3, line: 14, baseType: !31, size: 8, offset: 96)
+!146 = !DIDerivedType(tag: DW_TAG_member, name: "c", scope: !137, file: !3, line: 15, baseType: !27, size: 32, offset: 128)
+!147 = !DIDerivedType(tag: DW_TAG_member, name: "d", scope: !137, file: !3, line: 16, baseType: !29, size: 32, offset: 160)
+!148 = !{!""}
+!149 = !DILocalVariable(name: "s", arg: 1, scope: !131, file: !1, line: 21, type: !135)
+!150 = !DILocation(line: 0, scope: !131)
+!151 = !DILocation(line: 21, column: 16, scope: !131)
+!152 = distinct !DISubprogram(name: "PALLAS_SPEC_1", scope: !1, file: !1, line: 26, type: !132, scopeLine: 26, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !35)
+!153 = !DILocalVariable(name: "s", arg: 1, scope: !152, file: !1, line: 26, type: !135)
+!154 = !DILocation(line: 0, scope: !152)
+!155 = !DILocation(line: 26, column: 16, scope: !152)
+!156 = distinct !DISubprogram(name: "PALLAS_SPEC_2", scope: !1, file: !1, line: 31, type: !132, scopeLine: 31, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !35)
+!157 = !DILocalVariable(name: "s", arg: 1, scope: !156, file: !1, line: 31, type: !135)
+!158 = !DILocation(line: 0, scope: !156)
+!159 = !DILocation(line: 31, column: 16, scope: !156)
+!160 = distinct !DISubprogram(name: "PALLAS_SPEC_3", scope: !1, file: !1, line: 36, type: !132, scopeLine: 36, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !35)
+!161 = !DILocalVariable(name: "s", arg: 1, scope: !160, file: !1, line: 36, type: !135)
+!162 = !DILocation(line: 0, scope: !160)
+!163 = !DILocation(line: 36, column: 16, scope: !160)
+!164 = distinct !DISubprogram(name: "PALLAS_SPEC_4", scope: !1, file: !1, line: 41, type: !132, scopeLine: 41, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !35)
+!165 = !DILocalVariable(name: "s", arg: 1, scope: !164, file: !1, line: 41, type: !135)
+!166 = !DILocation(line: 0, scope: !164)
+!167 = !DILocation(line: 41, column: 16, scope: !164)
+!168 = distinct !DISubprogram(name: "PALLAS_SPEC_5", scope: !1, file: !1, line: 46, type: !132, scopeLine: 46, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !35)
+!169 = !DILocalVariable(name: "s", arg: 1, scope: !168, file: !1, line: 46, type: !135)
+!170 = !DILocation(line: 0, scope: !168)
+!171 = !DILocation(line: 46, column: 16, scope: !168)
+!172 = distinct !DISubprogram(name: "PALLAS_SPEC_6", scope: !1, file: !1, line: 51, type: !132, scopeLine: 51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !35)
+!173 = !DILocalVariable(name: "s", arg: 1, scope: !172, file: !1, line: 51, type: !135)
+!174 = !DILocation(line: 0, scope: !172)
+!175 = !DILocation(line: 51, column: 16, scope: !172)
+!176 = distinct !DISubprogram(name: "PALLAS_SPEC_7", scope: !1, file: !1, line: 56, type: !132, scopeLine: 56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !35)
+!177 = !DILocalVariable(name: "s", arg: 1, scope: !176, file: !1, line: 56, type: !135)
+!178 = !DILocation(line: 0, scope: !176)
+!179 = !DILocation(line: 56, column: 16, scope: !176)
+!180 = distinct !DISubprogram(name: "PALLAS_SPEC_8", scope: !1, file: !1, line: 23, type: !132, scopeLine: 23, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !35)
+!181 = !DILocalVariable(name: "s", arg: 1, scope: !180, file: !1, line: 23, type: !135)
+!182 = !DILocation(line: 0, scope: !180)
+!183 = !DILocation(line: 23, column: 16, scope: !180)
+!184 = !DILocation(line: 23, column: 47, scope: !180)
+!185 = !DILocation(line: 23, column: 32, scope: !180)
+!186 = !DILocation(line: 23, column: 29, scope: !180)
+!187 = distinct !DISubprogram(name: "PALLAS_SPEC_9", scope: !1, file: !1, line: 28, type: !132, scopeLine: 28, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !35)
+!188 = !DILocalVariable(name: "s", arg: 1, scope: !187, file: !1, line: 28, type: !135)
+!189 = !DILocation(line: 0, scope: !187)
+!190 = !DILocation(line: 28, column: 31, scope: !187)
+!191 = !DILocation(line: 28, column: 16, scope: !187)
+!192 = !DILocation(line: 28, column: 50, scope: !187)
+!193 = !DILocation(line: 28, column: 35, scope: !187)
+!194 = !DILocation(line: 28, column: 33, scope: !187)
+!195 = distinct !DISubprogram(name: "PALLAS_SPEC_10", scope: !1, file: !1, line: 33, type: !132, scopeLine: 33, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !35)
+!196 = !DILocalVariable(name: "s", arg: 1, scope: !195, file: !1, line: 33, type: !135)
+!197 = !DILocation(line: 0, scope: !195)
+!198 = !DILocation(line: 33, column: 31, scope: !195)
+!199 = !DILocation(line: 33, column: 16, scope: !195)
+!200 = !DILocation(line: 33, column: 50, scope: !195)
+!201 = !DILocation(line: 33, column: 35, scope: !195)
+!202 = !DILocation(line: 33, column: 33, scope: !195)
+!203 = distinct !DISubprogram(name: "PALLAS_SPEC_11", scope: !1, file: !1, line: 38, type: !132, scopeLine: 38, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !35)
+!204 = !DILocalVariable(name: "s", arg: 1, scope: !203, file: !1, line: 38, type: !135)
+!205 = !DILocation(line: 0, scope: !203)
+!206 = !DILocation(line: 38, column: 31, scope: !203)
+!207 = !DILocation(line: 38, column: 16, scope: !203)
+!208 = !DILocation(line: 38, column: 50, scope: !203)
+!209 = !DILocation(line: 38, column: 35, scope: !203)
+!210 = !DILocation(line: 38, column: 33, scope: !203)
+!211 = distinct !DISubprogram(name: "PALLAS_SPEC_12", scope: !1, file: !1, line: 43, type: !132, scopeLine: 43, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !35)
+!212 = !DILocalVariable(name: "s", arg: 1, scope: !211, file: !1, line: 43, type: !135)
+!213 = !DILocation(line: 0, scope: !211)
+!214 = !DILocation(line: 43, column: 31, scope: !211)
+!215 = !DILocation(line: 43, column: 16, scope: !211)
+!216 = !DILocation(line: 43, column: 51, scope: !211)
+!217 = !DILocation(line: 43, column: 53, scope: !211)
+!218 = !DILocation(line: 43, column: 36, scope: !211)
+!219 = !DILocation(line: 43, column: 33, scope: !211)
+!220 = distinct !DISubprogram(name: "PALLAS_SPEC_13", scope: !1, file: !1, line: 48, type: !132, scopeLine: 48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !35)
+!221 = !DILocalVariable(name: "s", arg: 1, scope: !220, file: !1, line: 48, type: !135)
+!222 = !DILocation(line: 0, scope: !220)
+!223 = !DILocation(line: 48, column: 31, scope: !220)
+!224 = !DILocation(line: 48, column: 33, scope: !220)
+!225 = !DILocation(line: 48, column: 16, scope: !220)
+!226 = !DILocation(line: 48, column: 52, scope: !220)
+!227 = !DILocation(line: 48, column: 37, scope: !220)
+!228 = !DILocation(line: 48, column: 35, scope: !220)
+!229 = distinct !DISubprogram(name: "PALLAS_SPEC_14", scope: !1, file: !1, line: 53, type: !132, scopeLine: 53, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !35)
+!230 = !DILocalVariable(name: "s", arg: 1, scope: !229, file: !1, line: 53, type: !135)
+!231 = !DILocation(line: 0, scope: !229)
+!232 = !DILocation(line: 53, column: 31, scope: !229)
+!233 = !DILocation(line: 53, column: 33, scope: !229)
+!234 = !DILocation(line: 53, column: 16, scope: !229)
+!235 = !DILocation(line: 53, column: 52, scope: !229)
+!236 = !DILocation(line: 53, column: 37, scope: !229)
+!237 = !DILocation(line: 53, column: 35, scope: !229)
+!238 = distinct !DISubprogram(name: "PALLAS_SPEC_15", scope: !1, file: !1, line: 58, type: !132, scopeLine: 58, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !35)
+!239 = !DILocalVariable(name: "s", arg: 1, scope: !238, file: !1, line: 58, type: !135)
+!240 = !DILocation(line: 0, scope: !238)
+!241 = !DILocation(line: 58, column: 31, scope: !238)
+!242 = !DILocation(line: 58, column: 33, scope: !238)
+!243 = !DILocation(line: 58, column: 16, scope: !238)
+!244 = !DILocation(line: 58, column: 52, scope: !238)
+!245 = !DILocation(line: 58, column: 37, scope: !238)
+!246 = !DILocation(line: 58, column: 35, scope: !238)

--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -1339,9 +1339,14 @@ sealed trait ResourceTerm[G] extends Expr[G] with ResourceTermImpl[G]
 // Trait mirroring Viper's PossibleTrigger should be implemented by all expressions that eventually become nodes that implement Viper's trait
 sealed trait PossibleTrigger[G] extends Expr[G] with PossibleTriggerImpl[G]
 
+final case class DummyConstant[G](t: Type[G])(
+    implicit val o: Origin = DiagnosticOrigin
+) extends Expr[G] with DummyConstantImpl[G]
+
 sealed trait Constant[G] extends Expr[G] with ConstantImpl[G]
 sealed trait ConstantInt[G] extends Constant[G] with ConstantIntImpl[G]
 sealed trait ConstantFloat[G] extends Constant[G]
+// Dummy constant, used for type inference, should not appear in the AST after a rewrite (therefore there is no entry in CoercingRewriter ensuring we crash)
 final case class CIntegerValue[G](value: BigInt, t: Type[G])(
     implicit val o: Origin
 ) extends ConstantInt[G] with Expr[G] with CIntegerValueImpl[G]
@@ -4011,6 +4016,14 @@ final case class LLVMMemset[G](
     volatile: Expr[G],
 )(val blame: Blame[VerificationFailure])(implicit val o: Origin)
     extends LLVMStatement[G] with LLVMMemsetImpl[G]
+
+final case class LLVMMemcpy[G](
+    dst: Expr[G],
+    src: Expr[G],
+    len: Expr[G],
+    volatile: Expr[G],
+)(val blame: Blame[VerificationFailure])(implicit val o: Origin)
+    extends LLVMStatement[G] with LLVMMemcpyImpl[G]
 
 final case class LLVMBranchUnreachable[G]()(
     val blame: Blame[UnreachableReachedError]

--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -1995,9 +1995,7 @@ final case class ByValueClassLocation[G](expr: Expr[G])(implicit val o: Origin)
 final case class PredicateLocation[G](inv: ApplyAnyPredicate[G])(
     implicit val o: Origin
 ) extends Location[G] with PredicateLocationImpl[G]
-final case class AmbiguousLocation[G](expr: Expr[G])(
-    val blame: Blame[PointerLocationError]
-)(implicit val o: Origin)
+final case class AmbiguousLocation[G](expr: Expr[G])(implicit val o: Origin)
     extends Location[G] with AmbiguousLocationImpl[G]
 final case class InLinePatternLocation[G](loc: Location[G], pattern: Expr[G])(
     implicit val o: Origin
@@ -4144,7 +4142,7 @@ final case class LLVMFracOf[G](
 final case class LLVMPerm[G](
     loc: Ref[G, Variable[G]],
     perm: Ref[G, Variable[G]],
-)(val blame: Blame[PointerLocationError])(implicit val o: Origin)
+)(val blame: Blame[PointerDerefError])(implicit val o: Origin)
     extends LLVMExpr[G] with LLVMPermImpl[G]
 
 final case class LLVMImplies[G](

--- a/src/col/vct/col/ast/Node.scala
+++ b/src/col/vct/col/ast/Node.scala
@@ -4061,6 +4061,13 @@ final case class LLVMFloatExtend[G](
 )(implicit val o: Origin)
     extends LLVMExpr[G] with LLVMFloatExtendImpl[G]
 
+final case class LLVMIntegerPointerCast[G](
+    inputType: Type[G],
+    outputType: Type[G],
+    value: Expr[G],
+)(implicit val o: Origin)
+    extends LLVMExpr[G] with LLVMIntegerPointerCastImpl[G]
+
 sealed trait LLVMArithOpWithOverflow[G]
     extends LLVMStatement[G] with LLVMArithOpWithOverflowImpl[G]
 

--- a/src/col/vct/col/ast/expr/op/BinExprImpl.scala
+++ b/src/col/vct/col/ast/expr/op/BinExprImpl.scala
@@ -91,7 +91,9 @@ object BinOperatorTypes {
   case class NumericBinError(lt: Type[_], rt: Type[_], o: Origin)
       extends VerificationError.UserError {
     override def text: String =
-      o.messageInContext(f"Expected types to numeric, but got: ${lt} and ${rt}")
+      o.messageInContext(
+        f"Expected types to be numeric, but got: ${lt} and ${rt}"
+      )
     override def code: String = "numericBinError"
   }
 

--- a/src/col/vct/col/ast/lang/llvm/LLVMIntegerPointerCastImpl.scala
+++ b/src/col/vct/col/ast/lang/llvm/LLVMIntegerPointerCastImpl.scala
@@ -1,0 +1,17 @@
+package vct.col.ast.lang.llvm
+
+import vct.col.ast.ops.LLVMIntegerPointerCastOps
+import vct.col.ast.{LLVMIntegerPointerCast, Type}
+import vct.col.print._
+
+trait LLVMIntegerPointerCastImpl[G] extends LLVMIntegerPointerCastOps[G] {
+  this: LLVMIntegerPointerCast[G] =>
+  override def t: Type[G] = outputType
+  override def layout(implicit ctx: Ctx): Doc = {
+    Group(
+      if (outputType.asPointer.isDefined) { Text("inttoptr") }
+      else
+        { Text("ptrtoint") } <+> inputType <+> value <+> "to" <+> outputType
+    )
+  }
+}

--- a/src/col/vct/col/ast/lang/llvm/LLVMMemcpyImpl.scala
+++ b/src/col/vct/col/ast/lang/llvm/LLVMMemcpyImpl.scala
@@ -1,0 +1,14 @@
+package vct.col.ast.lang.llvm
+
+import vct.col.ast.LLVMMemcpy
+import vct.col.ast.ops.LLVMMemcpyOps
+import vct.col.print._
+
+trait LLVMMemcpyImpl[G] extends LLVMMemcpyOps[G] {
+  this: LLVMMemcpy[G] =>
+
+  override def layout(implicit ctx: Ctx): Doc = {
+    Text("memcpy(") <+> dst.show <+> Text(", ") <+> src.show <+> Text(", ") <+>
+      len.show <+> Text(", ") <+> volatile.show <+> Text(")")
+  }
+}

--- a/src/col/vct/col/ast/lang/llvm/LLVMTFloatImpl.scala
+++ b/src/col/vct/col/ast/lang/llvm/LLVMTFloatImpl.scala
@@ -3,6 +3,7 @@ package vct.col.ast.lang.llvm
 import vct.col.ast.ops.LLVMTFloatOps
 import vct.col.ast._
 import vct.col.print._
+import vct.col.typerules.TypeSize
 
 object LLVMTFloats {
   def fromLLVMTFloat[G](t: LLVMTFloat[G]): TFloat[G] =
@@ -40,4 +41,5 @@ trait LLVMTFloatImpl[G] extends LLVMTFloatOps[G] {
     }
 
   override def layout(implicit ctx: Ctx): Doc = floatType.show
+  override def bits: TypeSize = TypeSize.Exact(exponent + mantissa)
 }

--- a/src/col/vct/col/ast/lang/llvm/LLVMTIntImpl.scala
+++ b/src/col/vct/col/ast/lang/llvm/LLVMTIntImpl.scala
@@ -3,9 +3,11 @@ package vct.col.ast.lang.llvm
 import vct.col.ast.LLVMTInt
 import vct.col.ast.ops.LLVMTIntOps
 import vct.col.print._
+import vct.col.typerules.TypeSize
 
 trait LLVMTIntImpl[G] extends LLVMTIntOps[G] {
   this: LLVMTInt[G] =>
 
   override def layout(implicit ctx: Ctx): Doc = Text("i") <> bitWidth.toString
+  override def bits: TypeSize = TypeSize.Exact(bitWidth)
 }

--- a/src/col/vct/col/ast/unsorted/DummyConstantImpl.scala
+++ b/src/col/vct/col/ast/unsorted/DummyConstantImpl.scala
@@ -1,0 +1,10 @@
+package vct.col.ast.unsorted
+
+import vct.col.ast.DummyConstant
+import vct.col.ast.ops.DummyConstantOps
+import vct.col.print._
+
+trait DummyConstantImpl[G] extends DummyConstantOps[G] {
+  this: DummyConstant[G] =>
+  // override def layout(implicit ctx: Ctx): Doc = ???
+}

--- a/src/col/vct/col/typerules/CoercingRewriter.scala
+++ b/src/col/vct/col/typerules/CoercingRewriter.scala
@@ -2389,6 +2389,7 @@ abstract class CoercingRewriter[Pre <: Generation]()
       case sub: LLVMSubWithOverflow[Pre] => sub
       case mult: LLVMMultWithOverflow[Pre] => mult
       case memset: LLVMMemset[Pre] => memset
+      case memcpy: LLVMMemcpy[Pre] => memcpy
       case ModelDo(model, perm, after, action, impl) =>
         ModelDo(model, rat(perm), after, action, impl)
       case n @ Notify(obj) => Notify(cls(obj))(n.blame)

--- a/src/col/vct/col/typerules/CoercingRewriter.scala
+++ b/src/col/vct/col/typerules/CoercingRewriter.scala
@@ -2242,6 +2242,7 @@ abstract class CoercingRewriter[Pre <: Generation]()
         LLVMTruncate(inputType, outputType, coerce(value, inputType))
       case LLVMFloatExtend(inputType, outputType, value) =>
         LLVMFloatExtend(inputType, outputType, coerce(value, inputType))
+      case LLVMIntegerPointerCast(_, _, _) => e
       case LLVMIntegerValue(_, _) => e
       case LLVMFloatValue(_, _) => e
       case LLVMPointerValue(_) => e

--- a/src/col/vct/col/typerules/CoercingRewriter.scala
+++ b/src/col/vct/col/typerules/CoercingRewriter.scala
@@ -2844,7 +2844,7 @@ abstract class CoercingRewriter[Pre <: Generation]()
         PointerLocation(pointer(pointerExp)._1)(p.blame)
       case ByValueClassLocation(expr) => node
       case PredicateLocation(inv) => PredicateLocation(inv)
-      case al @ AmbiguousLocation(expr) => AmbiguousLocation(expr)(al.blame)
+      case al @ AmbiguousLocation(expr) => AmbiguousLocation(expr)
       case patLoc @ InLinePatternLocation(loc, pat) =>
         InLinePatternLocation(loc, pat)
     }

--- a/src/col/vct/col/typerules/CoercionUtils.scala
+++ b/src/col/vct/col/typerules/CoercionUtils.scala
@@ -381,6 +381,8 @@ case object CoercionUtils {
             getAnyCoercion(element, innerType).getOrElse(return None),
           ))
         }
+      // We do not check correct typing on the LLVMTPointers yet, leaving this for after type inference
+      case (LLVMTPointer(_), LLVMTPointer(_)) => CoerceIdentity(source)
       case (TFraction(), TZFraction()) => CoerceFracZFrac()
       case (TFraction(), TRational()) =>
         CoercionSequence(Seq(CoerceFracZFrac(), CoerceZFracRat()))
@@ -722,7 +724,7 @@ case object CoercionUtils {
       case t: CPPTArray[G] =>
         Some((CoerceCPPArrayPointer(t.innerType), TPointer(t.innerType, None)))
       case LLVMTPointer(None) =>
-        Some((CoerceIdentity(source), TPointer[G](TAnyValue(), None)))
+        Some((CoerceIdentity(source), TPointer[G](TVoid(), None)))
       case LLVMTPointer(Some(innerType)) =>
         Some((CoerceIdentity(source), TPointer(innerType, None)))
       case LLVMTArray(numElements, innerType) if numElements > 0 =>

--- a/src/llvm/CMakeLists.txt
+++ b/src/llvm/CMakeLists.txt
@@ -1,0 +1,82 @@
+cmake_minimum_required(VERSION 3.12)
+project(Pallas)
+
+set(CMAKE_CXX_STANDARD 20)
+
+# LLVM
+find_package(LLVM 17 REQUIRED CONFIG)
+
+message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+
+include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
+separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
+add_definitions(${LLVM_DEFINITIONS_LIST})
+
+link_directories(${LLVM_LIBRARY_DIRS})
+
+# LLVM is normally built without RTTI. Be consistent with that.
+if (NOT LLVM_ENABLE_RTTI)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+    set(protobuf_DISABLE_RTTI ON)
+endif ()
+
+llvm_map_components_to_libnames(LLVM_LIBS core support irreader passes analysis)
+# end LLVM
+
+
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# Protobuf
+set(protobuf_BUILD_TESTS OFF)
+set(ABSL_PROPAGATE_CXX_STD ON)
+
+add_subdirectory("${PROTOBUF_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/protobuf")
+include("${PROTOBUF_DIR}/cmake/protobuf-generate.cmake")
+
+# enable extra warnings
+if (MSVC)
+    # warning level 4
+    add_compile_options(/W4)
+else()
+    # additional warnings
+    add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-parameter)
+endif()
+
+# COL
+add_library(COL STATIC
+"${SCALA_PB_DIR}/scalapb/scalapb.proto"
+"${SERIALIZE_DIR}/vct/col/ast/BigDecimal.proto"
+"${SERIALIZE_DIR}/vct/col/ast/BigInt.proto"
+"${SERIALIZE_DIR}/vct/col/ast/BitString.proto"
+"${SERIALIZE_DIR}/vct/col/ast/Blame.proto"
+"${SERIALIZE_DIR}/vct/col/ast/ExpectedError.proto"
+"${SERIALIZE_DIR}/vct/col/ast/Origin.proto"
+"${SERIALIZE_DIR}/vct/col/ast/Ref.proto"
+"${MEGACOL_DIR}/vct/col/ast/col.proto"
+)
+target_link_libraries(COL PUBLIC protobuf::libprotobuf)
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/generated")
+set(PROTO_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+target_include_directories(COL PUBLIC "$<BUILD_INTERFACE:${PROTO_BINARY_DIR}>")
+
+protobuf_generate(
+        TARGET COL
+        TARGET_DIR "."
+        IMPORT_DIRS "${SERIALIZE_DIR}" "${SCALA_PB_DIR}" "${MEGACOL_DIR}"
+        PROTOC_OUT_DIR "${PROTO_BINARY_DIR}")
+
+
+add_subdirectory(lib)
+
+add_library(Pallas SHARED
+    $<TARGET_OBJECTS:Plugin>
+    $<TARGET_OBJECTS:Transform>
+    $<TARGET_OBJECTS:Passes>
+    $<TARGET_OBJECTS:Origin>
+    $<TARGET_OBJECTS:Util>
+    $<TARGET_OBJECTS:COL>
+    $<TARGET_OBJECTS:protobuf::libprotobuf>
+)
+target_link_libraries(Pallas PUBLIC Plugin Transform Passes Origin Util)

--- a/src/llvm/CMakeLists.txt
+++ b/src/llvm/CMakeLists.txt
@@ -60,6 +60,7 @@ target_link_libraries(COL PUBLIC protobuf::libprotobuf)
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/generated")
 set(PROTO_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
 target_include_directories(COL PUBLIC "$<BUILD_INTERFACE:${PROTO_BINARY_DIR}>")
+target_precompile_headers(COL PRIVATE "$<BUILD_INTERFACE:${PROTO_BINARY_DIR}>/vct/col/ast/col.pb.h")
 
 protobuf_generate(
         TARGET COL

--- a/src/llvm/include/Origin/OriginProvider.h
+++ b/src/llvm/include/Origin/OriginProvider.h
@@ -1,7 +1,15 @@
 #ifndef PALLAS_ORIGINPROVIDER_H
 #define PALLAS_ORIGINPROVIDER_H
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Woverflow"
+#endif // __GNUC__
 #include "vct/col/ast/Origin.pb.h"
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif // __GNUC__
 #include <llvm/Analysis/LoopInfo.h>
 #include <llvm/IR/DebugInfoMetadata.h>
 #include <llvm/IR/Instruction.h>

--- a/src/llvm/include/Passes/Function/ExprWrapperMapper.h
+++ b/src/llvm/include/Passes/Function/ExprWrapperMapper.h
@@ -1,15 +1,6 @@
 #ifndef PALLAS_EXPRWRAPPERMAPPER_H
 #define PALLAS_EXPRWRAPPERMAPPER_H
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
-#pragma GCC diagnostic ignored "-Woverflow"
-#endif // __GNUC__
-#include "vct/col/ast/col.pb.h"
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 #include <llvm/IR/Function.h>
 #include <llvm/IR/PassManager.h>
 #include <optional>

--- a/src/llvm/include/Passes/Function/ExprWrapperMapper.h
+++ b/src/llvm/include/Passes/Function/ExprWrapperMapper.h
@@ -1,7 +1,15 @@
 #ifndef PALLAS_EXPRWRAPPERMAPPER_H
 #define PALLAS_EXPRWRAPPERMAPPER_H
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Woverflow"
+#endif // __GNUC__
 #include "vct/col/ast/col.pb.h"
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif // __GNUC__
 #include <llvm/IR/Function.h>
 #include <llvm/IR/PassManager.h>
 #include <optional>

--- a/src/llvm/include/Passes/Function/FunctionContractDeclarer.h
+++ b/src/llvm/include/Passes/Function/FunctionContractDeclarer.h
@@ -1,7 +1,15 @@
 #ifndef PALLAS_FUNCTIONCONTRACTDECLARER_H
 #define PALLAS_FUNCTIONCONTRACTDECLARER_H
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Woverflow"
+#endif // __GNUC__
 #include "vct/col/ast/col.pb.h"
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif // __GNUC__
 #include <llvm/IR/PassManager.h>
 
 /**

--- a/src/llvm/include/Passes/Function/FunctionDeclarer.h
+++ b/src/llvm/include/Passes/Function/FunctionDeclarer.h
@@ -1,7 +1,15 @@
 #ifndef PALLAS_FUNCTIONDECLARER_H
 #define PALLAS_FUNCTIONDECLARER_H
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Woverflow"
+#endif // __GNUC__
 #include "vct/col/ast/col.pb.h"
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif // __GNUC__
 #include <llvm/IR/PassManager.h>
 
 /**

--- a/src/llvm/include/Passes/Function/PallasFunctionContractDeclarerPass.h
+++ b/src/llvm/include/Passes/Function/PallasFunctionContractDeclarerPass.h
@@ -1,7 +1,15 @@
 #ifndef PALLAS_PALLASFUNCTIONCONTRACTDECLARERPASS_H
 #define PALLAS_PALLASFUNCTIONCONTRACTDECLARERPASS_H
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Woverflow"
+#endif // __GNUC__
 #include "vct/col/ast/col.pb.h"
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #include <memory>
 

--- a/src/llvm/include/Passes/Function/PureAssigner.h
+++ b/src/llvm/include/Passes/Function/PureAssigner.h
@@ -1,7 +1,15 @@
 #ifndef PALLAS_PUREASSIGNER_H
 #define PALLAS_PUREASSIGNER_H
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Woverflow"
+#endif // __GNUC__
 #include "vct/col/ast/col.pb.h"
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif // __GNUC__
 #include <llvm/IR/PassManager.h>
 /**
  * The PureAssignerPass checks if a LLVM function is pure (i.e. whether the

--- a/src/llvm/include/Passes/Module/GlobalVariableDeclarer.h
+++ b/src/llvm/include/Passes/Module/GlobalVariableDeclarer.h
@@ -1,7 +1,15 @@
 #ifndef PALLAS_GLOBALVARIABLEDECLARER_H
 #define PALLAS_GLOBALVARIABLEDECLARER_H
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Woverflow"
+#endif // __GNUC__
 #include "vct/col/ast/col.pb.h"
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif // __GNUC__
 #include <llvm/IR/PassManager.h>
 
 namespace pallas {

--- a/src/llvm/include/Passes/Module/ModuleSpecCollector.h
+++ b/src/llvm/include/Passes/Module/ModuleSpecCollector.h
@@ -1,15 +1,6 @@
 #ifndef PALLAS_MODULESPECCOLLECTOR_H
 #define PALLAS_MODULESPECCOLLECTOR_H
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
-#pragma GCC diagnostic ignored "-Woverflow"
-#endif // __GNUC__
-#include "vct/col/ast/col.pb.h"
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif // __GNUC__
 #include <llvm/IR/PassManager.h>
 /**
  * Pass that adds global specifications (i.e. not related to a loop or function)
@@ -18,7 +9,6 @@
  */
 namespace pallas {
 using namespace llvm;
-namespace col = vct::col::ast;
 
 class ModuleSpecCollectorPass
     : public AnalysisInfoMixin<ModuleSpecCollectorPass> {

--- a/src/llvm/include/Passes/Module/ModuleSpecCollector.h
+++ b/src/llvm/include/Passes/Module/ModuleSpecCollector.h
@@ -1,7 +1,15 @@
 #ifndef PALLAS_MODULESPECCOLLECTOR_H
 #define PALLAS_MODULESPECCOLLECTOR_H
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Woverflow"
+#endif // __GNUC__
 #include "vct/col/ast/col.pb.h"
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif // __GNUC__
 #include <llvm/IR/PassManager.h>
 /**
  * Pass that adds global specifications (i.e. not related to a loop or function)

--- a/src/llvm/include/Passes/Module/ProtobufPrinter.h
+++ b/src/llvm/include/Passes/Module/ProtobufPrinter.h
@@ -1,7 +1,15 @@
 #ifndef PALLAS_PROTOBUFPRINTER_H
 #define PALLAS_PROTOBUFPRINTER_H
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Woverflow"
+#endif // __GNUC__
 #include "vct/col/ast/col.pb.h"
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif // __GNUC__
 #include <llvm/IR/PassManager.h>
 
 namespace pallas {

--- a/src/llvm/include/Passes/Module/RootContainer.h
+++ b/src/llvm/include/Passes/Module/RootContainer.h
@@ -1,7 +1,15 @@
 #ifndef PALLAS_ROOTCONTAINER_H
 #define PALLAS_ROOTCONTAINER_H
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Woverflow"
+#endif // __GNUC__
 #include "vct/col/ast/col.pb.h"
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif // __GNUC__
 #include <llvm/IR/PassManager.h>
 
 namespace pallas {

--- a/src/llvm/include/Passes/Module/StructConsolidator.h
+++ b/src/llvm/include/Passes/Module/StructConsolidator.h
@@ -1,0 +1,53 @@
+#ifndef PALLAS_STRUCTCONSOLIDATOR_H
+#define PALLAS_MODULESPECCOLLECTOR_H
+
+#include <llvm/IR/Value.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/DataLayout.h>
+#include <llvm/IR/PassManager.h>
+
+namespace pallas {
+using namespace llvm;
+
+class StructConsolidatorPass : public PassInfoMixin<StructConsolidatorPass> {
+    public:
+    PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
+    private:
+    struct Write {
+        uint64_t offset;
+        uint64_t size;
+        Value *src;
+    };
+
+    struct ArgInfo {
+        const Argument * argument;
+        uint64_t offset;
+        uint64_t size;
+    };
+
+    using FieldMap = DenseMap<uint64_t, std::pair<size_t, Value *>>;
+    struct ReplaceableArgSet {
+        SmallVector<ArgInfo> arguments;
+        AllocaInst *alloc;
+        AllocaInst *intermediary;
+        DenseMap<CallBase *, FieldMap> calls;
+        bool valid;
+    };
+
+    using WriteVec = SmallVector<Write>;
+    using AllocaMap = DenseMap<AllocaInst *, WriteVec>;
+    using ReplaceableVec = SmallVector<ReplaceableArgSet>;
+
+    void removeRecursively(Value *V);
+    void removeParentless(Value *V);
+    bool digToField(Value *V, const DataLayout &L, const StructType &structType, FieldMap &fields, ArgInfo &A, APInt offsetIntoSource, uint64_t offsetIntoField, size_t pointerDepth);
+    void gatherUseData(const Function &F, const DataLayout &L, ReplaceableArgSet &set);
+    bool gatherWrites(const Function &F, const DataLayout &L, uint64_t typeSize, const Value &value, APInt currentOffset, WriteVec &writes);
+    const Function &updateFunction(Function &F, const ReplaceableVec &sets);
+    void replaceFunctionUse(CallInst *call, const Function &oldF, Function *newF, const ReplaceableVec &sets);
+    ReplaceableVec findReplaceableSets(Function &F, const DataLayout &L);
+};
+
+}
+
+#endif

--- a/src/llvm/include/Passes/Module/StructConsolidator.h
+++ b/src/llvm/include/Passes/Module/StructConsolidator.h
@@ -1,37 +1,39 @@
 #ifndef PALLAS_STRUCTCONSOLIDATOR_H
 #define PALLAS_MODULESPECCOLLECTOR_H
 
-#include <llvm/IR/Value.h>
-#include <llvm/IR/Instructions.h>
+#include <llvm/ADT/SmallSet.h>
 #include <llvm/IR/DataLayout.h>
+#include <llvm/IR/Instructions.h>
 #include <llvm/IR/PassManager.h>
+#include <llvm/IR/Value.h>
 
 namespace pallas {
 using namespace llvm;
 
 class StructConsolidatorPass : public PassInfoMixin<StructConsolidatorPass> {
-    public:
+  public:
     PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
-    private:
+
+  private:
     struct Write {
-        uint64_t offset;
-        uint64_t size;
-        Value *src;
+        uint64_t Offset;
+        uint64_t Size;
+        Value *Src;
     };
 
     struct ArgInfo {
-        const Argument * argument;
-        uint64_t offset;
-        uint64_t size;
+        const Argument *Arg;
+        uint64_t Offset;
+        uint64_t Size;
     };
 
     using FieldMap = DenseMap<uint64_t, std::pair<size_t, Value *>>;
     struct ReplaceableArgSet {
-        SmallVector<ArgInfo> arguments;
-        AllocaInst *alloc;
-        AllocaInst *intermediary;
-        DenseMap<CallBase *, FieldMap> calls;
-        bool valid;
+        SmallVector<ArgInfo> Arguments;
+        AllocaInst *Alloc;
+        AllocaInst *Intermediary;
+        DenseMap<CallBase *, FieldMap> Calls;
+        bool Valid;
     };
 
     using WriteVec = SmallVector<Write>;
@@ -40,14 +42,22 @@ class StructConsolidatorPass : public PassInfoMixin<StructConsolidatorPass> {
 
     void removeRecursively(Value *V);
     void removeParentless(Value *V);
-    bool digToField(Value *V, const DataLayout &L, const StructType &structType, FieldMap &fields, ArgInfo &A, APInt offsetIntoSource, uint64_t offsetIntoField, size_t pointerDepth);
-    void gatherUseData(const Function &F, const DataLayout &L, ReplaceableArgSet &set);
-    bool gatherWrites(const Function &F, const DataLayout &L, uint64_t typeSize, const Value &value, APInt currentOffset, WriteVec &writes);
-    const Function &updateFunction(Function &F, const ReplaceableVec &sets);
-    void replaceFunctionUse(CallInst *call, const Function &oldF, Function *newF, const ReplaceableVec &sets);
+    bool digToField(Value *V, const DataLayout &L, const StructType &ST,
+                    FieldMap &Fields, ArgInfo &A, APInt SourceOffset,
+                    uint64_t FieldOffset, size_t Depth);
+    void gatherUseData(const Function &F, const DataLayout &L,
+                       ReplaceableArgSet &Set);
+    bool gatherWrites(const Function &F, const DataLayout &L, uint64_t Size,
+                      const Value &V, APInt Offset, WriteVec &Writes);
+    void replaceWrapperCalls(Function *F, Function *NF,
+                             SmallSet<const Argument *, 8> &ToBeRemoved,
+                             MDNode *MD, SmallSet<MDNode *, 8> &Visited);
+    const Function &updateFunction(Function &F, const ReplaceableVec &Sets);
+    void replaceFunctionUse(CallInst *Call, const Function &OldF,
+                            Function *NewF, const ReplaceableVec &Sets);
     ReplaceableVec findReplaceableSets(Function &F, const DataLayout &L);
 };
 
-}
+} // namespace pallas
 
 #endif

--- a/src/llvm/include/Transform/Instruction/CastOpTransform.h
+++ b/src/llvm/include/Transform/Instruction/CastOpTransform.h
@@ -24,5 +24,13 @@ void transformTrunc(llvm::TruncInst &truncInstruction,
 void transformFPExt(llvm::FPExtInst &fpextInstruction,
                     col::LlvmBasicBlock &colBlock,
                     pallas::FunctionCursor &funcCursor);
+
+void transformPtrToInt(llvm::PtrToIntInst &fpextInstruction,
+                       col::LlvmBasicBlock &colBlock,
+                       pallas::FunctionCursor &funcCursor);
+
+void transformIntToPtr(llvm::IntToPtrInst &fpextInstruction,
+                       col::LlvmBasicBlock &colBlock,
+                       pallas::FunctionCursor &funcCursor);
 } // namespace llvm2col
 #endif // PALLAS_CASTOPTRANSFORM_H

--- a/src/llvm/include/Transform/Instruction/IntrinsicsTransform.h
+++ b/src/llvm/include/Transform/Instruction/IntrinsicsTransform.h
@@ -56,6 +56,12 @@ void transformMemset(llvm::CallInst &callInstruction,
                      col::LlvmBasicBlock &colBlock,
                      pallas::FunctionCursor &funcCursor);
 
+/**
+ * Transform call to the @llvm.memcpy.*-intrinsic
+ */
+void transformMemcpy(llvm::CallInst &callInstruction,
+                     col::LlvmBasicBlock &colBlock,
+                     pallas::FunctionCursor &funcCursor);
 } // namespace llvm2col
 
 #endif // PALLAS_INTRINSICSTRANSFORM_H

--- a/src/llvm/include/Transform/LoopContractTransform.h
+++ b/src/llvm/include/Transform/LoopContractTransform.h
@@ -1,7 +1,15 @@
 #ifndef PALLAS_LOOPCONTRACTTRANSFORM_H
 #define PALLAS_LOOPCONTRACTTRANSFORM_H
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Woverflow"
+#endif // __GNUC__
 #include "vct/col/ast/col.pb.h"
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #include "Passes/Function/FunctionBodyTransformer.h"
 

--- a/src/llvm/include/Transform/SpecStatementTransform.h
+++ b/src/llvm/include/Transform/SpecStatementTransform.h
@@ -2,7 +2,15 @@
 #define PALLAS_SPECSTATEMENTTRANSFORM_H
 
 #include "Passes/Function/FunctionBodyTransformer.h"
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Woverflow"
+#endif // __GNUC__
 #include "vct/col/ast/col.pb.h"
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif // __GNUC__
 #include <llvm/IR/Instruction.h>
 #include <llvm/IR/Metadata.h>
 

--- a/src/llvm/include/Util/BlockUtils.h
+++ b/src/llvm/include/Util/BlockUtils.h
@@ -1,7 +1,15 @@
 #ifndef PALLAS_BLOCKUTILS_H
 #define PALLAS_BLOCKUTILS_H
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Woverflow"
+#endif // __GNUC__
 #include "vct/col/ast/col.pb.h"
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif // __GNUC__
 
 namespace pallas {
 namespace col = vct::col::ast;

--- a/src/llvm/include/Util/PallasWrapperUtils.h
+++ b/src/llvm/include/Util/PallasWrapperUtils.h
@@ -1,7 +1,15 @@
 #ifndef PALLAS_WRAPPER_UTILS_H
 #define PALLAS_WRAPPER_UTILS_H
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Woverflow"
+#endif // __GNUC__
 #include "vct/col/ast/col.pb.h"
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif // __GNUC__
 
 #include "Passes/Function/FunctionBodyTransformer.h"
 

--- a/src/llvm/lib/CMakeLists.txt
+++ b/src/llvm/lib/CMakeLists.txt
@@ -8,5 +8,6 @@ add_library(Plugin OBJECT
 target_link_libraries(Plugin COL Transform Passes Origin Util)
 target_include_directories(Plugin PRIVATE
     "${CMAKE_SOURCE_DIR}/include"
-    "${PROTO_BINARY_DIR}"
 )
+target_precompile_headers(Plugin REUSE_FROM COL)
+

--- a/src/llvm/lib/CMakeLists.txt
+++ b/src/llvm/lib/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_subdirectory(Origin)
+add_subdirectory(Util)
+add_subdirectory(Transform)
+add_subdirectory(Passes)
+
+add_library(Plugin OBJECT
+            Plugin.cpp)
+target_link_libraries(Plugin COL Transform Passes Origin Util)
+target_include_directories(Plugin PRIVATE
+    "${CMAKE_SOURCE_DIR}/include"
+    "${PROTO_BINARY_DIR}"
+)

--- a/src/llvm/lib/Origin/CMakeLists.txt
+++ b/src/llvm/lib/Origin/CMakeLists.txt
@@ -7,5 +7,6 @@ add_library(Origin STATIC
 target_link_libraries(Origin COL)
 target_include_directories(Origin PRIVATE
     "${CMAKE_SOURCE_DIR}/include"
-    "${PROTO_BINARY_DIR}"
 )
+target_precompile_headers(Origin REUSE_FROM COL)
+

--- a/src/llvm/lib/Origin/CMakeLists.txt
+++ b/src/llvm/lib/Origin/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_library(Origin STATIC
+    OriginProvider.cpp
+    ShortPositionDeriver.cpp
+    ContextDeriver.cpp
+    PreferredNameDeriver.cpp)
+
+target_link_libraries(Origin COL)
+target_include_directories(Origin PRIVATE
+    "${CMAKE_SOURCE_DIR}/include"
+    "${PROTO_BINARY_DIR}"
+)

--- a/src/llvm/lib/Passes/CMakeLists.txt
+++ b/src/llvm/lib/Passes/CMakeLists.txt
@@ -1,0 +1,21 @@
+add_library(Passes STATIC
+    # Function/
+    Function/ExprWrapperMapper.cpp
+    Function/FunctionBodyTransformer.cpp
+    Function/FunctionContractDeclarer.cpp
+    Function/FunctionDeclarer.cpp
+    Function/PallasFunctionContractDeclarerPass.cpp
+    Function/PureAssigner.cpp
+    # Module/
+    Module/GlobalVariableDeclarer.cpp
+    Module/ModuleSpecCollector.cpp
+    Module/ProtobufPrinter.cpp
+    Module/RootContainer.cpp
+)
+
+target_link_libraries(Passes COL)
+target_include_directories(Passes PRIVATE
+    "${CMAKE_SOURCE_DIR}/include"
+    "${PROTO_BINARY_DIR}"
+)
+

--- a/src/llvm/lib/Passes/CMakeLists.txt
+++ b/src/llvm/lib/Passes/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(Passes STATIC
     Module/ModuleSpecCollector.cpp
     Module/ProtobufPrinter.cpp
     Module/RootContainer.cpp
+    Module/StructConsolidator.cpp
 )
 
 target_link_libraries(Passes COL)

--- a/src/llvm/lib/Passes/CMakeLists.txt
+++ b/src/llvm/lib/Passes/CMakeLists.txt
@@ -16,6 +16,6 @@ add_library(Passes STATIC
 target_link_libraries(Passes COL)
 target_include_directories(Passes PRIVATE
     "${CMAKE_SOURCE_DIR}/include"
-    "${PROTO_BINARY_DIR}"
 )
+target_precompile_headers(Passes REUSE_FROM COL)
 

--- a/src/llvm/lib/Passes/Function/ExprWrapperMapper.cpp
+++ b/src/llvm/lib/Passes/Function/ExprWrapperMapper.cpp
@@ -45,7 +45,8 @@ ExprWrapperMapper::Result ExprWrapperMapper::run(Function &F,
     // wrapper-function in a specification.
     for (Function &parentF : llvmModule->functions()) {
         // Skip wrapper-functions and intrinsics
-        if (utils::isPallasExprWrapper(parentF) || parentF.isIntrinsic()) {
+        if (utils::isPallasExprWrapper(parentF) || parentF.isIntrinsic() ||
+            utils::isPallasSpecLib(parentF)) {
             continue;
         }
 
@@ -72,6 +73,9 @@ ExprWrapperMapper::Result ExprWrapperMapper::run(Function &F,
                 }
             }
         }
+
+        if (parentF.isDeclaration())
+            continue;
 
         // Check all loop-contracts
         LoopInfo &loopInfo = FAM.getResult<LoopAnalysis>(parentF);

--- a/src/llvm/lib/Passes/Function/ExprWrapperMapper.cpp
+++ b/src/llvm/lib/Passes/Function/ExprWrapperMapper.cpp
@@ -1,9 +1,16 @@
 #include "Passes/Function/ExprWrapperMapper.h"
-#include "Passes/Function/FunctionDeclarer.h"
 
-#include "Origin/OriginProvider.h"
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Woverflow"
+#endif // __GNUC__
+#include "vct/col/ast/col.pb.h"
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif // __GNUC__
+
 #include "Util/Constants.h"
-#include "Util/Exceptions.h"
 #include "Util/PallasMD.h"
 
 #include <llvm/Analysis/LoopInfo.h>

--- a/src/llvm/lib/Passes/Function/PureAssigner.cpp
+++ b/src/llvm/lib/Passes/Function/PureAssigner.cpp
@@ -104,7 +104,7 @@ bool PureAssignerPass::isPallasPureWellformed(MDNode &contractMD, Function &f) {
     auto *pureConst =
         dyn_cast<ConstantAsMetadata>(contractMD.getOperand(1).get());
     auto *pureVal = dyn_cast_if_present<ConstantInt>(pureConst->getValue());
-    if (pureVal == nullptr || (!pureVal->getBitWidth() == 1)) {
+    if (pureVal == nullptr || (pureVal->getBitWidth() != 1)) {
         reportError(f, "Ill-formed contract. Second operand should be boolean");
         return false;
     }

--- a/src/llvm/lib/Passes/Module/ModuleSpecCollector.cpp
+++ b/src/llvm/lib/Passes/Module/ModuleSpecCollector.cpp
@@ -1,3 +1,12 @@
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Woverflow"
+#endif // __GNUC__
+#include "vct/col/ast/col.pb.h"
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif // __GNUC__
 #include "Passes/Module/ModuleSpecCollector.h"
 #include "Origin/OriginProvider.h"
 #include "Passes/Module/RootContainer.h"
@@ -9,6 +18,7 @@ namespace pallas {
 const std::string SOURCE_LOC = "Passes::Module::ModuleSpecCollector";
 
 using namespace llvm;
+namespace col = vct::col::ast;
 
 PreservedAnalyses ModuleSpecCollectorPass::run(Module &M,
                                                ModuleAnalysisManager &MAM) {

--- a/src/llvm/lib/Passes/Module/StructConsolidator.cpp
+++ b/src/llvm/lib/Passes/Module/StructConsolidator.cpp
@@ -1,0 +1,724 @@
+#include "Passes/Module/StructConsolidator.h"
+#include "Util/Exceptions.h"
+#include <algorithm>
+#include <llvm-17/llvm/IR/GlobalValue.h>
+#include <llvm/IR/GlobalVariable.h>
+#include <llvm/IR/Operator.h>
+#include <llvm/ADT/ArrayRef.h>
+#include <llvm/IR/DataLayout.h>
+#include <llvm/ADT/SmallSet.h>
+#include <llvm/IR/Attributes.h>
+#include <llvm/IR/DerivedTypes.h>
+#include <llvm/ADT/DenseMap.h>
+#include <llvm/IR/DebugInfoMetadata.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Argument.h>
+#include <llvm/IR/Intrinsics.h>
+#include <llvm/BinaryFormat/Dwarf.h>
+#include <llvm/Support/raw_ostream.h>
+#include <llvm/Support/Debug.h>
+#include <llvm/Support/Casting.h>
+#include <llvm/IR/BasicBlock.h>
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/Transforms/Utils/Local.h>
+
+namespace pallas {
+const std::string SOURCE_LOC = "Passes::Module::StructConsolidator";
+
+using namespace llvm;
+
+struct Interval {
+    uint64_t start;
+    uint64_t end;
+};
+
+struct IntervalSet {
+    SmallVector<Interval> intervals;
+
+    void add(uint64_t start, uint64_t end) {
+        assert(start < end);
+        if (intervals.empty()) {
+            intervals.push_back({start, end});
+        } else {
+            for (size_t i = 0, size = intervals.size(); i < size; ++i) {
+                if (intervals[i].start > start) {
+                    if (intervals[i].start <= end) {
+                        intervals[i].start = start;
+                        intervals[i].end = std::max(intervals[i].end, end);
+                    } else {
+                        intervals.insert(intervals.begin() + i, {start, end});
+                    }
+                } else {
+                    if (intervals[i].end <= start) {
+                        intervals[i].end = std::max(intervals[i].end, end);
+                    } else if (i == end - 1) {
+                        intervals.push_back({start, end});
+                    }
+                }
+            }
+        }
+    }
+
+    bool contains(uint64_t start, uint64_t end) {
+        for (const Interval &i : intervals) {
+            if (i.start < start) {
+                if (end <= i.end) {
+                    return true;
+                }
+            } else {
+                return i.start == start && end <= i.end;
+            } 
+        }
+        return false;
+    }
+};
+
+// WARNING: This can remove a lot of things, be very careful when calling this
+void StructConsolidatorPass::removeRecursively(Value *V) {
+    errs() << "Recursively removing `";
+    V->print(errs());
+    errs() << "`\n";
+    while (!V->user_empty()){
+        removeRecursively(V->user_back());
+    }
+    if (Instruction *I = dyn_cast<Instruction>(V)) {
+        for (Use &U : I->operands()) {
+            Value *OpV = U.get();
+            U.set(nullptr);
+
+            if (!OpV->use_empty()) continue;
+
+            errs() << "Recursively deleting `";
+            OpV->print(errs());
+            errs() << "`\n";
+            RecursivelyDeleteTriviallyDeadInstructions(OpV);
+        }
+        I->eraseFromParent();
+    }
+}
+
+void StructConsolidatorPass::removeParentless(Value *V) {
+    if (isa<Instruction>(V)) {
+        if (cast<Instruction>(V)->getParent()) return;
+        for (auto &O : cast<Instruction>(V)->operands()){
+            removeParentless(O);
+        }
+        V->deleteValue();
+    }
+}
+
+bool StructConsolidatorPass::digToField(Value *V, const DataLayout &L, const StructType &structType, FieldMap &fields, ArgInfo &A, APInt offsetIntoSource, uint64_t offsetIntoField, size_t pointerDepth) {
+    // For now let's not consider deeper nesting
+    if (pointerDepth > 1) return false;
+
+    auto &[i, field] = fields[A.offset + offsetIntoField];
+    Type *elementType = structType.getStructElementType(i);
+    // We only want to find one source for each field
+    if (field != NULL) return false;
+    if (pointerDepth == 0 && V->getType() == elementType) {
+        // We found a good source!
+        field = V;
+        return true;
+    }
+
+    if (isa<LoadInst>(V)) {
+        LoadInst &load = *cast<LoadInst>(V);
+        return digToField(load.getPointerOperand(), L, structType, fields, A, offsetIntoSource, offsetIntoField, pointerDepth + 1);
+    }
+
+    if (isa<GetElementPtrInst>(V)) {
+        GetElementPtrInst &gep = *cast<GetElementPtrInst>(V);
+        if (!gep.accumulateConstantOffset(L, offsetIntoSource)) return false;
+
+        return digToField(gep.getPointerOperand(), L, structType, fields, A, offsetIntoSource, offsetIntoField, pointerDepth);
+    }
+
+    if (isa<AllocaInst>(V)) {
+        const AllocaInst &allocA = *cast<AllocaInst>(V);
+        assert(pointerDepth == 1);
+
+        if (structType.getElementType(i) == allocA.getAllocatedType()) {
+            // This is our source, we just need to load it
+            // Byte-align is fine since we're never generating this code
+            field = new LoadInst(elementType, V, Twine("insertedLoad"), false, Align());
+            return true;
+        }
+
+        if (!isa<StructType>(allocA.getAllocatedType())) {
+            // While this could technically be an intermediary there should be no need to generate it like that since you could have a direct Load instruction
+            return false;
+        }
+
+        StructType *allocStructType = cast<StructType>(allocA.getAllocatedType());
+        const StructLayout *structLayout = L.getStructLayout(allocStructType);
+
+        // Decompose into available fields!
+        // We have A.size bytes that we are reading from this allocation
+        // We will get all fields starting from field[A.offset + offsetIntoField]
+        int64_t remaining = A.size;
+        while (remaining > 0) {
+            auto &[i2, field2] = fields[A.offset + offsetIntoField];
+            assert (field2 == NULL);
+            int sourceIndex = structLayout->getElementContainingOffset(offsetIntoSource.getLimitedValue());
+
+            // Somehow we've ended up misaligned somewhere
+            if (offsetIntoSource != structLayout->getElementOffset(sourceIndex)) return false;
+            
+            if (structType.getStructElementType(i2) == allocStructType->getStructElementType(sourceIndex)) {
+                // Found a match
+                field2 = new LoadInst(elementType,
+                     GetElementPtrInst::Create(allocStructType, V,
+                        ArrayRef(new Value *[]{
+                            ConstantInt::get(structType.getContext(), APInt(32, 0)),
+                            ConstantInt::get(structType.getContext(), APInt(32, i2))
+                        }, 2)),
+                      Twine("insertedLoad"), false, Align());
+                const TypeSize offset = L.getTypeAllocSize(structType.getStructElementType(i2));
+                offsetIntoSource += offset;
+                offsetIntoField += offset.getFixedValue();
+                remaining -= offset.getFixedValue();
+            } else {
+                // This must be an intermediary struct
+                // TODO: Find memcpy
+                return false;
+            }
+        }
+        assert(remaining == 0);
+
+        return true;
+    }
+
+    return false;
+}
+
+void StructConsolidatorPass::gatherUseData(const Function &F, const DataLayout &L, ReplaceableArgSet &set) {
+    StructType *structType = cast<StructType>(set.alloc->getAllocatedType());
+    const StructLayout *structLayout = L.getStructLayout(structType);
+    const ArrayRef<TypeSize> offsets = structLayout->getMemberOffsets(); 
+    for (const Use &U : F.uses()) {
+        FieldMap fields(offsets.size());
+        for (size_t i = 0; i < offsets.size(); ++i) {
+            fields.insert({offsets[i].getFixedValue(), {i, nullptr}});
+        }
+        
+        if (!isa<CallInst>(U.getUser())) {
+            // Copy of logic from Function::hasAddressTaken
+            const User *FUU = U.getUser();
+            if (isa<BitCastOperator, AddrSpaceCastOperator>(U) && FUU->hasOneUse() && !FUU->user_begin()->user_empty()) FUU = *FUU->user_begin();
+            if (llvm::all_of(FUU->users(), [](const User *U) {
+                    if (const auto *GV = dyn_cast<GlobalVariable>(U))
+                        return GV->hasName() && (GV->getName() == "llvm.compiler.used" || GV->getName() == "llvm.used");
+                    return false;
+                }))
+                return;
+
+            std::string M;
+            {
+                raw_string_ostream S(M);
+                S << "Not including function `";
+                F.printAsOperand(S, true, F.getParent());
+                S << "`, because it is used in `";
+                U.getUser()->print(S);
+                S << "`";
+            }
+            ErrorReporter::addWarning(SOURCE_LOC, M);
+            set.valid = false;
+            return;
+        }
+
+        CallInst *call = cast<CallInst>(U.getUser());
+        if (call->getCalledFunction() != &F || call->hasOperandBundles()) {
+            set.valid = false;
+            return;
+        }
+        const Use *P = call->arg_begin();
+        // Find operands for every arg in set.arguments
+        for (const Argument *A = F.arg_begin(), *E = F.arg_end(); A != E; ++A, ++P) {
+            bool found = false;
+            for (ArgInfo &A2 : set.arguments) {
+                if (A == A2.argument) {
+                    if (!digToField(P->get(), L, *structType, fields, A2, APInt(L.getPointerSizeInBits(F.getAddressSpace()), 0, false), 0, 0)) {
+                        set.valid = false;
+                        for (auto &[_k, v] : fields) {
+                            auto &[_i, field] = v;
+                            if (field != NULL && isa<Instruction>(field)) {
+                                Instruction *I = cast<Instruction>(field);
+                                removeParentless(I);
+                            }
+                        }
+                        return;
+                    }
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                set.valid = false;
+                return;
+            }
+        }
+        // For each operand move up until we find a variable of type set.alloc->getAllocationType
+        // If not found bail
+        //  (alternatively we can look to see if we can find a value the matches the size / offset of the fields corresponding to the arg)
+        //  (For example: %1 = alloca {i32, i32}; %2 = 10; %3 = load i64, ptr %1, align 4; call void f(%3, %2))
+        // If found store origin (and intermediary), we'll allow multiple origins as long as they're all of the appropriate type
+        set.calls.insert({call, fields});
+    }
+}
+
+
+void StructConsolidatorPass::replaceFunctionUse(CallInst *call, const Function &oldF, Function *newF, const ReplaceableVec &sets) {
+    DenseMap<size_t, std::pair<size_t, const ArgInfo &>> argToSetArg(sets.size());
+    // SmallSet<const Argument *, 8> ToBeRemoved;
+    // for (const ReplaceableArgSet &set : sets) {
+    //     for (const ArgInfo &A : set.arguments) {
+    //         ToBeRemoved.insert(A.argument);
+    //     }
+    // }
+    for (size_t i = 0; i < sets.size(); ++i) {
+        for (const ArgInfo &A : sets[i].arguments) {
+            argToSetArg.insert({A.argument->getArgNo(), {i, A}});
+        }
+    }
+
+    std::vector<Value *> newArgs;
+    newArgs.reserve(call->arg_size() - argToSetArg.size() + sets.size());
+
+    size_t ArgI = 0;
+    for (const Use *A = call->arg_begin(), *E = call->arg_end(); A != E; ++A, ++ArgI) {
+        if (!argToSetArg.contains(ArgI)) {
+            newArgs.push_back(A->get());
+        }
+    }
+    std::vector<AllocaInst *> allocAs;
+    allocAs.reserve(sets.size());
+
+    for (const ReplaceableArgSet &set : sets) {
+        AllocaInst *allocA = new AllocaInst(set.alloc->getAllocatedType(), newF->getAddressSpace(), Twine("InsertedAllocA"), call);
+        // Find appropriate call, loop over all the fields in the field map, GEP then STORE and done!
+        bool found = false;
+        for (const auto &[C, F] : set.calls) {
+            if (C == call) {
+                for (const auto &[_off, source] : F) {
+                    const auto &[i, field] = source;
+                    GetElementPtrInst *gep = GetElementPtrInst::CreateInBounds(set.alloc->getAllocatedType(), allocA, ArrayRef(new Value *[]{
+                        ConstantInt::get(newF->getContext(), APInt(32, 0)),
+                        ConstantInt::get(newF->getContext(), APInt(32, i))               
+                    }, 2), Twine("InsertedCallerGEP"), call);
+                    if (field == NULL) {
+                        break;
+                    }
+                    if (isa<Instruction>(field)) {
+                        Instruction *I = cast<Instruction>(field);
+                        if (I->getParent() == NULL) {
+                            for (Use &U : I->operands()) {
+                                if (isa<Instruction>(U.get())) {
+                                    Instruction *I2 = cast<Instruction>(U.get());
+                                    if (I2->getParent() == NULL) {
+                                        I2->insertBefore(call);
+                                    }
+                                }
+                            }
+                            I->insertBefore(call);
+                        }
+                     }
+                    new StoreInst(field, gep, call);
+                }
+
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            ErrorReporter::addError(SOURCE_LOC, "Transformation failed, call set was missing a call to the function");
+        }
+        newArgs.push_back(allocA);
+    }
+
+    // Again most of this is from the DeadArgumentElimination pass
+    AttributeList PAL = call->getAttributes();
+    if (!PAL.isEmpty()) {
+      SmallVector<AttributeSet, 8> ArgAttrs;
+      for (unsigned ArgNo = 0; ArgNo < newArgs.size(); ++ArgNo)
+        ArgAttrs.push_back(PAL.getParamAttrs(ArgNo));
+      PAL = AttributeList::get(oldF.getContext(), PAL.getFnAttrs(),
+                               PAL.getRetAttrs(), ArgAttrs);
+    }
+
+
+    SmallVector<OperandBundleDef, 1> OpBundles;
+    call->getOperandBundlesAsDefs(OpBundles);
+
+    CallInst *newCall = CallInst::Create(newF, ArrayRef(newArgs), OpBundles, "", call);
+    newCall->setTailCallKind(call->getTailCallKind());
+    newCall->setCallingConv(call->getCallingConv());
+    newCall->setAttributes(PAL);
+    newCall->copyMetadata(*call, {LLVMContext::MD_prof, LLVMContext::MD_dbg});
+
+    call->replaceAllUsesWith(newCall);
+    newCall->takeName(call);
+    // Copied from RecursivelyDeleteTrivallyDeadInstructions (because call is not trivially dead)
+    for (Use &OpU : call->operands()) {
+        Value *OpV = OpU.get();
+        OpU.set(nullptr);
+
+        if (!OpV->use_empty()) continue;
+
+        RecursivelyDeleteTriviallyDeadInstructions(OpV);
+    }
+    call->eraseFromParent();
+}
+
+bool StructConsolidatorPass::gatherWrites(const Function &F, const DataLayout& L, uint64_t typeSize, const Value &value, APInt currentOffset, WriteVec &writes) {
+    for (const Use &U : value.uses()) {
+        User *I = U.getUser();
+        if (isa<GetElementPtrInst>(I)) {
+            GetElementPtrInst *gep = cast<GetElementPtrInst>(I);
+            // Check if we are indeed ofsetting *from* "value" as a pointer
+            if (U.getOperandNo() != 0) return false;
+            APInt newOffset = currentOffset;
+            if (!gep->accumulateConstantOffset(L, newOffset))  return false;
+            if (!gatherWrites(F, L, typeSize, *gep, newOffset, writes)) return false;
+        } else if (isa<StoreInst>(I)) {
+            StoreInst *store = cast<StoreInst>(I);
+            TypeSize size = L.getTypeSizeInBits(store->getValueOperand()->getType());
+            // We don't support type sizes parameterized with vscale
+            if (size.isScalable()) return false;
+            // We only allow store's originating from arguments
+            if (!isa<Argument>(store->getValueOperand())) return false;
+            // We only allow byte-aligned stores
+            if (size.getFixedValue() % 8 != 0) return false;
+            Write write = {currentOffset.getLimitedValue(), size.getFixedValue() / 8, store->getValueOperand()};
+            writes.push_back(write);
+        } else if (isa<CallInst>(I)) {
+            // Check for memcpy
+            CallInst *call = cast<CallInst>(I);
+            Function *IF = call->getCalledFunction();
+            if (IF->getIntrinsicID() != Intrinsic::memcpy) return false;
+
+            // Check if we are indeed writing to our value (otherwise we are the destination, skip)
+            if (U.getOperandNo() != 0) continue;
+
+            // We only support memcpys of the whole struct
+            if (!currentOffset.isZero()) return false;
+
+            Value *src = call->getArgOperand(1);
+            // Expecting src is an alloca of a struct with the same size as our struct
+            if (!isa<AllocaInst>(src)) return false;
+            AllocaInst *srcInstruction = cast<AllocaInst>(src);
+            std::optional<TypeSize> srcSize = srcInstruction->getAllocationSize(L);
+            if (!srcSize.has_value() || *srcSize < typeSize) return false;
+
+            Value *len = call->getArgOperand(2);
+            // Expecting len is an integer equal to the size of our struct
+            if (!isa<ConstantInt>(len)) return false;
+            if (!cast<ConstantInt>(len)->equalsInt(typeSize)) return false;
+
+            Write write = { currentOffset.getLimitedValue(), typeSize, srcInstruction};
+            writes.push_back(write);
+        } else if (isa<LoadInst>(I)) {
+            // Don't traverse further when we find a load
+        } else {
+            // What to do with other uses? Loads are fine but other stuff might not be allowable
+            std::string message;
+            {
+                raw_string_ostream stream(message);
+                stream << "Not considering `";
+                value.printAsOperand(stream , true, F.getParent());
+                stream << "` valid due to: `";
+                I->print(stream);
+            }
+            ErrorReporter::addError(SOURCE_LOC, message);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+StructConsolidatorPass::ReplaceableVec StructConsolidatorPass::findReplaceableSets(Function &F, const DataLayout &L) {
+    const unsigned int addressSpace = L.getAllocaAddrSpace();
+    ReplaceableVec replaceableSets;
+    DenseMap<const AllocaInst *, size_t> intermediaries;
+    AllocaMap allocas;
+    // Find alloca's
+    // Find indexes into the allocated object
+    // Find writes to the allocated object or its indices
+
+    // Create set of alloca's and writes to offsets within the struct
+    // Check if there are no duplicate writes
+    // Check if all writes originate from the input
+    for (BasicBlock &BB : F) {
+        for (Instruction &I : BB) {
+            AllocaInst *allocA = dyn_cast<AllocaInst>(&I);
+            if (!allocA) continue;
+            // We only want to find alloca's allocating space for a single struct
+            Type *type = allocA->getAllocatedType();
+            if (allocA->isArrayAllocation() || !isa<StructType>(type)) continue;
+            StructType *structType = cast<StructType>(type);
+            TypeSize size = L.getTypeSizeInBits(structType);
+            // We don't support type sizes parameterized with vscale
+            if (size.isScalable()) continue;
+            // We only allow byte-aligned stores
+            if (size.getFixedValue() % 8 != 0) continue;
+            
+            SmallVector<Write> writes;
+            if (gatherWrites(F, L, size.getFixedValue()/8, *allocA, APInt(L.getPointerSizeInBits(addressSpace), 0, false), writes)) {
+                const StructLayout *structLayout = L.getStructLayout(structType);
+
+                IntervalSet intervals;
+                for (const Write &W : writes) {
+                    intervals.add(W.offset, W.offset + W.size);
+                }
+
+                bool valid = true;
+                for (size_t i = 0; i < structType->getNumElements(); ++i) {
+                    if (structLayout->getElementOffset(i).isScalable()) {
+                        valid = false;
+                        break;
+                    }
+                    uint64_t offset = structLayout->getElementOffset(i).getFixedValue();
+                    // How does this work if getTypeStoreSize is not a multiple of 8?
+                    if (!intervals.contains(offset, offset + L.getTypeStoreSize( structType->getElementType(i)))) {
+                        valid = false;
+                        break;
+                    }
+                }
+                if (valid) allocas.insert({allocA, writes});
+            }
+        }
+    }
+    for (std::pair<AllocaInst *, WriteVec> allocA : allocas) {
+        ReplaceableArgSet set;
+        set.alloc = allocA.first;
+        set.intermediary = NULL;
+        set.valid = true;
+        for (Write &W : allocA.second) {
+            assert(W.src != NULL);
+            if (AllocaInst *intermediary = dyn_cast<AllocaInst>(W.src)) {
+                if (const AllocaMap::const_iterator &search = allocas.find(intermediary); search != allocas.end() && set.intermediary == NULL) {
+                    set.intermediary = intermediary;
+                    continue;
+                } else {
+                    ErrorReporter::addWarning(SOURCE_LOC, "Not adding because invalid");
+                    set.valid = false;
+                    break;
+                } 
+            } else {
+                assert(isa<Argument>(W.src) &&
+                        "Expected the write src to be an alloca or function argument");
+                set.arguments.push_back({cast<Argument>(W.src), W.offset, W.size});
+            }
+        }
+        if (set.valid) {
+            if (set.intermediary != NULL) intermediaries.insert({set.intermediary, replaceableSets.size()});
+            std::sort(set.arguments.begin(), set.arguments.end(), [&](const ArgInfo &a, const ArgInfo &b) {
+                return a.argument < b.argument;
+            });
+
+            assert(std::unique(set.arguments.begin(), set.arguments.end(), [&](const ArgInfo &a, const ArgInfo &b) {
+                return a.argument == b.argument;
+            }) == set.arguments.end());
+            replaceableSets.push_back(set);
+        }
+    }
+    for (ReplaceableArgSet &set : replaceableSets) {
+        if (auto user = intermediaries.find(set.alloc); user != intermediaries.end()) {
+            if (set.intermediary) {
+                // We do not allow chaining intermediaries
+                set.valid = false;
+                replaceableSets[user->second].valid = false;
+            } else {
+                SmallVector<ArgInfo> &otherArgs = replaceableSets[user->second].arguments;
+                for (ArgInfo A : set.arguments) {
+                    otherArgs.push_back(A);
+                }
+                std::sort(otherArgs.begin(), otherArgs.end(), [&](const ArgInfo &a, const ArgInfo &b) {
+                    return a.argument < b.argument;
+                });
+
+                assert(std::unique(otherArgs.begin(), otherArgs.end(), [&](const ArgInfo &a, const ArgInfo &b) {
+                    return a.argument == b.argument;
+                }) == otherArgs.end());
+            }
+        }
+
+        gatherUseData(F, L, set);
+    }
+
+    // Mutating loop
+    for(ReplaceableVec::const_iterator it = replaceableSets.begin(); it != replaceableSets.end();) {
+        if (!it->valid || (!it->intermediary && it->arguments.empty()) || intermediaries.contains(it->alloc)) {
+            it = replaceableSets.erase(it);
+        } else {
+            errs() << "Found replacable set `";
+            it->alloc->print(errs());
+            errs() << "`,\nintermediary: `";
+            if (it->intermediary) {it->intermediary->print(errs());} else {errs() << "NULL";}
+            errs() << "`,\nargs:\n";
+            for (const ArgInfo &A : it->arguments) {
+                errs() << "`";
+                A.argument->print(errs());
+                errs() << "` at " << A.offset << " for " << A.size << " bytes\n";
+            }
+            errs() << "`,\ncalls:\n";
+            for (const auto &[call, fields] : it->calls) {
+                errs() << "\t`";
+                call->print(errs());
+                errs() << "` sources:\n";
+                for (const auto &[field, v] : fields) {
+                    const auto &[i, src] = v;
+                    errs() << "\t\t field: " << field << ", i: " << i << ", src: " << src << "\n";
+                }
+            }
+            ++it;
+        }
+        
+    }
+
+    return replaceableSets;
+}
+
+const Function &StructConsolidatorPass::updateFunction(Function &F, const ReplaceableVec &sets) {
+    // Based on DeadArgumentEliminationPass::removeDeadStuffFromFunction
+    assert(!F.isVarArg());
+
+    SmallSet<const Argument *, 8> ToBeRemoved;
+    for (const ReplaceableArgSet &set : sets) {
+        for (const ArgInfo &A : set.arguments) {
+            ToBeRemoved.insert(A.argument);
+        }
+    }
+    FunctionType *FTy = F.getFunctionType();
+    std::vector<Type *> Params;
+    Params.reserve(F.arg_size() - ToBeRemoved.size() + sets.size());
+    SmallVector<AttributeSet> ArgAttrVec;
+    const AttributeList &PAL = F.getAttributes();
+
+    size_t ArgI = 0;
+    for (const Argument *I = F.arg_begin(), *E = F.arg_end(); I != E; ++I, ++ArgI) {
+        if (!ToBeRemoved.contains(I)) {
+            Params.push_back(I->getType());
+            ArgAttrVec.push_back(PAL.getParamAttrs(ArgI));
+        }
+    }
+
+    const size_t newParamIdx = Params.size();
+    for (const ReplaceableArgSet &set : sets) {
+        Params.push_back(PointerType::get(F.getContext(), F.getAddressSpace()));
+        AttrBuilder B(F.getContext());
+        B.addByValAttr(set.alloc->getAllocatedType());
+        B.addAttribute(Attribute::NoUndef);
+        ArgAttrVec.push_back(AttributeSet::get(F.getContext(), B));
+    }
+
+    // AllocSize attribute may refer to removed argument
+    AttributeSet FnAttrs = PAL.getFnAttrs().removeAttribute(F.getContext(), Attribute::AllocSize);
+
+    assert(ArgAttrVec.size() == Params.size());
+
+    // TODO: Perhaps we also want to detect and transform cases where a small struct is returned
+    AttributeList NewPAL = AttributeList::get(F.getContext(), FnAttrs, PAL.getRetAttrs(), ArgAttrVec);
+
+    FunctionType *NFTy = FunctionType::get(FTy->getReturnType(), Params, false);
+
+    assert(NFTy != FTy);
+
+    Function *NF = Function::Create(NFTy, F.getLinkage(), F.getAddressSpace());
+    NF->copyAttributesFrom(&F);
+    NF->setComdat(F.getComdat());
+    NF->setAttributes(NewPAL);
+    F.getParent()->getFunctionList().insert(F.getIterator(), NF);
+    NF->takeName(&F);
+    // NF->IsNewDbgInfoFormat = F->IsNewDbgInfoFormat;
+
+    for (User *U : make_early_inc_range(F.users())) {
+        if (CallInst *C = dyn_cast<CallInst>(U)) {
+            replaceFunctionUse(C, F, NF, sets);
+        }
+    }
+
+    NF->splice(NF->begin(), &F);
+
+    ArgI = 0;
+    for (Argument *I = F.arg_begin(), *E = F.arg_end(); I != E; ++I) {
+        if (!ToBeRemoved.contains(I)) {
+            I->replaceAllUsesWith(NF->getArg(ArgI));
+            ++ArgI;
+        }
+    }
+
+    for (; ArgI < Params.size(); ++ArgI) {
+        const ReplaceableArgSet &set = sets[ArgI - newParamIdx];
+        set.alloc->replaceAllUsesWith(NF->getArg(ArgI));
+        set.alloc->eraseFromParent();
+        if (set.intermediary) {
+            RecursivelyDeleteTriviallyDeadInstructions(set.intermediary);
+        }
+    }
+    for (Argument *I = F.arg_begin(), *E = F.arg_end(); I != E; ++I) {
+        if (ToBeRemoved.contains(I)) {
+            removeRecursively(I);
+        }
+    }
+
+    SmallVector<std::pair<unsigned, MDNode *>, 1> MDs;
+    F.getAllMetadata(MDs);
+    for (auto [KindID, Node] : MDs)
+        NF->addMetadata(KindID, *Node);
+
+    if (NFTy != FTy && NF->getSubprogram()) {
+        DISubprogram *SP = NF->getSubprogram();
+        auto Temp = SP->getType()->cloneWithCC(llvm::dwarf::DW_CC_nocall);
+        SP->replaceType(MDNode::replaceWithPermanent(std::move(Temp)));
+    }
+
+    // While we've handled the calls we also need to update constants and metadata
+    F.replaceAllUsesWith(NF);
+
+    F.eraseFromParent();
+
+    return *NF;
+}
+
+PreservedAnalyses StructConsolidatorPass::run(Module &M,
+                                              ModuleAnalysisManager &MAM) {
+    bool madeChanges = false;
+    const DataLayout &L = M.getDataLayout();
+
+    DenseMap<Function *, ReplaceableVec> transformableFunctions;
+
+    for (Function &F : M) {
+        // Ensure that this a function which we can safely transform:
+        // - It is not a declaration and cannot change externally
+        // - It is not a varargs function
+        // - It has no parameters with the InAllocA or Preallocated attributes
+        // (these imply extra assumptions the caller is making regarding the
+        // value this function returns and how we treat the passed in arguments)
+        // These checks match those in the DeadArgumentEliminationPass
+        if (!F.hasExactDefinition() || F.isVarArg() ||
+            F.getAttributes().hasAttrSomewhere(Attribute::InAlloca) ||
+            F.getAttributes().hasAttrSomewhere(Attribute::Preallocated) ||
+            F.hasFnAttribute(Attribute::Naked)) {
+                continue;
+        }
+
+        if (ReplaceableVec sets = findReplaceableSets(F, L); !sets.empty()) {
+            transformableFunctions.insert({&F, sets});
+        }
+    }
+
+    for (auto const& [F, sets] : transformableFunctions) {
+        Function &oldF = *F;
+        const Function &newF = updateFunction(oldF, sets);
+    }
+
+    if (madeChanges) {
+        return PreservedAnalyses::none();
+    } else {
+        return PreservedAnalyses::all();
+    }
+}
+} // namespace pallas

--- a/src/llvm/lib/Passes/Module/StructConsolidator.cpp
+++ b/src/llvm/lib/Passes/Module/StructConsolidator.cpp
@@ -1,27 +1,31 @@
 #include "Passes/Module/StructConsolidator.h"
+#include "Util/Constants.h"
 #include "Util/Exceptions.h"
+#include "Util/PallasMD.h"
 #include <algorithm>
-#include <llvm-17/llvm/IR/GlobalValue.h>
-#include <llvm/IR/GlobalVariable.h>
-#include <llvm/IR/Operator.h>
 #include <llvm/ADT/ArrayRef.h>
-#include <llvm/IR/DataLayout.h>
-#include <llvm/ADT/SmallSet.h>
-#include <llvm/IR/Attributes.h>
-#include <llvm/IR/DerivedTypes.h>
 #include <llvm/ADT/DenseMap.h>
-#include <llvm/IR/DebugInfoMetadata.h>
-#include <llvm/ADT/SmallVector.h>
-#include <llvm/IR/Constants.h>
-#include <llvm/IR/Instructions.h>
-#include <llvm/IR/Argument.h>
-#include <llvm/IR/Intrinsics.h>
-#include <llvm/BinaryFormat/Dwarf.h>
-#include <llvm/Support/raw_ostream.h>
-#include <llvm/Support/Debug.h>
-#include <llvm/Support/Casting.h>
-#include <llvm/IR/BasicBlock.h>
 #include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/SmallSet.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/BinaryFormat/Dwarf.h>
+#include <llvm/IR/Argument.h>
+#include <llvm/IR/Attributes.h>
+#include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/DataLayout.h>
+#include <llvm/IR/DebugInfoMetadata.h>
+#include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/GlobalValue.h>
+#include <llvm/IR/GlobalVariable.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Intrinsics.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Metadata.h>
+#include <llvm/IR/Operator.h>
+#include <llvm/Support/Casting.h>
+#include <llvm/Support/Debug.h>
+#include <llvm/Support/raw_ostream.h>
 #include <llvm/Transforms/Utils/Local.h>
 
 namespace pallas {
@@ -30,46 +34,46 @@ const std::string SOURCE_LOC = "Passes::Module::StructConsolidator";
 using namespace llvm;
 
 struct Interval {
-    uint64_t start;
-    uint64_t end;
+    uint64_t Start;
+    uint64_t End;
 };
 
 struct IntervalSet {
-    SmallVector<Interval> intervals;
+    SmallVector<Interval> Intervals;
 
-    void add(uint64_t start, uint64_t end) {
-        assert(start < end);
-        if (intervals.empty()) {
-            intervals.push_back({start, end});
+    void add(uint64_t Start, uint64_t End) {
+        assert(Start < End);
+        if (Intervals.empty()) {
+            Intervals.push_back({Start, End});
         } else {
-            for (size_t i = 0, size = intervals.size(); i < size; ++i) {
-                if (intervals[i].start > start) {
-                    if (intervals[i].start <= end) {
-                        intervals[i].start = start;
-                        intervals[i].end = std::max(intervals[i].end, end);
+            for (size_t Idx = 0, Size = Intervals.size(); Idx < Size; ++Idx) {
+                if (Intervals[Idx].Start > Start) {
+                    if (Intervals[Idx].Start <= End) {
+                        Intervals[Idx].Start = Start;
+                        Intervals[Idx].End = std::max(Intervals[Idx].End, End);
                     } else {
-                        intervals.insert(intervals.begin() + i, {start, end});
+                        Intervals.insert(Intervals.begin() + Idx, {Start, End});
                     }
                 } else {
-                    if (intervals[i].end <= start) {
-                        intervals[i].end = std::max(intervals[i].end, end);
-                    } else if (i == end - 1) {
-                        intervals.push_back({start, end});
+                    if (Intervals[Idx].End <= Start) {
+                        Intervals[Idx].End = std::max(Intervals[Idx].End, End);
+                    } else if (Idx == End - 1) {
+                        Intervals.push_back({Start, End});
                     }
                 }
             }
         }
     }
 
-    bool contains(uint64_t start, uint64_t end) {
-        for (const Interval &i : intervals) {
-            if (i.start < start) {
-                if (end <= i.end) {
+    bool contains(uint64_t Start, uint64_t End) {
+        for (const Interval &I : Intervals) {
+            if (I.Start < Start) {
+                if (End <= I.End) {
                     return true;
                 }
             } else {
-                return i.start == start && end <= i.end;
-            } 
+                return I.Start == Start && End <= I.End;
+            }
         }
         return false;
     }
@@ -77,22 +81,17 @@ struct IntervalSet {
 
 // WARNING: This can remove a lot of things, be very careful when calling this
 void StructConsolidatorPass::removeRecursively(Value *V) {
-    errs() << "Recursively removing `";
-    V->print(errs());
-    errs() << "`\n";
-    while (!V->user_empty()){
+    while (!V->user_empty()) {
         removeRecursively(V->user_back());
     }
-    if (Instruction *I = dyn_cast<Instruction>(V)) {
+    if (auto *I = dyn_cast<Instruction>(V)) {
         for (Use &U : I->operands()) {
             Value *OpV = U.get();
             U.set(nullptr);
 
-            if (!OpV->use_empty()) continue;
+            if (!OpV->use_empty())
+                continue;
 
-            errs() << "Recursively deleting `";
-            OpV->print(errs());
-            errs() << "`\n";
             RecursivelyDeleteTriviallyDeadInstructions(OpV);
         }
         I->eraseFromParent();
@@ -100,92 +99,110 @@ void StructConsolidatorPass::removeRecursively(Value *V) {
 }
 
 void StructConsolidatorPass::removeParentless(Value *V) {
-    if (isa<Instruction>(V)) {
-        if (cast<Instruction>(V)->getParent()) return;
-        for (auto &O : cast<Instruction>(V)->operands()){
+    if (auto *I = dyn_cast<Instruction>(V)) {
+        if (I->getParent())
+            return;
+        for (auto &O : I->operands()) {
             removeParentless(O);
         }
         V->deleteValue();
     }
 }
 
-bool StructConsolidatorPass::digToField(Value *V, const DataLayout &L, const StructType &structType, FieldMap &fields, ArgInfo &A, APInt offsetIntoSource, uint64_t offsetIntoField, size_t pointerDepth) {
+bool StructConsolidatorPass::digToField(Value *V, const DataLayout &L,
+                                        const StructType &ST, FieldMap &Fields,
+                                        ArgInfo &A, APInt SourceOffset,
+                                        uint64_t FieldOffset, size_t Depth) {
     // For now let's not consider deeper nesting
-    if (pointerDepth > 1) return false;
+    if (Depth > 1)
+        return false;
 
-    auto &[i, field] = fields[A.offset + offsetIntoField];
-    Type *elementType = structType.getStructElementType(i);
+    auto &[Idx, Field] = Fields[A.Offset + FieldOffset];
+    Type *ET = ST.getStructElementType(Idx);
     // We only want to find one source for each field
-    if (field != NULL) return false;
-    if (pointerDepth == 0 && V->getType() == elementType) {
+    if (Field != NULL)
+        return false;
+    if (Depth == 0 && V->getType() == ET) {
         // We found a good source!
-        field = V;
+        Field = V;
         return true;
     }
 
-    if (isa<LoadInst>(V)) {
-        LoadInst &load = *cast<LoadInst>(V);
-        return digToField(load.getPointerOperand(), L, structType, fields, A, offsetIntoSource, offsetIntoField, pointerDepth + 1);
+    if (auto *Load = dyn_cast<LoadInst>(V)) {
+        return digToField(Load->getPointerOperand(), L, ST, Fields, A,
+                          SourceOffset, FieldOffset, Depth + 1);
     }
 
-    if (isa<GetElementPtrInst>(V)) {
-        GetElementPtrInst &gep = *cast<GetElementPtrInst>(V);
-        if (!gep.accumulateConstantOffset(L, offsetIntoSource)) return false;
+    if (auto *GEP = dyn_cast<GetElementPtrInst>(V)) {
+        if (!GEP->accumulateConstantOffset(L, SourceOffset))
+            return false;
 
-        return digToField(gep.getPointerOperand(), L, structType, fields, A, offsetIntoSource, offsetIntoField, pointerDepth);
+        return digToField(GEP->getPointerOperand(), L, ST, Fields, A,
+                          SourceOffset, FieldOffset, Depth);
     }
 
-    if (isa<AllocaInst>(V)) {
-        const AllocaInst &allocA = *cast<AllocaInst>(V);
-        assert(pointerDepth == 1);
+    if (auto *AllocA = dyn_cast<AllocaInst>(V)) {
+        assert(Depth == 1);
 
-        if (structType.getElementType(i) == allocA.getAllocatedType()) {
+        if (ST.getElementType(Idx) == AllocA->getAllocatedType()) {
             // This is our source, we just need to load it
             // Byte-align is fine since we're never generating this code
-            field = new LoadInst(elementType, V, Twine("insertedLoad"), false, Align());
+            Field = new LoadInst(ET, V, Twine("insertedLoad"), false, Align());
             return true;
         }
 
-        if (!isa<StructType>(allocA.getAllocatedType())) {
-            // While this could technically be an intermediary there should be no need to generate it like that since you could have a direct Load instruction
+        if (!isa<StructType>(AllocA->getAllocatedType())) {
+            // While this could technically be an intermediary there should be
+            // no need to generate it like that since you could have a direct
+            // Load instruction
             return false;
         }
 
-        StructType *allocStructType = cast<StructType>(allocA.getAllocatedType());
-        const StructLayout *structLayout = L.getStructLayout(allocStructType);
+        StructType *AllocST = cast<StructType>(AllocA->getAllocatedType());
+        const StructLayout *structLayout = L.getStructLayout(AllocST);
 
         // Decompose into available fields!
         // We have A.size bytes that we are reading from this allocation
-        // We will get all fields starting from field[A.offset + offsetIntoField]
-        int64_t remaining = A.size;
-        while (remaining > 0) {
-            auto &[i2, field2] = fields[A.offset + offsetIntoField];
-            assert (field2 == NULL);
-            int sourceIndex = structLayout->getElementContainingOffset(offsetIntoSource.getLimitedValue());
+        // We will get all fields starting from field[A.offset +
+        // offsetIntoField]
+        int64_t Remaining = A.Size;
+        while (Remaining > 0) {
+            auto &[InnerIdx, InnerField] = Fields[A.Offset + FieldOffset];
+            assert(InnerField == NULL);
+            int sourceIndex = structLayout->getElementContainingOffset(
+                SourceOffset.getLimitedValue());
 
             // Somehow we've ended up misaligned somewhere
-            if (offsetIntoSource != structLayout->getElementOffset(sourceIndex)) return false;
-            
-            if (structType.getStructElementType(i2) == allocStructType->getStructElementType(sourceIndex)) {
+            if (SourceOffset != structLayout->getElementOffset(sourceIndex))
+                return false;
+
+            if (ST.getStructElementType(InnerIdx) ==
+                AllocST->getStructElementType(sourceIndex)) {
                 // Found a match
-                field2 = new LoadInst(elementType,
-                     GetElementPtrInst::Create(allocStructType, V,
-                        ArrayRef(new Value *[]{
-                            ConstantInt::get(structType.getContext(), APInt(32, 0)),
-                            ConstantInt::get(structType.getContext(), APInt(32, i2))
-                        }, 2)),
-                      Twine("insertedLoad"), false, Align());
-                const TypeSize offset = L.getTypeAllocSize(structType.getStructElementType(i2));
-                offsetIntoSource += offset;
-                offsetIntoField += offset.getFixedValue();
-                remaining -= offset.getFixedValue();
+                InnerField = new LoadInst(
+                    ET,
+                    GetElementPtrInst::Create(
+                        AllocST, V,
+                        ArrayRef(
+                            new Value *[] {
+                                ConstantInt::get(ST.getContext(), APInt(32, 0)),
+                                    ConstantInt::get(ST.getContext(),
+                                                     APInt(32, InnerIdx))
+                            },
+                            2)),
+                    Twine("insertedLoad"), false, Align());
+                const TypeSize Offset =
+                    L.getTypeAllocSize(ST.getStructElementType(InnerIdx));
+                SourceOffset += Offset;
+                FieldOffset += Offset.getFixedValue();
+                Remaining -= Offset.getFixedValue();
             } else {
                 // This must be an intermediary struct
                 // TODO: Find memcpy
                 return false;
             }
         }
-        assert(remaining == 0);
+        assert(Remaining == 0);
 
         return true;
     }
@@ -193,23 +210,29 @@ bool StructConsolidatorPass::digToField(Value *V, const DataLayout &L, const Str
     return false;
 }
 
-void StructConsolidatorPass::gatherUseData(const Function &F, const DataLayout &L, ReplaceableArgSet &set) {
-    StructType *structType = cast<StructType>(set.alloc->getAllocatedType());
-    const StructLayout *structLayout = L.getStructLayout(structType);
-    const ArrayRef<TypeSize> offsets = structLayout->getMemberOffsets(); 
+void StructConsolidatorPass::gatherUseData(const Function &F,
+                                           const DataLayout &L,
+                                           ReplaceableArgSet &Set) {
+    auto *ST = cast<StructType>(Set.Alloc->getAllocatedType());
+    const StructLayout *SL = L.getStructLayout(ST);
+    const auto Offsets = SL->getMemberOffsets();
     for (const Use &U : F.uses()) {
-        FieldMap fields(offsets.size());
-        for (size_t i = 0; i < offsets.size(); ++i) {
-            fields.insert({offsets[i].getFixedValue(), {i, nullptr}});
+        FieldMap Fields(Offsets.size());
+        for (size_t Idx = 0, E = Offsets.size(); Idx < E; ++Idx) {
+            Fields.insert({Offsets[Idx].getFixedValue(), {Idx, nullptr}});
         }
-        
+
         if (!isa<CallInst>(U.getUser())) {
             // Copy of logic from Function::hasAddressTaken
             const User *FUU = U.getUser();
-            if (isa<BitCastOperator, AddrSpaceCastOperator>(U) && FUU->hasOneUse() && !FUU->user_begin()->user_empty()) FUU = *FUU->user_begin();
+            if (isa<BitCastOperator, AddrSpaceCastOperator>(U) &&
+                FUU->hasOneUse() && !FUU->user_begin()->user_empty())
+                FUU = *FUU->user_begin();
             if (llvm::all_of(FUU->users(), [](const User *U) {
                     if (const auto *GV = dyn_cast<GlobalVariable>(U))
-                        return GV->hasName() && (GV->getName() == "llvm.compiler.used" || GV->getName() == "llvm.used");
+                        return GV->hasName() &&
+                               (GV->getName() == "llvm.compiler.used" ||
+                                GV->getName() == "llvm.used");
                     return false;
                 }))
                 return;
@@ -224,209 +247,250 @@ void StructConsolidatorPass::gatherUseData(const Function &F, const DataLayout &
                 S << "`";
             }
             ErrorReporter::addWarning(SOURCE_LOC, M);
-            set.valid = false;
+            Set.Valid = false;
             return;
         }
 
-        CallInst *call = cast<CallInst>(U.getUser());
-        if (call->getCalledFunction() != &F || call->hasOperandBundles()) {
-            set.valid = false;
+        auto *Call = cast<CallInst>(U.getUser());
+        if (Call->getCalledFunction() != &F || Call->hasOperandBundles()) {
+            Set.Valid = false;
             return;
         }
-        const Use *P = call->arg_begin();
+        const Use *P = Call->arg_begin();
         // Find operands for every arg in set.arguments
-        for (const Argument *A = F.arg_begin(), *E = F.arg_end(); A != E; ++A, ++P) {
-            bool found = false;
-            for (ArgInfo &A2 : set.arguments) {
-                if (A == A2.argument) {
-                    if (!digToField(P->get(), L, *structType, fields, A2, APInt(L.getPointerSizeInBits(F.getAddressSpace()), 0, false), 0, 0)) {
-                        set.valid = false;
-                        for (auto &[_k, v] : fields) {
-                            auto &[_i, field] = v;
-                            if (field != NULL && isa<Instruction>(field)) {
-                                Instruction *I = cast<Instruction>(field);
-                                removeParentless(I);
-                            }
-                        }
-                        return;
-                    }
-                    found = true;
+        for (const Argument *FA = F.arg_begin(), *E = F.arg_end(); FA != E;
+             ++FA, ++P) {
+            bool Found = false;
+            for (ArgInfo &SA : Set.Arguments) {
+                if (FA != SA.Arg)
+                    continue;
+                if (digToField(
+                        P->get(), L, *ST, Fields, SA,
+                        APInt(L.getPointerSizeInBits(F.getAddressSpace()), 0,
+                              false),
+                        0, 0)) {
+                    Found = true;
                     break;
                 }
+                Set.Valid = false;
+                for (auto &[_Key, Value] : Fields) {
+                    auto &[_Idx, Field] = Value;
+                    if (Field != NULL && isa<Instruction>(Field)) {
+                        removeParentless(cast<Instruction>(Field));
+                    }
+                }
+                return;
             }
-            if (!found) {
-                set.valid = false;
+            if (!Found) {
+                Set.Valid = false;
                 return;
             }
         }
-        // For each operand move up until we find a variable of type set.alloc->getAllocationType
-        // If not found bail
-        //  (alternatively we can look to see if we can find a value the matches the size / offset of the fields corresponding to the arg)
-        //  (For example: %1 = alloca {i32, i32}; %2 = 10; %3 = load i64, ptr %1, align 4; call void f(%3, %2))
-        // If found store origin (and intermediary), we'll allow multiple origins as long as they're all of the appropriate type
-        set.calls.insert({call, fields});
+        // For each operand move up until we find a variable of type
+        // set.alloc->getAllocationType If not found bail
+        //  (alternatively we can look to see if we can find a value the matches
+        //  the size / offset of the fields corresponding to the arg) (For
+        //  example: %1 = alloca {i32, i32}; %2 = 10; %3 = load i64, ptr %1,
+        //  align 4; call void f(%3, %2))
+        // If found store origin (and intermediary), we'll allow multiple
+        // origins as long as they're all of the appropriate type
+        Set.Calls.insert({Call, Fields});
     }
 }
 
-
-void StructConsolidatorPass::replaceFunctionUse(CallInst *call, const Function &oldF, Function *newF, const ReplaceableVec &sets) {
-    DenseMap<size_t, std::pair<size_t, const ArgInfo &>> argToSetArg(sets.size());
-    // SmallSet<const Argument *, 8> ToBeRemoved;
-    // for (const ReplaceableArgSet &set : sets) {
-    //     for (const ArgInfo &A : set.arguments) {
-    //         ToBeRemoved.insert(A.argument);
-    //     }
-    // }
-    for (size_t i = 0; i < sets.size(); ++i) {
-        for (const ArgInfo &A : sets[i].arguments) {
-            argToSetArg.insert({A.argument->getArgNo(), {i, A}});
+void StructConsolidatorPass::replaceFunctionUse(CallInst *Call,
+                                                const Function &OldF,
+                                                Function *NewF,
+                                                const ReplaceableVec &Sets) {
+    SmallSet<size_t, 8> ToBeRemoved;
+    for (const auto &Set : Sets) {
+        for (const ArgInfo &A : Set.Arguments) {
+            ToBeRemoved.insert(A.Arg->getArgNo());
         }
     }
 
-    std::vector<Value *> newArgs;
-    newArgs.reserve(call->arg_size() - argToSetArg.size() + sets.size());
+    std::vector<Value *> NewArgs;
+    NewArgs.reserve(Call->arg_size() - ToBeRemoved.size() + Sets.size());
 
     size_t ArgI = 0;
-    for (const Use *A = call->arg_begin(), *E = call->arg_end(); A != E; ++A, ++ArgI) {
-        if (!argToSetArg.contains(ArgI)) {
-            newArgs.push_back(A->get());
+    for (const Use *A = Call->arg_begin(), *E = Call->arg_end(); A != E;
+         ++A, ++ArgI) {
+        if (!ToBeRemoved.contains(ArgI)) {
+            NewArgs.push_back(A->get());
         }
     }
-    std::vector<AllocaInst *> allocAs;
-    allocAs.reserve(sets.size());
+    std::vector<AllocaInst *> AllocAs;
+    AllocAs.reserve(Sets.size());
 
-    for (const ReplaceableArgSet &set : sets) {
-        AllocaInst *allocA = new AllocaInst(set.alloc->getAllocatedType(), newF->getAddressSpace(), Twine("InsertedAllocA"), call);
-        // Find appropriate call, loop over all the fields in the field map, GEP then STORE and done!
-        bool found = false;
-        for (const auto &[C, F] : set.calls) {
-            if (C == call) {
-                for (const auto &[_off, source] : F) {
-                    const auto &[i, field] = source;
-                    GetElementPtrInst *gep = GetElementPtrInst::CreateInBounds(set.alloc->getAllocatedType(), allocA, ArrayRef(new Value *[]{
-                        ConstantInt::get(newF->getContext(), APInt(32, 0)),
-                        ConstantInt::get(newF->getContext(), APInt(32, i))               
-                    }, 2), Twine("InsertedCallerGEP"), call);
-                    if (field == NULL) {
-                        break;
-                    }
-                    if (isa<Instruction>(field)) {
-                        Instruction *I = cast<Instruction>(field);
-                        if (I->getParent() == NULL) {
-                            for (Use &U : I->operands()) {
-                                if (isa<Instruction>(U.get())) {
-                                    Instruction *I2 = cast<Instruction>(U.get());
-                                    if (I2->getParent() == NULL) {
-                                        I2->insertBefore(call);
-                                    }
-                                }
-                            }
-                            I->insertBefore(call);
-                        }
-                     }
-                    new StoreInst(field, gep, call);
+    for (const auto &Set : Sets) {
+        AllocaInst *AllocA = new AllocaInst(Set.Alloc->getAllocatedType(),
+                                            NewF->getAddressSpace(),
+                                            Twine("InsertedAllocA"), Call);
+        bool Found = false;
+        for (const auto &[C, F] : Set.Calls) {
+            if (C != Call)
+                continue;
+            for (const auto &[_Offset, Source] : F) {
+                const auto &[Idx, Field] = Source;
+                auto *GEP = GetElementPtrInst::CreateInBounds(
+                    Set.Alloc->getAllocatedType(), AllocA,
+                    ArrayRef(
+                        new Value *[] {
+                            ConstantInt::get(NewF->getContext(), APInt(32, 0)),
+                                ConstantInt::get(NewF->getContext(),
+                                                 APInt(32, Idx))
+                        },
+                        2),
+                    Twine("InsertedCallerGEP"), Call);
+                if (Field == NULL) {
+                    break;
                 }
-
-                found = true;
-                break;
+                if (auto *I = dyn_cast<Instruction>(Field)) {
+                    if (I->getParent() == NULL) {
+                        for (Use &U : I->operands()) {
+                            if (auto *I2 = dyn_cast<Instruction>(U.get())) {
+                                if (I2->getParent() == NULL)
+                                    I2->insertBefore(Call);
+                            }
+                        }
+                        I->insertBefore(Call);
+                    }
+                }
+                new StoreInst(Field, GEP, Call);
             }
+
+            Found = true;
+            break;
         }
-        if (!found) {
-            ErrorReporter::addError(SOURCE_LOC, "Transformation failed, call set was missing a call to the function");
+        if (!Found) {
+            ErrorReporter::addError(SOURCE_LOC,
+                                    "Transformation failed, call set was "
+                                    "missing a call to the function");
         }
-        newArgs.push_back(allocA);
+        NewArgs.push_back(AllocA);
     }
 
     // Again most of this is from the DeadArgumentElimination pass
-    AttributeList PAL = call->getAttributes();
+    AttributeList PAL = Call->getAttributes();
     if (!PAL.isEmpty()) {
-      SmallVector<AttributeSet, 8> ArgAttrs;
-      for (unsigned ArgNo = 0; ArgNo < newArgs.size(); ++ArgNo)
-        ArgAttrs.push_back(PAL.getParamAttrs(ArgNo));
-      PAL = AttributeList::get(oldF.getContext(), PAL.getFnAttrs(),
-                               PAL.getRetAttrs(), ArgAttrs);
+        SmallVector<AttributeSet, 8> ArgAttrs;
+        for (unsigned ArgNo = 0; ArgNo < NewArgs.size(); ++ArgNo)
+            ArgAttrs.push_back(PAL.getParamAttrs(ArgNo));
+        PAL = AttributeList::get(OldF.getContext(), PAL.getFnAttrs(),
+                                 PAL.getRetAttrs(), ArgAttrs);
     }
 
-
     SmallVector<OperandBundleDef, 1> OpBundles;
-    call->getOperandBundlesAsDefs(OpBundles);
+    Call->getOperandBundlesAsDefs(OpBundles);
 
-    CallInst *newCall = CallInst::Create(newF, ArrayRef(newArgs), OpBundles, "", call);
-    newCall->setTailCallKind(call->getTailCallKind());
-    newCall->setCallingConv(call->getCallingConv());
+    CallInst *newCall =
+        CallInst::Create(NewF, ArrayRef(NewArgs), OpBundles, "", Call);
+    newCall->setTailCallKind(Call->getTailCallKind());
+    newCall->setCallingConv(Call->getCallingConv());
     newCall->setAttributes(PAL);
-    newCall->copyMetadata(*call, {LLVMContext::MD_prof, LLVMContext::MD_dbg});
+    newCall->copyMetadata(*Call, {LLVMContext::MD_prof, LLVMContext::MD_dbg});
 
-    call->replaceAllUsesWith(newCall);
-    newCall->takeName(call);
-    // Copied from RecursivelyDeleteTrivallyDeadInstructions (because call is not trivially dead)
-    for (Use &OpU : call->operands()) {
+    Call->replaceAllUsesWith(newCall);
+    newCall->takeName(Call);
+    // Copied from RecursivelyDeleteTrivallyDeadInstructions (because call is
+    // not trivially dead)
+    for (Use &OpU : Call->operands()) {
         Value *OpV = OpU.get();
         OpU.set(nullptr);
 
-        if (!OpV->use_empty()) continue;
+        if (!OpV->use_empty())
+            continue;
 
         RecursivelyDeleteTriviallyDeadInstructions(OpV);
     }
-    call->eraseFromParent();
+    Call->eraseFromParent();
 }
 
-bool StructConsolidatorPass::gatherWrites(const Function &F, const DataLayout& L, uint64_t typeSize, const Value &value, APInt currentOffset, WriteVec &writes) {
-    for (const Use &U : value.uses()) {
+bool StructConsolidatorPass::gatherWrites(const Function &F,
+                                          const DataLayout &L, uint64_t Size,
+                                          const Value &V, APInt Offset,
+                                          WriteVec &Writes) {
+    for (const Use &U : V.uses()) {
         User *I = U.getUser();
-        if (isa<GetElementPtrInst>(I)) {
-            GetElementPtrInst *gep = cast<GetElementPtrInst>(I);
+        if (auto *GEP = dyn_cast<GetElementPtrInst>(I)) {
             // Check if we are indeed ofsetting *from* "value" as a pointer
-            if (U.getOperandNo() != 0) return false;
-            APInt newOffset = currentOffset;
-            if (!gep->accumulateConstantOffset(L, newOffset))  return false;
-            if (!gatherWrites(F, L, typeSize, *gep, newOffset, writes)) return false;
-        } else if (isa<StoreInst>(I)) {
-            StoreInst *store = cast<StoreInst>(I);
-            TypeSize size = L.getTypeSizeInBits(store->getValueOperand()->getType());
+            if (U.getOperandNo() != 0)
+                return false;
+            APInt NewOffset = Offset;
+            if (!GEP->accumulateConstantOffset(L, NewOffset))
+                return false;
+            if (!gatherWrites(F, L, Size, *GEP, NewOffset, Writes))
+                return false;
+        } else if (auto *Store = dyn_cast<StoreInst>(I)) {
+            TypeSize size =
+                L.getTypeSizeInBits(Store->getValueOperand()->getType());
             // We don't support type sizes parameterized with vscale
-            if (size.isScalable()) return false;
+            if (size.isScalable())
+                return false;
             // We only allow store's originating from arguments
-            if (!isa<Argument>(store->getValueOperand())) return false;
+            if (!isa<Argument>(Store->getValueOperand()))
+                return false;
             // We only allow byte-aligned stores
-            if (size.getFixedValue() % 8 != 0) return false;
-            Write write = {currentOffset.getLimitedValue(), size.getFixedValue() / 8, store->getValueOperand()};
-            writes.push_back(write);
-        } else if (isa<CallInst>(I)) {
+            if (size.getFixedValue() % 8 != 0)
+                return false;
+            Write W = {Offset.getLimitedValue(), size.getFixedValue() / 8,
+                       Store->getValueOperand()};
+            Writes.push_back(W);
+        } else if (auto *Call = dyn_cast<CallInst>(I)) {
             // Check for memcpy
-            CallInst *call = cast<CallInst>(I);
-            Function *IF = call->getCalledFunction();
-            if (IF->getIntrinsicID() != Intrinsic::memcpy) return false;
+            Function *IF = Call->getCalledFunction();
+            // If we are calling a spec lib function then it will not have
+            // side-effects
+            if (IF->hasMetadata(constants::PALLAS_SPEC_LIB_MARKER))
+                continue;
 
-            // Check if we are indeed writing to our value (otherwise we are the destination, skip)
-            if (U.getOperandNo() != 0) continue;
+            if (IF->getIntrinsicID() != Intrinsic::memcpy)
+                return false;
+
+            // Check if we are indeed writing to our value (otherwise we are the
+            // destination, skip)
+            if (U.getOperandNo() != 0)
+                continue;
 
             // We only support memcpys of the whole struct
-            if (!currentOffset.isZero()) return false;
+            if (!Offset.isZero())
+                return false;
 
-            Value *src = call->getArgOperand(1);
-            // Expecting src is an alloca of a struct with the same size as our struct
-            if (!isa<AllocaInst>(src)) return false;
-            AllocaInst *srcInstruction = cast<AllocaInst>(src);
-            std::optional<TypeSize> srcSize = srcInstruction->getAllocationSize(L);
-            if (!srcSize.has_value() || *srcSize < typeSize) return false;
+            Value *Src = Call->getArgOperand(1);
+            // Expecting src is an alloca of a struct with the same size as our
+            // struct
+            if (!isa<AllocaInst>(Src))
+                return false;
+            AllocaInst *SrcI = cast<AllocaInst>(Src);
+            auto SrcSize = SrcI->getAllocationSize(L);
+            if (!SrcSize.has_value() || *SrcSize < Size)
+                return false;
 
-            Value *len = call->getArgOperand(2);
+            Value *Length = Call->getArgOperand(2);
             // Expecting len is an integer equal to the size of our struct
-            if (!isa<ConstantInt>(len)) return false;
-            if (!cast<ConstantInt>(len)->equalsInt(typeSize)) return false;
+            if (!isa<ConstantInt>(Length))
+                return false;
+            if (!cast<ConstantInt>(Length)->equalsInt(Size))
+                return false;
 
-            Write write = { currentOffset.getLimitedValue(), typeSize, srcInstruction};
-            writes.push_back(write);
+            Write W = {Offset.getLimitedValue(), Size, SrcI};
+            Writes.push_back(W);
         } else if (isa<LoadInst>(I)) {
             // Don't traverse further when we find a load
-        } else {
-            // What to do with other uses? Loads are fine but other stuff might not be allowable
+        } else if (!F.hasMetadata(constants::PALLAS_WRAPPER_FUNC)) {
+            // For wrapper functions we allow arbitrary use of the alloca and
+            // derivates for now, we need to evaluate how safe that is. Since
+            // these wrapper functions are inlined it makes sense to talk about,
+            // for example, the address of the caller's struct instead of the
+            // address of the local struct.
+
+            // What to do with other uses? Loads are fine but other stuff might
+            // not be allowable
             std::string message;
             {
                 raw_string_ostream stream(message);
                 stream << "Not considering `";
-                value.printAsOperand(stream , true, F.getParent());
+                V.printAsOperand(stream, true, F.getParent());
                 stream << "` valid due to: `";
                 I->print(stream);
             }
@@ -438,11 +502,18 @@ bool StructConsolidatorPass::gatherWrites(const Function &F, const DataLayout& L
     return true;
 }
 
-StructConsolidatorPass::ReplaceableVec StructConsolidatorPass::findReplaceableSets(Function &F, const DataLayout &L) {
-    const unsigned int addressSpace = L.getAllocaAddrSpace();
-    ReplaceableVec replaceableSets;
-    DenseMap<const AllocaInst *, size_t> intermediaries;
-    AllocaMap allocas;
+StructConsolidatorPass::ReplaceableVec
+StructConsolidatorPass::findReplaceableSets(Function &F, const DataLayout &L) {
+    const auto CompareArgs = [&](const ArgInfo &X, const ArgInfo &Y) {
+        return X.Arg < Y.Arg;
+    };
+    const auto EqualArgs = [&](const ArgInfo &X, const ArgInfo &Y) {
+        return X.Arg == Y.Arg;
+    };
+    const unsigned int AS = L.getAllocaAddrSpace();
+    ReplaceableVec Sets;
+    DenseMap<const AllocaInst *, size_t> Intermediaries;
+    AllocaMap AllocAs;
     // Find alloca's
     // Find indexes into the allocated object
     // Find writes to the allocated object or its indices
@@ -452,175 +523,232 @@ StructConsolidatorPass::ReplaceableVec StructConsolidatorPass::findReplaceableSe
     // Check if all writes originate from the input
     for (BasicBlock &BB : F) {
         for (Instruction &I : BB) {
-            AllocaInst *allocA = dyn_cast<AllocaInst>(&I);
-            if (!allocA) continue;
-            // We only want to find alloca's allocating space for a single struct
-            Type *type = allocA->getAllocatedType();
-            if (allocA->isArrayAllocation() || !isa<StructType>(type)) continue;
-            StructType *structType = cast<StructType>(type);
-            TypeSize size = L.getTypeSizeInBits(structType);
+            auto *AllocA = dyn_cast<AllocaInst>(&I);
+            if (!AllocA)
+                continue;
+            // We only want to find alloca's allocating space for a single
+            // struct
+            Type *type = AllocA->getAllocatedType();
+            if (AllocA->isArrayAllocation() || !isa<StructType>(type))
+                continue;
+            auto *ST = cast<StructType>(type);
+            TypeSize Size = L.getTypeSizeInBits(ST);
             // We don't support type sizes parameterized with vscale
-            if (size.isScalable()) continue;
+            if (Size.isScalable())
+                continue;
             // We only allow byte-aligned stores
-            if (size.getFixedValue() % 8 != 0) continue;
-            
-            SmallVector<Write> writes;
-            if (gatherWrites(F, L, size.getFixedValue()/8, *allocA, APInt(L.getPointerSizeInBits(addressSpace), 0, false), writes)) {
-                const StructLayout *structLayout = L.getStructLayout(structType);
+            if (Size.getFixedValue() % 8 != 0)
+                continue;
 
-                IntervalSet intervals;
-                for (const Write &W : writes) {
-                    intervals.add(W.offset, W.offset + W.size);
-                }
+            SmallVector<Write> Writes;
+            if (!gatherWrites(F, L, Size.getFixedValue() / 8, *AllocA,
+                              APInt(L.getPointerSizeInBits(AS), 0, false),
+                              Writes))
+                continue;
+            const auto *SL = L.getStructLayout(ST);
 
-                bool valid = true;
-                for (size_t i = 0; i < structType->getNumElements(); ++i) {
-                    if (structLayout->getElementOffset(i).isScalable()) {
-                        valid = false;
-                        break;
-                    }
-                    uint64_t offset = structLayout->getElementOffset(i).getFixedValue();
-                    // How does this work if getTypeStoreSize is not a multiple of 8?
-                    if (!intervals.contains(offset, offset + L.getTypeStoreSize( structType->getElementType(i)))) {
-                        valid = false;
-                        break;
-                    }
-                }
-                if (valid) allocas.insert({allocA, writes});
+            IntervalSet Intervals;
+            for (const Write &W : Writes) {
+                Intervals.add(W.Offset, W.Offset + W.Size);
             }
+
+            bool Valid = true;
+            for (size_t Idx = 0, E = ST->getNumElements(); Idx < E; ++Idx) {
+                if (SL->getElementOffset(Idx).isScalable()) {
+                    Valid = false;
+                    break;
+                }
+                uint64_t Offset = SL->getElementOffset(Idx).getFixedValue();
+                // How does this work if getTypeStoreSize is not a multiple of
+                // 8?
+                if (!Intervals.contains(
+                        Offset,
+                        Offset + L.getTypeStoreSize(ST->getElementType(Idx)))) {
+                    Valid = false;
+                    break;
+                }
+            }
+            if (Valid)
+                AllocAs.insert({AllocA, Writes});
         }
     }
-    for (std::pair<AllocaInst *, WriteVec> allocA : allocas) {
-        ReplaceableArgSet set;
-        set.alloc = allocA.first;
-        set.intermediary = NULL;
-        set.valid = true;
-        for (Write &W : allocA.second) {
-            assert(W.src != NULL);
-            if (AllocaInst *intermediary = dyn_cast<AllocaInst>(W.src)) {
-                if (const AllocaMap::const_iterator &search = allocas.find(intermediary); search != allocas.end() && set.intermediary == NULL) {
-                    set.intermediary = intermediary;
+    for (std::pair<AllocaInst *, WriteVec> AllocA : AllocAs) {
+        ReplaceableArgSet Set;
+        Set.Alloc = AllocA.first;
+        Set.Intermediary = NULL;
+        Set.Valid = true;
+        for (Write &W : AllocA.second) {
+            assert(W.Src != NULL);
+            if (auto *Intermediary = dyn_cast<AllocaInst>(W.Src)) {
+                if (const auto &It = AllocAs.find(Intermediary);
+                    It != AllocAs.end() && Set.Intermediary == NULL) {
+                    Set.Intermediary = Intermediary;
                     continue;
                 } else {
-                    ErrorReporter::addWarning(SOURCE_LOC, "Not adding because invalid");
-                    set.valid = false;
+                    ErrorReporter::addWarning(SOURCE_LOC,
+                                              "Not adding because invalid");
+                    Set.Valid = false;
                     break;
-                } 
+                }
             } else {
-                assert(isa<Argument>(W.src) &&
-                        "Expected the write src to be an alloca or function argument");
-                set.arguments.push_back({cast<Argument>(W.src), W.offset, W.size});
+                assert(isa<Argument>(W.Src) &&
+                       "Expected the write src to be an alloca or function "
+                       "argument");
+                Set.Arguments.push_back(
+                    {cast<Argument>(W.Src), W.Offset, W.Size});
             }
         }
-        if (set.valid) {
-            if (set.intermediary != NULL) intermediaries.insert({set.intermediary, replaceableSets.size()});
-            std::sort(set.arguments.begin(), set.arguments.end(), [&](const ArgInfo &a, const ArgInfo &b) {
-                return a.argument < b.argument;
-            });
+        if (Set.Valid) {
+            if (Set.Intermediary != NULL)
+                Intermediaries.insert({Set.Intermediary, Sets.size()});
+            llvm::sort(Set.Arguments.begin(), Set.Arguments.end(), CompareArgs);
 
-            assert(std::unique(set.arguments.begin(), set.arguments.end(), [&](const ArgInfo &a, const ArgInfo &b) {
-                return a.argument == b.argument;
-            }) == set.arguments.end());
-            replaceableSets.push_back(set);
+            assert(std::unique(Set.Arguments.begin(), Set.Arguments.end(),
+                               EqualArgs) == Set.Arguments.end());
+            Sets.push_back(Set);
         }
     }
-    for (ReplaceableArgSet &set : replaceableSets) {
-        if (auto user = intermediaries.find(set.alloc); user != intermediaries.end()) {
-            if (set.intermediary) {
+    for (auto &Set : Sets) {
+        if (auto U = Intermediaries.find(Set.Alloc);
+            U != Intermediaries.end()) {
+            if (Set.Intermediary) {
                 // We do not allow chaining intermediaries
-                set.valid = false;
-                replaceableSets[user->second].valid = false;
-            } else {
-                SmallVector<ArgInfo> &otherArgs = replaceableSets[user->second].arguments;
-                for (ArgInfo A : set.arguments) {
-                    otherArgs.push_back(A);
-                }
-                std::sort(otherArgs.begin(), otherArgs.end(), [&](const ArgInfo &a, const ArgInfo &b) {
-                    return a.argument < b.argument;
-                });
-
-                assert(std::unique(otherArgs.begin(), otherArgs.end(), [&](const ArgInfo &a, const ArgInfo &b) {
-                    return a.argument == b.argument;
-                }) == otherArgs.end());
+                Set.Valid = false;
+                Sets[U->second].Valid = false;
+                continue;
             }
+            SmallVector<ArgInfo> &OtherArgs = Sets[U->second].Arguments;
+            for (ArgInfo A : Set.Arguments) {
+                OtherArgs.push_back(A);
+            }
+            llvm::sort(OtherArgs.begin(), OtherArgs.end(), CompareArgs);
+
+            assert(std::unique(OtherArgs.begin(), OtherArgs.end(), EqualArgs) ==
+                   OtherArgs.end());
         }
 
-        gatherUseData(F, L, set);
+        gatherUseData(F, L, Set);
     }
 
     // Mutating loop
-    for(ReplaceableVec::const_iterator it = replaceableSets.begin(); it != replaceableSets.end();) {
-        if (!it->valid || (!it->intermediary && it->arguments.empty()) || intermediaries.contains(it->alloc)) {
-            it = replaceableSets.erase(it);
+    for (auto It = Sets.begin(); It != Sets.end();) {
+        if (!It->Valid || (!It->Intermediary && It->Arguments.empty()) ||
+            Intermediaries.contains(It->Alloc)) {
+            It = Sets.erase(It);
         } else {
-            errs() << "Found replacable set `";
-            it->alloc->print(errs());
-            errs() << "`,\nintermediary: `";
-            if (it->intermediary) {it->intermediary->print(errs());} else {errs() << "NULL";}
-            errs() << "`,\nargs:\n";
-            for (const ArgInfo &A : it->arguments) {
-                errs() << "`";
-                A.argument->print(errs());
-                errs() << "` at " << A.offset << " for " << A.size << " bytes\n";
-            }
-            errs() << "`,\ncalls:\n";
-            for (const auto &[call, fields] : it->calls) {
-                errs() << "\t`";
-                call->print(errs());
-                errs() << "` sources:\n";
-                for (const auto &[field, v] : fields) {
-                    const auto &[i, src] = v;
-                    errs() << "\t\t field: " << field << ", i: " << i << ", src: " << src << "\n";
-                }
-            }
-            ++it;
+            ++It;
         }
-        
     }
 
-    return replaceableSets;
+    return Sets;
 }
 
-const Function &StructConsolidatorPass::updateFunction(Function &F, const ReplaceableVec &sets) {
+void StructConsolidatorPass::replaceWrapperCalls(
+    Function *F, Function *NF, SmallSet<const Argument *, 8> &ToBeRemoved,
+    MDNode *MD, SmallSet<MDNode *, 8> &Visited) {
+    if (!Visited.insert(MD).second)
+        return;
+    for (const MDOperand &O : MD->operands()) {
+        if (auto *NO = dyn_cast_if_present<MDNode>(O.get())) {
+            replaceWrapperCalls(F, NF, ToBeRemoved, NO, Visited);
+        }
+    }
+    if (MD->getNumOperands() < 2)
+        return;
+
+    ValueAsMetadata *MF = ValueAsMetadata::get(F);
+    SmallVector<Metadata *> NewOperands;
+    const MDOperand &First = MD->getOperand(0);
+    size_t Offset;
+    if (First && (First.equalsStr(constants::PALLAS_ASSERT) ||
+                  First.equalsStr(constants::PALLAS_ASSUME))) {
+        auto *Loc = dyn_cast_if_present<MDNode>(MD->getOperand(1).get());
+        if (!Loc || !utils::isWellformedPallasLocation(Loc))
+            return;
+        if (MD->getOperand(2).get() != MF)
+            return;
+        NewOperands.push_back(MD->getOperand(0).get());
+        NewOperands.push_back(MD->getOperand(1).get());
+        Offset = 3;
+    } else {
+        // Loop invariant
+        auto *Loc = dyn_cast_if_present<MDNode>(First.get());
+        if (!Loc || !utils::isWellformedPallasLocation(Loc))
+            return;
+        if (MD->getOperand(1).get() != MF)
+            return;
+        NewOperands.push_back(MD->getOperand(0).get());
+        Offset = 2;
+    }
+
+    // Relatively certain now that we are looking at a call to the wrapper
+    // function Now we reorder the arguments to match the new order
+    NewOperands.push_back(ValueAsMetadata::get(NF));
+
+    size_t ArgI = 0;
+    for (Argument *I = F->arg_begin(), *E = F->arg_end(); I != E; ++I, ++ArgI) {
+        if (!ToBeRemoved.contains(I)) {
+            NewOperands.push_back(MD->getOperand(Offset + ArgI).get());
+        }
+    }
+    ArgI = 0;
+    for (Argument *I = F->arg_begin(), *E = F->arg_end(); I != E; ++I, ++ArgI) {
+        if (ToBeRemoved.contains(I)) {
+            NewOperands.push_back(MD->getOperand(Offset + ArgI).get());
+        }
+    }
+
+    for (ArgI = 0; ArgI < MD->getNumOperands(); ++ArgI) {
+        MD->replaceOperandWith(ArgI, NewOperands[ArgI]);
+    }
+}
+
+const Function &
+StructConsolidatorPass::updateFunction(Function &F,
+                                       const ReplaceableVec &Sets) {
     // Based on DeadArgumentEliminationPass::removeDeadStuffFromFunction
     assert(!F.isVarArg());
 
     SmallSet<const Argument *, 8> ToBeRemoved;
-    for (const ReplaceableArgSet &set : sets) {
-        for (const ArgInfo &A : set.arguments) {
-            ToBeRemoved.insert(A.argument);
+    for (const auto &set : Sets) {
+        for (const ArgInfo &A : set.Arguments) {
+            ToBeRemoved.insert(A.Arg);
         }
     }
     FunctionType *FTy = F.getFunctionType();
     std::vector<Type *> Params;
-    Params.reserve(F.arg_size() - ToBeRemoved.size() + sets.size());
+    Params.reserve(F.arg_size() - ToBeRemoved.size() + Sets.size());
     SmallVector<AttributeSet> ArgAttrVec;
     const AttributeList &PAL = F.getAttributes();
 
     size_t ArgI = 0;
-    for (const Argument *I = F.arg_begin(), *E = F.arg_end(); I != E; ++I, ++ArgI) {
+    for (const Argument *I = F.arg_begin(), *E = F.arg_end(); I != E;
+         ++I, ++ArgI) {
         if (!ToBeRemoved.contains(I)) {
             Params.push_back(I->getType());
             ArgAttrVec.push_back(PAL.getParamAttrs(ArgI));
         }
     }
 
-    const size_t newParamIdx = Params.size();
-    for (const ReplaceableArgSet &set : sets) {
+    const size_t NewIdx = Params.size();
+    for (const auto &set : Sets) {
         Params.push_back(PointerType::get(F.getContext(), F.getAddressSpace()));
         AttrBuilder B(F.getContext());
-        B.addByValAttr(set.alloc->getAllocatedType());
+        B.addByValAttr(set.Alloc->getAllocatedType());
         B.addAttribute(Attribute::NoUndef);
         ArgAttrVec.push_back(AttributeSet::get(F.getContext(), B));
     }
 
     // AllocSize attribute may refer to removed argument
-    AttributeSet FnAttrs = PAL.getFnAttrs().removeAttribute(F.getContext(), Attribute::AllocSize);
+    AttributeSet FnAttrs =
+        PAL.getFnAttrs().removeAttribute(F.getContext(), Attribute::AllocSize);
 
     assert(ArgAttrVec.size() == Params.size());
 
-    // TODO: Perhaps we also want to detect and transform cases where a small struct is returned
-    AttributeList NewPAL = AttributeList::get(F.getContext(), FnAttrs, PAL.getRetAttrs(), ArgAttrVec);
+    // TODO: Perhaps we also want to detect and transform cases where a small
+    // struct is returned
+    AttributeList NewPAL = AttributeList::get(F.getContext(), FnAttrs,
+                                              PAL.getRetAttrs(), ArgAttrVec);
 
     FunctionType *NFTy = FunctionType::get(FTy->getReturnType(), Params, false);
 
@@ -635,8 +763,8 @@ const Function &StructConsolidatorPass::updateFunction(Function &F, const Replac
     // NF->IsNewDbgInfoFormat = F->IsNewDbgInfoFormat;
 
     for (User *U : make_early_inc_range(F.users())) {
-        if (CallInst *C = dyn_cast<CallInst>(U)) {
-            replaceFunctionUse(C, F, NF, sets);
+        if (auto *C = dyn_cast<CallInst>(U)) {
+            replaceFunctionUse(C, F, NF, Sets);
         }
     }
 
@@ -651,23 +779,23 @@ const Function &StructConsolidatorPass::updateFunction(Function &F, const Replac
     }
 
     for (; ArgI < Params.size(); ++ArgI) {
-        const ReplaceableArgSet &set = sets[ArgI - newParamIdx];
-        set.alloc->replaceAllUsesWith(NF->getArg(ArgI));
-        set.alloc->eraseFromParent();
-        if (set.intermediary) {
-            RecursivelyDeleteTriviallyDeadInstructions(set.intermediary);
-        }
-    }
-    for (Argument *I = F.arg_begin(), *E = F.arg_end(); I != E; ++I) {
-        if (ToBeRemoved.contains(I)) {
-            removeRecursively(I);
+        const auto &Set = Sets[ArgI - NewIdx];
+        Set.Alloc->replaceAllUsesWith(NF->getArg(ArgI));
+        Set.Alloc->eraseFromParent();
+        if (Set.Intermediary) {
+            RecursivelyDeleteTriviallyDeadInstructions(Set.Intermediary);
         }
     }
 
+    const unsigned WrapperID =
+        F.getContext().getMDKindID(constants::PALLAS_WRAPPER_FUNC);
+    bool IsWrapper = false;
     SmallVector<std::pair<unsigned, MDNode *>, 1> MDs;
     F.getAllMetadata(MDs);
-    for (auto [KindID, Node] : MDs)
+    for (auto [KindID, Node] : MDs) {
+        IsWrapper |= KindID == WrapperID;
         NF->addMetadata(KindID, *Node);
+    }
 
     if (NFTy != FTy && NF->getSubprogram()) {
         DISubprogram *SP = NF->getSubprogram();
@@ -675,7 +803,38 @@ const Function &StructConsolidatorPass::updateFunction(Function &F, const Replac
         SP->replaceType(MDNode::replaceWithPermanent(std::move(Temp)));
     }
 
-    // While we've handled the calls we also need to update constants and metadata
+    if (IsWrapper) {
+        // Look for a Pallas MDNode representing a call to the wrapper function
+        // TODO: This should maybe be cached? Or maybe we could store a
+        // reference to all of these in the !pallas.exprWrapper node?
+        SmallVector<MDNode *> Metas;
+        for (Function &OtherF : *F.getParent()) {
+            if (auto MD = OtherF.getMetadata(constants::PALLAS_FUNC_CONTRACT))
+                Metas.push_back(MD);
+            for (BasicBlock &BB : OtherF) {
+                for (Instruction &I : BB) {
+                    if (auto MD =
+                            I.getMetadata(constants::PALLAS_SPEC_STMNT_BLOCK))
+                        Metas.push_back(MD);
+                    if (auto MD = I.getMetadata(LLVMContext::MD_loop))
+                        Metas.push_back(MD);
+                }
+            }
+        }
+        for (MDNode *MD : Metas) {
+            SmallSet<MDNode *, 8> Visited;
+            replaceWrapperCalls(&F, NF, ToBeRemoved, MD, Visited);
+        }
+    }
+
+    for (Argument *I = F.arg_begin(), *E = F.arg_end(); I != E; ++I) {
+        if (ToBeRemoved.contains(I)) {
+            removeRecursively(I);
+        }
+    }
+
+    // While we've handled the calls we also need to update constants and
+    // metadata
     F.replaceAllUsesWith(NF);
 
     F.eraseFromParent();
@@ -685,7 +844,7 @@ const Function &StructConsolidatorPass::updateFunction(Function &F, const Replac
 
 PreservedAnalyses StructConsolidatorPass::run(Module &M,
                                               ModuleAnalysisManager &MAM) {
-    bool madeChanges = false;
+    bool MadeChanges = false;
     const DataLayout &L = M.getDataLayout();
 
     DenseMap<Function *, ReplaceableVec> transformableFunctions;
@@ -702,20 +861,20 @@ PreservedAnalyses StructConsolidatorPass::run(Module &M,
             F.getAttributes().hasAttrSomewhere(Attribute::InAlloca) ||
             F.getAttributes().hasAttrSomewhere(Attribute::Preallocated) ||
             F.hasFnAttribute(Attribute::Naked)) {
-                continue;
+            continue;
         }
 
-        if (ReplaceableVec sets = findReplaceableSets(F, L); !sets.empty()) {
-            transformableFunctions.insert({&F, sets});
+        if (ReplaceableVec Sets = findReplaceableSets(F, L); !Sets.empty()) {
+            transformableFunctions.insert({&F, Sets});
         }
     }
 
-    for (auto const& [F, sets] : transformableFunctions) {
-        Function &oldF = *F;
-        const Function &newF = updateFunction(oldF, sets);
+    for (auto const &[F, sets] : transformableFunctions) {
+        updateFunction(*F, sets);
+        MadeChanges = true;
     }
 
-    if (madeChanges) {
+    if (MadeChanges) {
         return PreservedAnalyses::none();
     } else {
         return PreservedAnalyses::all();

--- a/src/llvm/lib/Plugin.cpp
+++ b/src/llvm/lib/Plugin.cpp
@@ -9,6 +9,7 @@
 #include "Passes/Module/ModuleSpecCollector.h"
 #include "Passes/Module/ProtobufPrinter.h"
 #include "Passes/Module/RootContainer.h"
+#include "Passes/Module/StructConsolidator.h"
 
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
@@ -43,6 +44,9 @@ llvm::PassPluginLibraryInfo getPallasPluginInfo() {
                             return true;
                         } else if (Name == "pallas-print-protobuf") {
                             MPM.addPass(pallas::ProtobufPrinter());
+                            return true;
+                        } else if (Name == "pallas-consolidate-structs") {
+                            MPM.addPass(pallas::StructConsolidatorPass());
                             return true;
                         }
                         return false;

--- a/src/llvm/lib/Transform/CMakeLists.txt
+++ b/src/llvm/lib/Transform/CMakeLists.txt
@@ -1,0 +1,20 @@
+add_library(Transform STATIC
+    BlockTransform.cpp
+    LoopContractTransform.cpp
+    SpecStatementTransform.cpp
+    Transform.cpp
+    # Instruction/
+    Instruction/BinaryOpTransform.cpp
+    Instruction/CastOpTransform.cpp
+    Instruction/FuncletPadOpTransform.cpp
+    Instruction/IntrinsicsTransform.cpp
+    Instruction/MemoryOpTransform.cpp
+    Instruction/OtherOpTransform.cpp
+    Instruction/TermOpTransform.cpp
+    Instruction/UnaryOpTransform.cpp
+)
+target_link_libraries(Transform COL Util Origin)
+target_include_directories(Transform PRIVATE
+    "${CMAKE_SOURCE_DIR}/include"
+    "${PROTO_BINARY_DIR}"
+)

--- a/src/llvm/lib/Transform/CMakeLists.txt
+++ b/src/llvm/lib/Transform/CMakeLists.txt
@@ -16,5 +16,6 @@ add_library(Transform STATIC
 target_link_libraries(Transform COL Util Origin)
 target_include_directories(Transform PRIVATE
     "${CMAKE_SOURCE_DIR}/include"
-    "${PROTO_BINARY_DIR}"
 )
+target_precompile_headers(Transform REUSE_FROM COL)
+

--- a/src/llvm/lib/Transform/Instruction/CastOpTransform.cpp
+++ b/src/llvm/lib/Transform/Instruction/CastOpTransform.cpp
@@ -25,6 +25,14 @@ void llvm2col::transformCastOp(llvm::Instruction &llvmInstruction,
         transformTrunc(llvm::cast<llvm::TruncInst>(llvmInstruction), colBlock,
                        funcCursor);
         break;
+    case llvm::Instruction::PtrToInt:
+        transformPtrToInt(llvm::cast<llvm::PtrToIntInst>(llvmInstruction),
+                          colBlock, funcCursor);
+        break;
+    case llvm::Instruction::IntToPtr:
+        transformIntToPtr(llvm::cast<llvm::IntToPtrInst>(llvmInstruction),
+                          colBlock, funcCursor);
+        break;
     default:
         reportUnsupportedOperatorError(SOURCE_LOC, llvmInstruction);
     }
@@ -104,4 +112,42 @@ void llvm2col::transformFPExt(llvm::FPExtInst &fpextInstruction,
     llvm2col::transformAndSetExpr(funcCursor, fpextInstruction,
                                   *fpextInstruction.getOperand(0),
                                   *fpext->mutable_value());
+}
+
+void llvm2col::transformPtrToInt(llvm::PtrToIntInst &ptoiInstruction,
+                                 col::LlvmBasicBlock &colBlock,
+                                 pallas::FunctionCursor &funcCursor) {
+    col::Assign &assignment =
+        funcCursor.createAssignmentAndDeclaration(ptoiInstruction, colBlock);
+    col::Expr *castExpr = assignment.mutable_value();
+    col::LlvmIntegerPointerCast *cast =
+        castExpr->mutable_llvm_integer_pointer_cast();
+    cast->set_allocated_origin(
+        llvm2col::generateSingleStatementOrigin(ptoiInstruction));
+    llvm2col::transformAndSetExpr(funcCursor, ptoiInstruction,
+                                  *ptoiInstruction.getOperand(0),
+                                  *cast->mutable_value());
+    llvm2col::transformAndSetType(*ptoiInstruction.getSrcTy(),
+                                  *cast->mutable_input_type());
+    llvm2col::transformAndSetType(*ptoiInstruction.getDestTy(),
+                                  *cast->mutable_output_type());
+}
+
+void llvm2col::transformIntToPtr(llvm::IntToPtrInst &itopInstruction,
+                                 col::LlvmBasicBlock &colBlock,
+                                 pallas::FunctionCursor &funcCursor) {
+    col::Assign &assignment =
+        funcCursor.createAssignmentAndDeclaration(itopInstruction, colBlock);
+    col::Expr *castExpr = assignment.mutable_value();
+    col::LlvmIntegerPointerCast *cast =
+        castExpr->mutable_llvm_integer_pointer_cast();
+    cast->set_allocated_origin(
+        llvm2col::generateSingleStatementOrigin(itopInstruction));
+    llvm2col::transformAndSetExpr(funcCursor, itopInstruction,
+                                  *itopInstruction.getOperand(0),
+                                  *cast->mutable_value());
+    llvm2col::transformAndSetType(*itopInstruction.getSrcTy(),
+                                  *cast->mutable_input_type());
+    llvm2col::transformAndSetType(*itopInstruction.getDestTy(),
+                                  *cast->mutable_output_type());
 }

--- a/src/llvm/lib/Transform/Instruction/CastOpTransform.cpp
+++ b/src/llvm/lib/Transform/Instruction/CastOpTransform.cpp
@@ -117,6 +117,7 @@ void llvm2col::transformFPExt(llvm::FPExtInst &fpextInstruction,
 void llvm2col::transformPtrToInt(llvm::PtrToIntInst &ptoiInstruction,
                                  col::LlvmBasicBlock &colBlock,
                                  pallas::FunctionCursor &funcCursor) {
+    const auto &dataLayout = ptoiInstruction.getModule()->getDataLayout();
     col::Assign &assignment =
         funcCursor.createAssignmentAndDeclaration(ptoiInstruction, colBlock);
     col::Expr *castExpr = assignment.mutable_value();
@@ -128,14 +129,15 @@ void llvm2col::transformPtrToInt(llvm::PtrToIntInst &ptoiInstruction,
                                   *ptoiInstruction.getOperand(0),
                                   *cast->mutable_value());
     llvm2col::transformAndSetType(*ptoiInstruction.getSrcTy(),
-                                  *cast->mutable_input_type());
+                                  *cast->mutable_input_type(), dataLayout);
     llvm2col::transformAndSetType(*ptoiInstruction.getDestTy(),
-                                  *cast->mutable_output_type());
+                                  *cast->mutable_output_type(), dataLayout);
 }
 
 void llvm2col::transformIntToPtr(llvm::IntToPtrInst &itopInstruction,
                                  col::LlvmBasicBlock &colBlock,
                                  pallas::FunctionCursor &funcCursor) {
+    const auto &dataLayout = itopInstruction.getModule()->getDataLayout();
     col::Assign &assignment =
         funcCursor.createAssignmentAndDeclaration(itopInstruction, colBlock);
     col::Expr *castExpr = assignment.mutable_value();
@@ -147,7 +149,7 @@ void llvm2col::transformIntToPtr(llvm::IntToPtrInst &itopInstruction,
                                   *itopInstruction.getOperand(0),
                                   *cast->mutable_value());
     llvm2col::transformAndSetType(*itopInstruction.getSrcTy(),
-                                  *cast->mutable_input_type());
+                                  *cast->mutable_input_type(), dataLayout);
     llvm2col::transformAndSetType(*itopInstruction.getDestTy(),
-                                  *cast->mutable_output_type());
+                                  *cast->mutable_output_type(), dataLayout);
 }

--- a/src/llvm/lib/Transform/Instruction/IntrinsicsTransform.cpp
+++ b/src/llvm/lib/Transform/Instruction/IntrinsicsTransform.cpp
@@ -51,6 +51,9 @@ void llvm2col::transformIntrinsic(llvm::CallInst &callInstruction,
     case llvm::Intrinsic::memset:
         transformMemset(callInstruction, colBlock, funcCursor);
         break;
+    case llvm::Intrinsic::memcpy:
+        transformMemcpy(callInstruction, colBlock, funcCursor);
+        break;
     default:
         reportUnsupportedOperatorError(SOURCE_LOC, callInstruction);
     }
@@ -198,4 +201,32 @@ void llvm2col::transformMemset(llvm::CallInst &callInstruction,
     llvm2col::transformAndSetExpr(funcCursor, callInstruction,
                                   *callInstruction.getArgOperand(3),
                                   *memset->mutable_volatile_());
+}
+
+void llvm2col::transformMemcpy(llvm::CallInst &callInstruction,
+                               col::LlvmBasicBlock &colBlock,
+                               pallas::FunctionCursor &funcCursor) {
+    llvm::Function *intrFunc = callInstruction.getCalledFunction();
+    col::Block &body = pallas::bodyAsBlock(colBlock);
+    col::Variable &targetVar = funcCursor.declareVariable(callInstruction);
+    col::LlvmMemcpy *memcpy = body.add_statements()->mutable_llvm_memcpy();
+    memcpy->set_allocated_origin(
+        llvm2col::generateSingleStatementOrigin(callInstruction));
+    memcpy->set_allocated_blame(new col::Blame());
+    // dest
+    llvm2col::transformAndSetExpr(funcCursor, callInstruction,
+                                  *callInstruction.getArgOperand(0),
+                                  *memcpy->mutable_dst());
+    // value
+    llvm2col::transformAndSetExpr(funcCursor, callInstruction,
+                                  *callInstruction.getArgOperand(1),
+                                  *memcpy->mutable_src());
+    // len
+    llvm2col::transformAndSetExpr(funcCursor, callInstruction,
+                                  *callInstruction.getArgOperand(2),
+                                  *memcpy->mutable_len());
+    // volatile
+    llvm2col::transformAndSetExpr(funcCursor, callInstruction,
+                                  *callInstruction.getArgOperand(3),
+                                  *memcpy->mutable_volatile_());
 }

--- a/src/llvm/lib/Transform/Instruction/OtherOpTransform.cpp
+++ b/src/llvm/lib/Transform/Instruction/OtherOpTransform.cpp
@@ -103,36 +103,46 @@ void llvm2col::transformICmp(llvm::ICmpInst &icmpInstruction,
         funcCursor.createAssignmentAndDeclaration(icmpInstruction, colBlock);
     switch (llvm::ICmpInst::Predicate(icmpInstruction.getPredicate())) {
     case llvm::CmpInst::ICMP_EQ: {
-        col::Eq &eq = *assignment.mutable_value()->mutable_eq();
+        col::AmbiguousEq &eq =
+            *assignment.mutable_value()->mutable_ambiguous_eq();
+        eq.mutable_vector_inner_type()->mutable_t_int()->set_allocated_origin(
+            generateBinExprOrigin(icmpInstruction));
         transformCmpExpr(icmpInstruction, eq, funcCursor);
         break;
     }
     case llvm::CmpInst::ICMP_NE: {
-        col::Neq &neq = *assignment.mutable_value()->mutable_neq();
+        col::AmbiguousNeq &neq =
+            *assignment.mutable_value()->mutable_ambiguous_neq();
+        neq.mutable_vector_inner_type()->mutable_t_int()->set_allocated_origin(
+            generateBinExprOrigin(icmpInstruction));
         transformCmpExpr(icmpInstruction, neq, funcCursor);
         break;
     }
     case llvm::CmpInst::ICMP_SGT:
     case llvm::CmpInst::ICMP_UGT: {
-        col::Greater &gt = *assignment.mutable_value()->mutable_greater();
+        col::AmbiguousGreater &gt =
+            *assignment.mutable_value()->mutable_ambiguous_greater();
         transformCmpExpr(icmpInstruction, gt, funcCursor);
         break;
     }
     case llvm::CmpInst::ICMP_SGE:
     case llvm::CmpInst::ICMP_UGE: {
-        col::GreaterEq &geq = *assignment.mutable_value()->mutable_greater_eq();
+        col::AmbiguousGreaterEq &geq =
+            *assignment.mutable_value()->mutable_ambiguous_greater_eq();
         transformCmpExpr(icmpInstruction, geq, funcCursor);
         break;
     }
     case llvm::CmpInst::ICMP_SLT:
     case llvm::CmpInst::ICMP_ULT: {
-        col::Less &lt = *assignment.mutable_value()->mutable_less();
+        col::AmbiguousLess &lt =
+            *assignment.mutable_value()->mutable_ambiguous_less();
         transformCmpExpr(icmpInstruction, lt, funcCursor);
         break;
     }
     case llvm::CmpInst::ICMP_SLE:
     case llvm::CmpInst::ICMP_ULE: {
-        col::LessEq &leq = *assignment.mutable_value()->mutable_less_eq();
+        col::AmbiguousLessEq &leq =
+            *assignment.mutable_value()->mutable_ambiguous_less_eq();
         transformCmpExpr(icmpInstruction, leq, funcCursor);
         break;
     }
@@ -175,40 +185,51 @@ void llvm2col::transformFCmp(llvm::FCmpInst &fcmpInstruction,
             *assignment.mutable_value()->mutable_boolean_value();
         boolean.set_value(false);
         boolean.set_allocated_origin(generateBinExprOrigin(fcmpInstruction));
+        break;
     }
     case llvm::CmpInst::FCMP_OEQ:
     case llvm::CmpInst::FCMP_UEQ: {
-        col::Eq &eq = *assignment.mutable_value()->mutable_eq();
+        col::AmbiguousEq &eq =
+            *assignment.mutable_value()->mutable_ambiguous_eq();
+        eq.mutable_vector_inner_type()->mutable_t_int()->set_allocated_origin(
+            generateBinExprOrigin(fcmpInstruction));
         transformCmpExpr(fcmpInstruction, eq, funcCursor);
         break;
     }
     case llvm::CmpInst::FCMP_OGT:
     case llvm::CmpInst::FCMP_UGT: {
-        col::Greater &gt = *assignment.mutable_value()->mutable_greater();
+        col::AmbiguousGreater &gt =
+            *assignment.mutable_value()->mutable_ambiguous_greater();
         transformCmpExpr(fcmpInstruction, gt, funcCursor);
         break;
     }
     case llvm::CmpInst::FCMP_OGE:
     case llvm::CmpInst::FCMP_UGE: {
-        col::GreaterEq &geq = *assignment.mutable_value()->mutable_greater_eq();
+        col::AmbiguousGreaterEq &geq =
+            *assignment.mutable_value()->mutable_ambiguous_greater_eq();
         transformCmpExpr(fcmpInstruction, geq, funcCursor);
         break;
     }
     case llvm::CmpInst::FCMP_OLT:
     case llvm::CmpInst::FCMP_ULT: {
-        col::Less &lt = *assignment.mutable_value()->mutable_less();
+        col::AmbiguousLess &lt =
+            *assignment.mutable_value()->mutable_ambiguous_less();
         transformCmpExpr(fcmpInstruction, lt, funcCursor);
         break;
     }
     case llvm::CmpInst::FCMP_OLE:
     case llvm::CmpInst::FCMP_ULE: {
-        col::LessEq &leq = *assignment.mutable_value()->mutable_less_eq();
+        col::AmbiguousLessEq &leq =
+            *assignment.mutable_value()->mutable_ambiguous_less_eq();
         transformCmpExpr(fcmpInstruction, leq, funcCursor);
         break;
     }
     case llvm::CmpInst::FCMP_ONE:
     case llvm::CmpInst::FCMP_UNE: {
-        col::Neq &neq = *assignment.mutable_value()->mutable_neq();
+        col::AmbiguousNeq &neq =
+            *assignment.mutable_value()->mutable_ambiguous_neq();
+        neq.mutable_vector_inner_type()->mutable_t_int()->set_allocated_origin(
+            generateBinExprOrigin(fcmpInstruction));
         transformCmpExpr(fcmpInstruction, neq, funcCursor);
         break;
     }
@@ -217,11 +238,13 @@ void llvm2col::transformFCmp(llvm::FCmpInst &fcmpInstruction,
             *assignment.mutable_value()->mutable_boolean_value();
         boolean.set_value(true);
         boolean.set_allocated_origin(generateBinExprOrigin(fcmpInstruction));
+        break;
     }
     case llvm::CmpInst::FCMP_ORD:
     case llvm::CmpInst::FCMP_UNO: {
         pallas::ErrorReporter::addError(
             SOURCE_LOC, "Checking for NaNs is unsupported", fcmpInstruction);
+        break;
     }
     default:
         pallas::ErrorReporter::addError(SOURCE_LOC, "Unknown FCMP predicate",

--- a/src/llvm/lib/Util/CMakeLists.txt
+++ b/src/llvm/lib/Util/CMakeLists.txt
@@ -8,5 +8,6 @@ add_library(Util STATIC
 target_link_libraries(Util Transform COL Origin)
 target_include_directories(Util PRIVATE
     "${CMAKE_SOURCE_DIR}/include"
-    "${PROTO_BINARY_DIR}"
 )
+target_precompile_headers(Util REUSE_FROM COL)
+

--- a/src/llvm/lib/Util/CMakeLists.txt
+++ b/src/llvm/lib/Util/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(Util STATIC
+    BlockUtils.cpp
+    Exceptions.cpp
+    PallasDIMapping.cpp
+    PallasMD.cpp
+    PallasWrapperUtils.cpp
+)
+target_link_libraries(Util Transform COL Origin)
+target_include_directories(Util PRIVATE
+    "${CMAKE_SOURCE_DIR}/include"
+    "${PROTO_BINARY_DIR}"
+)

--- a/src/llvm/lib/Util/PallasWrapperUtils.cpp
+++ b/src/llvm/lib/Util/PallasWrapperUtils.cpp
@@ -23,11 +23,6 @@ void buildArgExprFromAlloca(col::LlvmFunctionInvocation &wrapperCall,
                             pallas::FunctionCursor &functionCursor) {
     col::Variable &colVar =
         functionCursor.getVariableMapEntry(llvmAlloca, false);
-    // Ptr deref
-    auto *ptrDeref = wrapperCall.add_args()->mutable_deref_pointer();
-    ptrDeref->set_allocated_origin(
-        llvm2col::generatePallasWrapperCallOrigin(llvmWFunc, srcLoc));
-    ptrDeref->set_allocated_blame(new col::Blame());
 
     // Cast, if type is packed struct with single element
     auto *structTy =
@@ -37,19 +32,32 @@ void buildArgExprFromAlloca(col::LlvmFunctionInvocation &wrapperCall,
                            structTy->getNumElements() == 1;
 
     col::Local *local = nullptr;
-    if (structTy != expectedTy && isTrivialStruct &&
-        structTy->getElementType(0) == expectedTy) {
-        auto *cast = ptrDeref->mutable_pointer()->mutable_cast();
-        cast->set_allocated_origin(
-            llvm2col::generatePallasWrapperCallOrigin(llvmWFunc, srcLoc));
-        col::TypeValue *tVal = cast->mutable_type_value()->mutable_type_value();
-        tVal->set_allocated_origin(
-            llvm2col::generatePallasWrapperCallOrigin(llvmWFunc, srcLoc));
-        llvm2col::transformAndSetPointerType(
-            *expectedTy, *tVal->mutable_value(),
-            llvmAlloca.getModule()->getDataLayout());
-        local = cast->mutable_value()->mutable_local();
+    if (structTy != nullptr && structTy != expectedTy) {
+        if (isTrivialStruct && structTy->getElementType(0) == expectedTy) {
+            auto *ptrDeref = wrapperCall.add_args()->mutable_deref_pointer();
+            ptrDeref->set_allocated_origin(
+                llvm2col::generatePallasWrapperCallOrigin(llvmWFunc, srcLoc));
+            ptrDeref->set_allocated_blame(new col::Blame());
+            auto *cast = ptrDeref->mutable_pointer()->mutable_cast();
+            cast->set_allocated_origin(
+                llvm2col::generatePallasWrapperCallOrigin(llvmWFunc, srcLoc));
+            col::TypeValue *tVal =
+                cast->mutable_type_value()->mutable_type_value();
+            tVal->set_allocated_origin(
+                llvm2col::generatePallasWrapperCallOrigin(llvmWFunc, srcLoc));
+            llvm2col::transformAndSetPointerType(
+                *expectedTy, *tVal->mutable_value(),
+                llvmAlloca.getModule()->getDataLayout());
+            local = cast->mutable_value()->mutable_local();
+        } else {
+            local = wrapperCall.add_args()->mutable_local();
+        }
     } else {
+        // Ptr deref
+        auto *ptrDeref = wrapperCall.add_args()->mutable_deref_pointer();
+        ptrDeref->set_allocated_origin(
+            llvm2col::generatePallasWrapperCallOrigin(llvmWFunc, srcLoc));
+        ptrDeref->set_allocated_blame(new col::Blame());
         local = ptrDeref->mutable_pointer()->mutable_local();
     }
 

--- a/src/main/vct/resources/Resources.scala
+++ b/src/main/vct/resources/Resources.scala
@@ -16,5 +16,5 @@ case object Resources {
   def getCPPcPath: Path = Paths.get("clang++")
   def getSystemCConfig: Path = getResource("/systemc/config")
   def getVeymontPath: Path = getResource("/veymont")
-  def getPallas: Path = getResource("/pallas")
+  def getPallas: Path = getResource("/libPallas.so")
 }

--- a/src/parsers/vct/parsers/parser/ColLLVMParser.scala
+++ b/src/parsers/vct/parsers/parser/ColLLVMParser.scala
@@ -52,7 +52,7 @@ case class ColLLVMParser(
     val command = Seq(
       "opt-17",
       s"--load-pass-plugin=$pallas",
-      s"--passes=function($prePStr),module(pallas-declare-variables,pallas-collect-module-spec),function(pallas-declare-function,pallas-assign-pure,llvm-declare-function-contract,pallas-declare-function-contract,pallas-transform-function-body),module(pallas-print-protobuf)",
+      s"--passes=function($prePStr),module(pallas-consolidate-structs,pallas-declare-variables,pallas-collect-module-spec),function(pallas-declare-function,pallas-assign-pure,llvm-declare-function-contract,pallas-declare-function-contract,pallas-transform-function-body),module(pallas-print-protobuf)",
       "--disable-output",
     )
 

--- a/src/parsers/vct/parsers/transform/CPPToCol.scala
+++ b/src/parsers/vct/parsers/transform/CPPToCol.scala
@@ -2157,20 +2157,14 @@ case class CPPToCol[G](
 
   def convert(implicit e: ValPrimaryPermissionContext): Expr[G] =
     e match {
-      case ValCurPerm(_, _, loc, _) =>
-        CurPerm(AmbiguousLocation(convert(loc))(blame(e)))
+      case ValCurPerm(_, _, loc, _) => CurPerm(AmbiguousLocation(convert(loc)))
       case ValPerm(_, _, loc, _, perm, _) =>
-        Perm(AmbiguousLocation(convert(loc))(blame(e)), convert(perm))
-      case ValValue(_, _, loc, _) =>
-        Value(AmbiguousLocation(convert(loc))(blame(e)))
+        Perm(AmbiguousLocation(convert(loc)), convert(perm))
+      case ValValue(_, _, loc, _) => Value(AmbiguousLocation(convert(loc)))
       case ValAutoValue(_, _, loc, _) =>
-        AutoValue(AmbiguousLocation(convert(loc))(blame(e)))
+        AutoValue(AmbiguousLocation(convert(loc)))
       case ValPointsTo(_, _, loc, _, perm, _, v, _) =>
-        PointsTo(
-          AmbiguousLocation(convert(loc))(blame(e)),
-          convert(perm),
-          convert(v),
-        )
+        PointsTo(AmbiguousLocation(convert(loc)), convert(perm), convert(v))
       case ValHPerm(_, _, loc, _, perm, _) =>
         ModelPerm(convert(loc), convert(perm))
       case ValAPerm(_, _, loc, _, perm, _) =>
@@ -2248,7 +2242,7 @@ case class CPPToCol[G](
       case ValForPerm(_, _, bindings, _, loc, _, body, _) =>
         ForPerm(
           convert(bindings),
-          AmbiguousLocation(convert(loc))(blame(loc))(origin(loc)),
+          AmbiguousLocation(convert(loc))(origin(loc)),
           convert(body),
         )
       case ValForPermWithValue(_, _, _, id, _, body, _) =>

--- a/src/parsers/vct/parsers/transform/CToCol.scala
+++ b/src/parsers/vct/parsers/transform/CToCol.scala
@@ -1945,20 +1945,14 @@ case class CToCol[G](
 
   def convert(implicit e: ValPrimaryPermissionContext): Expr[G] =
     e match {
-      case ValCurPerm(_, _, loc, _) =>
-        CurPerm(AmbiguousLocation(convert(loc))(blame(e)))
+      case ValCurPerm(_, _, loc, _) => CurPerm(AmbiguousLocation(convert(loc)))
       case ValPerm(_, _, loc, _, perm, _) =>
-        Perm(AmbiguousLocation(convert(loc))(blame(e)), convert(perm))
-      case ValValue(_, _, loc, _) =>
-        Value(AmbiguousLocation(convert(loc))(blame(e)))
+        Perm(AmbiguousLocation(convert(loc)), convert(perm))
+      case ValValue(_, _, loc, _) => Value(AmbiguousLocation(convert(loc)))
       case ValAutoValue(_, _, loc, _) =>
-        AutoValue(AmbiguousLocation(convert(loc))(blame(e)))
+        AutoValue(AmbiguousLocation(convert(loc)))
       case ValPointsTo(_, _, loc, _, perm, _, v, _) =>
-        PointsTo(
-          AmbiguousLocation(convert(loc))(blame(e)),
-          convert(perm),
-          convert(v),
-        )
+        PointsTo(AmbiguousLocation(convert(loc)), convert(perm), convert(v))
       case ValHPerm(_, _, loc, _, perm, _) =>
         ModelPerm(convert(loc), convert(perm))
       case ValAPerm(_, _, loc, _, perm, _) =>
@@ -2036,7 +2030,7 @@ case class CToCol[G](
       case ValForPerm(_, _, bindings, _, loc, _, body, _) =>
         ForPerm(
           convert(bindings),
-          AmbiguousLocation(convert(loc))(blame(loc))(origin(loc)),
+          AmbiguousLocation(convert(loc))(origin(loc)),
           convert(body),
         )
       case ValForPermWithValue(_, _, _, id, _, body, _) =>

--- a/src/parsers/vct/parsers/transform/JavaToCol.scala
+++ b/src/parsers/vct/parsers/transform/JavaToCol.scala
@@ -2419,20 +2419,14 @@ case class JavaToCol[G](
 
   def convert(implicit e: ValPrimaryPermissionContext): Expr[G] =
     e match {
-      case ValCurPerm(_, _, loc, _) =>
-        CurPerm(AmbiguousLocation(convert(loc))(blame(e)))
+      case ValCurPerm(_, _, loc, _) => CurPerm(AmbiguousLocation(convert(loc)))
       case ValPerm(_, _, loc, _, perm, _) =>
-        Perm(AmbiguousLocation(convert(loc))(blame(e)), convert(perm))
-      case ValValue(_, _, loc, _) =>
-        Value(AmbiguousLocation(convert(loc))(blame(e)))
+        Perm(AmbiguousLocation(convert(loc)), convert(perm))
+      case ValValue(_, _, loc, _) => Value(AmbiguousLocation(convert(loc)))
       case ValAutoValue(_, _, loc, _) =>
-        AutoValue(AmbiguousLocation(convert(loc))(blame(e)))
+        AutoValue(AmbiguousLocation(convert(loc)))
       case ValPointsTo(_, _, loc, _, perm, _, v, _) =>
-        PointsTo(
-          AmbiguousLocation(convert(loc))(blame(e)),
-          convert(perm),
-          convert(v),
-        )
+        PointsTo(AmbiguousLocation(convert(loc)), convert(perm), convert(v))
       case ValHPerm(_, _, loc, _, perm, _) =>
         ModelPerm(convert(loc), convert(perm))
       case ValAPerm(_, _, loc, _, perm, _) =>
@@ -2510,7 +2504,7 @@ case class JavaToCol[G](
       case ValForPerm(_, _, bindings, _, loc, _, body, _) =>
         ForPerm(
           convert(bindings),
-          AmbiguousLocation(convert(loc))(blame(loc))(origin(loc)),
+          AmbiguousLocation(convert(loc))(origin(loc)),
           convert(body),
         )
       case ValForPermWithValue(_, _, _, id, _, body, _) =>

--- a/src/parsers/vct/parsers/transform/LLVMContractToCol.scala
+++ b/src/parsers/vct/parsers/transform/LLVMContractToCol.scala
@@ -364,20 +364,14 @@ case class LLVMContractToCol[G](
 
   def convert(implicit e: ValPrimaryPermissionContext): Expr[G] =
     e match {
-      case ValCurPerm(_, _, loc, _) =>
-        CurPerm(AmbiguousLocation(convert(loc))(blame(e)))
+      case ValCurPerm(_, _, loc, _) => CurPerm(AmbiguousLocation(convert(loc)))
       case ValPerm(_, _, loc, _, perm, _) =>
-        Perm(AmbiguousLocation(convert(loc))(blame(e)), convert(perm))
-      case ValValue(_, _, loc, _) =>
-        Value(AmbiguousLocation(convert(loc))(blame(e)))
+        Perm(AmbiguousLocation(convert(loc)), convert(perm))
+      case ValValue(_, _, loc, _) => Value(AmbiguousLocation(convert(loc)))
       case ValAutoValue(_, _, loc, _) =>
-        AutoValue(AmbiguousLocation(convert(loc))(blame(e)))
+        AutoValue(AmbiguousLocation(convert(loc)))
       case ValPointsTo(_, _, loc, _, perm, _, v, _) =>
-        PointsTo(
-          AmbiguousLocation(convert(loc))(blame(e)),
-          convert(perm),
-          convert(v),
-        )
+        PointsTo(AmbiguousLocation(convert(loc)), convert(perm), convert(v))
       case ValHPerm(_, _, loc, _, perm, _) =>
         ModelPerm(convert(loc), convert(perm))
       case ValAPerm(_, _, loc, _, perm, _) =>
@@ -426,7 +420,7 @@ case class LLVMContractToCol[G](
       case ValForPerm(_, _, bindings, _, loc, _, body, _) =>
         ForPerm(
           convert(bindings),
-          AmbiguousLocation(convert(loc))(blame(loc))(origin(loc)),
+          AmbiguousLocation(convert(loc))(origin(loc)),
           convert(body),
         )
     }

--- a/src/parsers/vct/parsers/transform/PVLToCol.scala
+++ b/src/parsers/vct/parsers/transform/PVLToCol.scala
@@ -465,7 +465,7 @@ case class PVLToCol[G](
       case PvlChorPerm(_, _, endpoint, _, _, loc, _, perm, _) =>
         PVLChorPerm(
           PVLEndpointName(convert(endpoint))(origin(endpoint)),
-          AmbiguousLocation(convert(loc))(blame(expr)),
+          AmbiguousLocation(convert(loc)),
           convert(perm),
         )
       case PvlLongEndpointExpr(_, _, endpoint, _, inner, _) =>
@@ -1815,20 +1815,14 @@ case class PVLToCol[G](
 
   def convert(implicit e: ValPrimaryPermissionContext): Expr[G] =
     e match {
-      case ValCurPerm(_, _, loc, _) =>
-        CurPerm(AmbiguousLocation(convert(loc))(blame(e)))
+      case ValCurPerm(_, _, loc, _) => CurPerm(AmbiguousLocation(convert(loc)))
       case ValPerm(_, _, loc, _, perm, _) =>
-        Perm(AmbiguousLocation(convert(loc))(blame(e)), convert(perm))
-      case ValValue(_, _, loc, _) =>
-        Value(AmbiguousLocation(convert(loc))(blame(e)))
+        Perm(AmbiguousLocation(convert(loc)), convert(perm))
+      case ValValue(_, _, loc, _) => Value(AmbiguousLocation(convert(loc)))
       case ValAutoValue(_, _, loc, _) =>
-        AutoValue(AmbiguousLocation(convert(loc))(blame(e)))
+        AutoValue(AmbiguousLocation(convert(loc)))
       case ValPointsTo(_, _, loc, _, perm, _, v, _) =>
-        PointsTo(
-          AmbiguousLocation(convert(loc))(blame(e)),
-          convert(perm),
-          convert(v),
-        )
+        PointsTo(AmbiguousLocation(convert(loc)), convert(perm), convert(v))
       case ValHPerm(_, _, loc, _, perm, _) =>
         ModelPerm(convert(loc), convert(perm))
       case ValAPerm(_, _, loc, _, perm, _) =>
@@ -1906,7 +1900,7 @@ case class PVLToCol[G](
       case ValForPerm(_, _, bindings, _, loc, _, body, _) =>
         ForPerm(
           convert(bindings),
-          AmbiguousLocation(convert(loc))(blame(loc))(origin(loc)),
+          AmbiguousLocation(convert(loc))(origin(loc)),
           convert(body),
         )
       case ValForPermWithValue(_, _, _, id, _, body, _) =>

--- a/src/rewrite/vct/rewrite/ClassToRef.scala
+++ b/src/rewrite/vct/rewrite/ClassToRef.scala
@@ -175,6 +175,39 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
           toSize,
         )
       },
+    )) :+ new ADTAxiom[Post](foralls(
+      Seq(TNonNullPointer(newT, unique), TNonNullPointer(axiomType, None)),
+      body = { case Seq(a, b) =>
+        (a === PointerCast(
+          adtFunctionInvocation(
+            fieldRef,
+            args = Seq(
+              InlinePattern(PointerToAdt(b, axiomType)(NonNullPointerNull))
+            ),
+          ),
+          TNonNullPointer(newT, unique),
+          fieldSize,
+          toSize,
+        )) ==>
+          (InlinePattern(
+            PointerCast(a, TNonNullPointer(axiomType, None), toSize, structSize)
+          ) === b)
+      },
+    )) :+ new ADTAxiom[Post](foralls(
+      Seq(TNonNullPointer(TVoid(), None), TNonNullPointer(axiomType, None)),
+      body = { case Seq(x, y) =>
+        (x === InlinePattern(
+          PointerCast(y, TNonNullPointer(TVoid(), None), structSize, const(1))
+        )) ==>
+          (InlinePattern(
+            PointerCast(x, TNonNullPointer(newT, unique), const(1), fieldSize)
+          ) === PointerCast(
+            y,
+            TNonNullPointer(newT, unique),
+            structSize,
+            fieldSize,
+          ))
+      },
     ))
   }
 
@@ -377,6 +410,49 @@ case class ClassToRef[Pre <: Generation]() extends Rewriter[Pre] {
                   byValFieldSucc.ref(field),
                   args = Seq(PointerToAdt(a, axiomType)(NonNullPointerNull)),
                 )
+              },
+            )) :+ new ADTAxiom[Post](foralls(
+              Seq(
+                TNonNullPointer(newT, unique),
+                TNonNullPointer(axiomType, None),
+              ),
+              body = { case Seq(a, b) =>
+                (a === adtFunctionInvocation(
+                  byValFieldSucc.ref(field),
+                  args = Seq(InlinePattern(
+                    PointerToAdt(b, axiomType)(NonNullPointerNull)
+                  )),
+                )) ==>
+                  (InlinePattern(PointerCast(
+                    a,
+                    TNonNullPointer(axiomType, None),
+                    dispatch(cls.childSizes.head),
+                    dispatch(cls.size),
+                  )) === b)
+              },
+            )) :+ new ADTAxiom[Post](foralls(
+              Seq(
+                TNonNullPointer(TVoid(), None),
+                TNonNullPointer(axiomType, None),
+              ),
+              body = { case Seq(x, y) =>
+                (x === InlinePattern(PointerCast(
+                  y,
+                  TNonNullPointer(TVoid(), None),
+                  dispatch(cls.size),
+                  const(1),
+                ))) ==>
+                  (InlinePattern(PointerCast(
+                    x,
+                    TNonNullPointer(newT, unique),
+                    const(1),
+                    dispatch(cls.childSizes.head),
+                  )) === PointerCast(
+                    y,
+                    TNonNullPointer(newT, unique),
+                    dispatch(cls.size),
+                    dispatch(cls.childSizes.head),
+                  ))
               },
             ))
 

--- a/src/rewrite/vct/rewrite/DisambiguateLocation.scala
+++ b/src/rewrite/vct/rewrite/DisambiguateLocation.scala
@@ -66,9 +66,7 @@ case object DisambiguateLocation extends RewriterBuilder {
 case class DisambiguateLocation[Pre <: Generation]() extends Rewriter[Pre] {
   import DisambiguateLocation._
 
-  private def exprToLoc(expr: Expr[Pre], blame: Blame[PointerLocationError])(
-      implicit o: Origin
-  ): Location[Post] =
+  private def exprToLoc(expr: Expr[Pre])(implicit o: Origin): Location[Post] =
     expr match {
       case InlinePattern(inner, pattern, group) =>
         if (inner.t.asByValueClass.isDefined) {
@@ -78,7 +76,7 @@ case class DisambiguateLocation[Pre <: Generation]() extends Rewriter[Pre] {
           )
         }
         InLinePatternLocation(
-          exprToLoc(inner, blame),
+          exprToLoc(inner),
           InlinePattern(dispatch(inner), pattern, group)(expr.o),
         )(expr.o)
       case expr if expr.t.asByValueClass.isDefined =>
@@ -103,8 +101,7 @@ case class DisambiguateLocation[Pre <: Generation]() extends Rewriter[Pre] {
 
   override def dispatch(loc: Location[Pre]): Location[Post] =
     loc match {
-      case location @ AmbiguousLocation(expr) =>
-        exprToLoc(expr, location.blame)(loc.o)
+      case location @ AmbiguousLocation(expr) => exprToLoc(expr)(loc.o)
       case other => super.dispatch(other)
     }
 }

--- a/src/rewrite/vct/rewrite/lang/LangCToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangCToCol.scala
@@ -5,7 +5,7 @@ import hre.util.ScopedStack
 import vct.col.ast._
 import vct.col.ast.lang.c.CTVector.WrongVectorType
 import vct.col.ast.util.ExpressionEqualityCheck.isConstantInt
-import vct.rewrite.lang.LangSpecificToCol.NotAValue
+import vct.rewrite.lang.LangSpecificToCol.{NotAValue, InvalidPointerComparison}
 import vct.col.origin._
 import vct.col.ref.{LazyRef, Ref}
 import vct.col.resolve.lang.C
@@ -21,7 +21,6 @@ import vct.result.VerificationError.{Unreachable, UserError}
 import scala.annotation.tailrec
 import scala.collection.immutable.ListMap
 import scala.collection.mutable
-import vct.col.ref.UnresolvedRef
 
 case object LangCToCol {
   private case class MultipleSharedMemoryDeclaration(decl: Node[_])
@@ -272,15 +271,6 @@ case object LangCToCol {
     override def blame(error: DivByZero): Unit =
       blame.blame(TypeSizeMayBeZero(c))
   }
-
-  private case class InvalidPointerComparison(cmp: Expr[_]) extends UserError {
-    override def code: String = "incompatiblePointerComparison"
-    override def text: String =
-      cmp.o.messageInContext(
-        "Comparison between pointers of different types is not supported"
-      )
-  }
-
 }
 
 case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
@@ -614,7 +604,7 @@ case class LangCToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
           case e @ AmbiguousLessEq(_, _, _) =>
             e.rewrite(elementSize = elementSize)
         }
-      } else { throw InvalidPointerComparison(cmp) }
+      } else { throw InvalidPointerComparison(cmp.o) }
     } else { cmp.rewriteDefault() }
   }
 

--- a/src/rewrite/vct/rewrite/lang/LangJavaToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangJavaToCol.scala
@@ -226,12 +226,7 @@ case class LangJavaToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
                 fields.decls.indices.map(decl => {
                   val local = JavaLocal[Pre](fields.decls(decl).name)(DerefPerm)
                   local.ref = Some(RefJavaField[Pre](fields, decl))
-                  Perm(
-                    AmbiguousLocation(local)(PanicBlame(
-                      "Field location is not a pointer."
-                    )),
-                    WritePerm(),
-                  )
+                  Perm(AmbiguousLocation(local), WritePerm())
                 })
             }.flatten))
           }

--- a/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
@@ -389,9 +389,6 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
       expr.collect {
         case Local(Ref(v)) => v
         case LLVMPointerValue(Ref(g)) => g
-        // These two below probably don't do anything
-        case v: Variable[Pre] => v
-        case v: LLVMGlobalVariable[Pre] => v
       }.toSet
     }
 
@@ -424,6 +421,23 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
         case _ => None
       }
     }
+
+    // Returns variable and functions to strip and "rewrap" the type
+    def getVariablePossiblyWrapped(
+        expr: Expr[Pre]
+    ): Option[(Object, Type[Pre] => Type[Pre], Type[Pre] => Type[Pre])] =
+      expr match {
+        case Local(Ref(v)) => Some((v, t => t, t => t))
+        case LLVMPointerValue(Ref(g)) => Some((g, t => t, t => t))
+        case DerefPointer(p) =>
+          getVariablePossiblyWrapped(p).map { case (v, strip, wrap) =>
+            (
+              v,
+              { t: Type[Pre] => strip(t).asPointer.get.element },
+              { t: Type[Pre] => LLVMTPointer(Some(wrap(t))) },
+            )
+          }
+      }
 
     def addTypeGuess(
         obj: Object,
@@ -518,6 +532,19 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
                 dependencies,
                 _ => replaceWithGuesses(inv.args(idx), dependencies).t,
               )
+
+              getVariablePossiblyWrapped(inv.args(idx))
+                .foreach { case (v, strip, wrap) =>
+                  addTypeGuess(
+                    v,
+                    Set(arg),
+                    _ =>
+                      wrap(
+                        typeGuesses.get(arg).map(_.currentType)
+                          .getOrElse(inv.args(idx).t)
+                      ),
+                  )
+                }
             }
           }
       // Propagate pointer types across \old
@@ -1136,6 +1163,19 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
   def rewriteFloatExtend(fpext: LLVMFloatExtend[Pre]): Expr[Post] = {
     implicit val o: Origin = fpext.o
     CastFloat(rw.dispatch(fpext.value), rw.dispatch(fpext.t))
+  }
+
+  def rewriteIntegerPointerCast(
+      cast: LLVMIntegerPointerCast[Pre]
+  ): Expr[Post] = {
+    implicit val o: Origin = cast.o
+    val inputType = getInferredType(cast.value)
+    val outputType = getInferredType(cast)
+    val size =
+      if (cast.inputType.asPointer.isDefined) {
+        rw.c.sizeOf(inputType.asPointer.get.element, o)
+      } else { rw.c.sizeOf(outputType.asPointer.get.element, o) }
+    IntegerPointerCast(rw.dispatch(cast.value), rw.dispatch(outputType), size)
   }
 
   private def getInitializerForArithOpWithOverflow(

--- a/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
@@ -717,55 +717,88 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
     }
   }
 
+  private def addCast(arg: Expr[Pre], v: Variable[Pre]): Expr[Post] = {
+    arg match {
+      case dp @ DerefPointer(p) => {
+        val pt = getInferredType(p)
+        val et = pt.asPointer.get.element
+        val vt = getLocalVarType(v)
+        if (CoercionUtils.getAnyCoercion(et, vt).isDefined) { rw.dispatch(arg) }
+        else if (
+          et == TVoid[Pre]() || CoercionUtils.firstElementIsType(et, vt) ||
+          CoercionUtils.firstElementIsType(vt, et)
+        ) {
+          DerefPointer(
+            PointerCast(
+              rw.dispatch(arg),
+              TPointer(rw.dispatch(vt), None),
+              rw.c.sizeOf(et, p.o),
+              rw.c.sizeOf(vt, v.o),
+            )(dp.o)
+          )(dp.blame)(dp.o)
+        } else { throw InvalidPointerEquality(inv.o, vt, et) }
+      }
+      case _ if arg.t.asPointer.isDefined => {
+        val pt = getInferredType(arg)
+        val pet = pt.asPointer.get.element
+        val vt = getLocalVarType(v)
+        val vet = vt.asPointer.get.element
+        if (CoercionUtils.getAnyCoercion(pet, vet).isDefined) {
+          rw.dispatch(arg)
+        } else if (
+          pet == TVoid[Pre]() || CoercionUtils.firstElementIsType(pet, vet) ||
+          CoercionUtils.firstElementIsType(vet, pet)
+        ) {
+          PointerCast(
+            rw.dispatch(arg),
+            rw.dispatch(vt),
+            rw.c.sizeOf(pet, arg.o),
+            rw.c.sizeOf(vet, v.o),
+          )(arg.o)
+        } else { throw InvalidPointerEquality(inv.o, vet, pet) }
+      }
+      case _ => rw.dispatch(arg)
+    }
+  }
+
+  def rewriteAmbiguousFunctionInvocation(
+      inv: LLVMAmbiguousFunctionInvocation[Pre]
+  ): Invocation[Post] = {
+    implicit val o: Origin = inv.o
+
+    val given = inv.givenMap.map { case (Ref(v), e) =>
+      (rw.succ[Variable[Post]](v), addCast(e, v))
+    }
+    val yields = inv.yields.map { case (e, Ref(v)) =>
+      (addCast(e, v), rw.succ[Variable[Post]](v))
+    }
+
+    inv.ref.get.decl match {
+      case func: LLVMFunctionDefinition[Pre] =>
+        new ProcedureInvocation[Post](
+          ref = new LazyRef[Post, Procedure[Post]](llvmFunctionMap(func)),
+          args = inv.args.zip(func.args).map(p => addCast(p._1, p._2)),
+          givenMap = given,
+          yields = yields,
+          outArgs = Seq.empty,
+          typeArgs = Seq.empty,
+        )(inv.blame)
+      case func: LLVMSpecFunction[Pre] =>
+        new FunctionInvocation[Post](
+          ref = new LazyRef[Post, Function[Post]](specFunctionMap(func)),
+          args = inv.args.zip(func.args).map(p => addCast(p._1, p._2)),
+          givenMap = given,
+          yields = yields,
+          typeArgs = Seq.empty,
+        )(inv.blame)
+    }
+
+  }
+
   def rewriteFunctionInvocation(
       inv: LLVMFunctionInvocation[Pre]
   ): ProcedureInvocation[Post] = {
     implicit val o: Origin = inv.o
-
-    def addCast(arg: Expr[Pre], v: Variable[Pre]): Expr[Post] = {
-      arg match {
-        case dp @ DerefPointer(p) => {
-          val pt = getInferredType(p)
-          val et = pt.asPointer.get.element
-          val vt = getLocalVarType(v)
-          if (CoercionUtils.getAnyCoercion(et, vt).isDefined) {
-            rw.dispatch(arg)
-          } else if (
-            et == TVoid[Pre]() || CoercionUtils.firstElementIsType(et, vt) ||
-            CoercionUtils.firstElementIsType(vt, et)
-          ) {
-            DerefPointer(
-              PointerCast(
-                rw.dispatch(arg),
-                TPointer(rw.dispatch(vt), None),
-                rw.c.sizeOf(et, p.o),
-                rw.c.sizeOf(vt, v.o),
-              )(dp.o)
-            )(dp.blame)(dp.o)
-          } else { throw InvalidPointerEquality(inv.o, vt, et) }
-        }
-        case _ if arg.t.asPointer.isDefined => {
-          val pt = getInferredType(arg)
-          val pet = pt.asPointer.get.element
-          val vt = getLocalVarType(v)
-          val vet = vt.asPointer.get.element
-          if (CoercionUtils.getAnyCoercion(pet, vet).isDefined) {
-            rw.dispatch(arg)
-          } else if (
-            pet == TVoid[Pre]() || CoercionUtils.firstElementIsType(pet, vet) ||
-            CoercionUtils.firstElementIsType(vet, pet)
-          ) {
-            PointerCast(
-              rw.dispatch(arg),
-              rw.dispatch(vt),
-              rw.c.sizeOf(pet, arg.o),
-              rw.c.sizeOf(vet, v.o),
-            )(arg.o)
-          } else { throw InvalidPointerEquality(inv.o, vet, pet) }
-        }
-        case _ => rw.dispatch(arg)
-      }
-    }
 
     val given = inv.givenMap.map { case (Ref(v), e) =>
       (rw.succ[Variable[Post]](v), addCast(e, v))
@@ -777,12 +810,8 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
     new ProcedureInvocation[Post](
       ref = new LazyRef[Post, Procedure[Post]](llvmFunctionMap(inv.ref.decl)),
       args = inv.args.zip(inv.ref.decl.args).map(p => addCast(p._1, p._2)),
-      givenMap = inv.givenMap.map { case (Ref(v), e) =>
-        (rw.succ(v), rw.dispatch(e))
-      },
-      yields = inv.yields.map { case (e, Ref(v)) =>
-        (rw.dispatch(e), rw.succ(v))
-      },
+      givenMap = given,
+      yields = yields,
       outArgs = Seq.empty,
       typeArgs = Seq.empty,
     )(inv.blame)

--- a/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
@@ -2,6 +2,7 @@ package vct.rewrite.lang
 
 import com.typesafe.scalalogging.LazyLogging
 import hre.util.ScopedStack
+import vct.col.ast.expr.op.BinOperatorTypes
 import vct.col.ast.{Expr, _}
 import vct.col.origin._
 import vct.col.ref.{DirectRef, LazyRef, Ref}
@@ -727,7 +728,8 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
         val vt = getLocalVarType(v)
         if (CoercionUtils.getAnyCoercion(et, vt).isDefined) { rw.dispatch(arg) }
         else if (
-          et == TVoid[Pre]() || CoercionUtils.firstElementIsType(et, vt) ||
+          vt == TVoid[Pre]() || et == TVoid[Pre]() ||
+          CoercionUtils.firstElementIsType(et, vt) ||
           CoercionUtils.firstElementIsType(vt, et)
         ) {
           DerefPointer(
@@ -748,7 +750,8 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
         if (CoercionUtils.getAnyCoercion(pet, vet).isDefined) {
           rw.dispatch(arg)
         } else if (
-          pet == TVoid[Pre]() || CoercionUtils.firstElementIsType(pet, vet) ||
+          vet == TVoid[Pre]() || pet == TVoid[Pre]() ||
+          CoercionUtils.firstElementIsType(pet, vet) ||
           CoercionUtils.firstElementIsType(vet, pet)
         ) {
           PointerCast(
@@ -1364,8 +1367,85 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
         val innerT = getInferredType(inner)
         innerT match {
           case LLVMTPointer(Some(innerPtrT)) => innerPtrT
+          case t: PointerType[Pre] => t.element
           case _ => e.t
         }
+      // All BinExprs that use getNumericType
+      case b @ AmbiguousMinus(l, r) =>
+        AmbiguousMinus(
+          DummyConstant(getInferredType(l)),
+          DummyConstant(getInferredType(r)),
+        )(b.blame)(b.o).t
+      case b @ AmbiguousMult(l, r) =>
+        AmbiguousMult(
+          DummyConstant(getInferredType(l)),
+          DummyConstant(getInferredType(r)),
+        )(b.o).t
+      case b @ AmbiguousPlus(l, r) =>
+        AmbiguousPlus(
+          DummyConstant(getInferredType(l)),
+          DummyConstant(getInferredType(r)),
+        )(b.blame)(b.o).t
+      case b @ BitShr(l, r, bits) =>
+        BitShr(
+          DummyConstant(getInferredType(l)),
+          DummyConstant(getInferredType(r)),
+          bits,
+        )(b.blame)(b.o).t
+      case b @ BitOr(l, r, bits, signed) =>
+        BitOr(
+          DummyConstant(getInferredType(l)),
+          DummyConstant(getInferredType(r)),
+          bits,
+          signed,
+        )(b.blame)(b.o).t
+      case b @ BitShl(l, r, bits, signed) =>
+        BitShl(
+          DummyConstant(getInferredType(l)),
+          DummyConstant(getInferredType(r)),
+          bits,
+          signed,
+        )(b.blame)(b.o).t
+      case b @ BitUShr(l, r, bits, signed) =>
+        BitUShr(
+          DummyConstant(getInferredType(l)),
+          DummyConstant(getInferredType(r)),
+          bits,
+          signed,
+        )(b.blame)(b.o).t
+      case b @ BitXor(l, r, bits, signed) =>
+        BitXor(
+          DummyConstant(getInferredType(l)),
+          DummyConstant(getInferredType(r)),
+          bits,
+          signed,
+        )(b.blame)(b.o).t
+      case b: NumericBinExpr[Pre] =>
+        BinOperatorTypes.getNumericType(
+          getInferredType(b.left),
+          getInferredType(b.right),
+          b.o,
+        )
+      case b @ SmtlibPow(l, r) =>
+        SmtlibPow(
+          DummyConstant(getInferredType(l)),
+          DummyConstant(getInferredType(r)),
+        )(b.o).t
+      case b @ AmbiguousComputationalAnd(l, r) =>
+        AmbiguousComputationalAnd(
+          DummyConstant(getInferredType(l)),
+          DummyConstant(getInferredType(r)),
+        )(b.o).t
+      case b @ AmbiguousComputationalOr(l, r) =>
+        AmbiguousComputationalOr(
+          DummyConstant(getInferredType(l)),
+          DummyConstant(getInferredType(r)),
+        )(b.o).t
+      case b @ AmbiguousComputationalXor(l, r) =>
+        AmbiguousComputationalXor(
+          DummyConstant(getInferredType(l)),
+          DummyConstant(getInferredType(r)),
+        )(b.o).t
       case _ => e.t
     }
 

--- a/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
@@ -7,11 +7,12 @@ import vct.col.origin._
 import vct.col.ref.{DirectRef, LazyRef, Ref}
 import vct.col.resolve.ctx.RefLLVMFunctionDefinition
 import vct.col.rewrite.{Generation, Rewritten}
+import vct.col.typerules.CoercionUtils
 import vct.col.util.AstBuildHelpers._
 import vct.col.util.{CurrentProgramContext, SubstituteReferences, SuccessionMap}
 import vct.result.VerificationError.{SystemError, Unreachable, UserError}
+import vct.rewrite.lang.LangSpecificToCol.InvalidPointerComparison
 
-import scala.:+
 import scala.collection.mutable
 
 case object LangLLVMToCol {
@@ -97,6 +98,19 @@ case object LangLLVMToCol {
 
     override def text: String =
       memset.o.messageInContext(s"Unsupported memset operation")
+  }
+
+  private final case class InvalidPointerEquality(
+      o: Origin,
+      lt: Type[_],
+      rt: Type[_],
+  ) extends UserError {
+    override def code: String = "invalidPointerEquality"
+
+    override def text: String =
+      o.messageInContext(
+        s"Expected types `$lt` and `$rt` to be interchangeable, there might be too little information for type inference"
+      )
   }
 
   private final case class UnreachableReached(
@@ -450,6 +464,15 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
 
     // TODO: This could be made more generic and also work with Assign nodes
     program.collect {
+      case Assign(target, value) =>
+        getVariable(target).foreach(v => {
+          val dependencies = findDependencies(value)
+          addTypeGuess(
+            v,
+            dependencies,
+            _ => replaceWithGuesses(value, dependencies).t,
+          )
+        })
       case func: LLVMFunctionDefinition[Pre] =>
         func.args.zipWithIndex.foreach { case (a, i) =>
           addTypeGuess(
@@ -692,65 +715,66 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
     }
   }
 
-  def rewriteAmbiguousFunctionInvocation(
-      inv: LLVMAmbiguousFunctionInvocation[Pre]
-  ): Invocation[Post] = {
-    implicit val o: Origin = inv.o
-    inv.ref.get.decl match {
-      case func: LLVMFunctionDefinition[Pre] =>
-        new ProcedureInvocation[Post](
-          ref = new LazyRef[Post, Procedure[Post]](llvmFunctionMap(func)),
-          args = inv.args.map(rw.dispatch),
-          givenMap = inv.givenMap.map { case (Ref(v), e) =>
-            (rw.succ(v), rw.dispatch(e))
-          },
-          yields = inv.yields.map { case (e, Ref(v)) =>
-            (rw.dispatch(e), rw.succ(v))
-          },
-          outArgs = Seq.empty,
-          typeArgs = Seq.empty,
-        )(inv.blame)
-      case func: LLVMSpecFunction[Pre] =>
-        new FunctionInvocation[Post](
-          ref = new LazyRef[Post, Function[Post]](specFunctionMap(func)),
-          args = inv.args.map(rw.dispatch),
-          givenMap = inv.givenMap.map { case (Ref(v), e) =>
-            (rw.succ(v), rw.dispatch(e))
-          },
-          yields = inv.yields.map { case (e, Ref(v)) =>
-            (rw.dispatch(e), rw.succ(v))
-          },
-          typeArgs = Seq.empty,
-        )(inv.blame)
-    }
-
-  }
-
   def rewriteFunctionInvocation(
       inv: LLVMFunctionInvocation[Pre]
   ): ProcedureInvocation[Post] = {
     implicit val o: Origin = inv.o
 
-    new ProcedureInvocation[Post](
-      ref = new LazyRef[Post, Procedure[Post]](llvmFunctionMap(inv.ref.decl)),
-      args = inv.args.zipWithIndex.map {
-        // TODO: This is really ugly, can we do the type inference in the resolve step and then do coercions to do this?
-        case (a, i) =>
-          val requiredType = localVariableInferredType
-            .getOrElse(inv.ref.decl.args(i), inv.ref.decl.args(i).t)
-          val givenType = getInferredType(a)
-          if (
-            givenType != requiredType && givenType.asPointer.isDefined &&
-            requiredType.asPointer.isDefined
+    def addCast(arg: Expr[Pre], v: Variable[Pre]): Expr[Post] = {
+      arg match {
+        case dp @ DerefPointer(p) => {
+          val pt = getInferredType(p)
+          val et = pt.asPointer.get.element
+          val vt = getLocalVarType(v)
+          if (CoercionUtils.getAnyCoercion(et, vt).isDefined) {
+            rw.dispatch(arg)
+          } else if (
+            et == TVoid[Pre]() || CoercionUtils.firstElementIsType(et, vt) ||
+            CoercionUtils.firstElementIsType(vt, et)
+          ) {
+            DerefPointer(
+              PointerCast(
+                rw.dispatch(arg),
+                TPointer(rw.dispatch(vt), None),
+                rw.c.sizeOf(et, p.o),
+                rw.c.sizeOf(vt, v.o),
+              )(dp.o)
+            )(dp.blame)(dp.o)
+          } else { throw InvalidPointerEquality(inv.o, vt, et) }
+        }
+        case _ if arg.t.asPointer.isDefined => {
+          val pt = getInferredType(arg)
+          val pet = pt.asPointer.get.element
+          val vt = getLocalVarType(v)
+          val vet = vt.asPointer.get.element
+          if (CoercionUtils.getAnyCoercion(pet, vet).isDefined) {
+            rw.dispatch(arg)
+          } else if (
+            pet == TVoid[Pre]() || CoercionUtils.firstElementIsType(pet, vet) ||
+            CoercionUtils.firstElementIsType(vet, pet)
           ) {
             PointerCast(
-              rw.dispatch(a),
-              rw.dispatch(requiredType),
-              rw.c.sizeOf(givenType.asPointer.get.element, inv.o),
-              rw.c.sizeOf(requiredType.asPointer.get.element, inv.o),
-            )
-          } else { rw.dispatch(a) }
-      },
+              rw.dispatch(arg),
+              rw.dispatch(vt),
+              rw.c.sizeOf(pet, arg.o),
+              rw.c.sizeOf(vet, v.o),
+            )(arg.o)
+          } else { throw InvalidPointerEquality(inv.o, vet, pet) }
+        }
+        case _ => rw.dispatch(arg)
+      }
+    }
+
+    val given = inv.givenMap.map { case (Ref(v), e) =>
+      (rw.succ[Variable[Post]](v), addCast(e, v))
+    }
+    val yields = inv.yields.map { case (e, Ref(v)) =>
+      (addCast(e, v), rw.succ[Variable[Post]](v))
+    }
+
+    new ProcedureInvocation[Post](
+      ref = new LazyRef[Post, Procedure[Post]](llvmFunctionMap(inv.ref.decl)),
+      args = inv.args.zip(inv.ref.decl.args).map(p => addCast(p._1, p._2)),
       givenMap = inv.givenMap.map { case (Ref(v), e) =>
         (rw.succ(v), rw.dispatch(e))
       },
@@ -816,7 +840,10 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
         t.packed,
         rw.c.sizeOf(t, t.o),
         elements.collect { t => rw.c.sizeOf(t, t.o) },
-      )(t.o.withContent(TypeName("struct")))
+      )(
+        t.o.withContent(TypeName("struct"))
+          .where(name = name.getOrElse("unknown"))
+      )
 
     rw.globalDeclarations.declare(newStruct)
     structMap(t) = newStruct
@@ -1578,6 +1605,50 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
     requireInWrapper(llvmOld)
     implicit val o: Origin = llvmOld.o
     LLVMOld[Post](rw.succ(llvmOld.v.decl))
+  }
+
+  def correctPointerComparison[T <: Expr[Post]](
+      left: Expr[Pre],
+      right: Expr[Pre],
+      op: (Expr[Post], Expr[Post], Option[Expr[Post]]) => T,
+  )(implicit o: Origin): T = {
+    val lt = getInferredType(left)
+    val rt = getInferredType(right)
+    val nl = rw.dispatch(left)
+    val nr = rw.dispatch(right)
+
+    def cast(e: Expr[Post], fromType: Type[Pre], toType: Type[Pre]) =
+      PointerCast(
+        e,
+        TPointer(rw.dispatch(toType), None),
+        rw.c.sizeOf(fromType, o),
+        rw.c.sizeOf(toType, o),
+      )
+
+    (lt, rt) match {
+      case (l, r) if l == r =>
+        op(nl, nr, l.asPointer.map(p => rw.c.sizeOf(p.element, o)))
+      case (LLVMTPointer(None), LLVMTPointer(None)) =>
+        op(nl, nr, Some(rw.c.sizeOf(TAnyValue(), o)))
+      case (LLVMTPointer(Some(lt)), LLVMTPointer(None)) =>
+        op(nl, cast(nr, TAnyValue(), lt), Some(rw.c.sizeOf(lt, o)))
+      case (LLVMTPointer(None), LLVMTPointer(Some(rt))) =>
+        op(cast(nl, TAnyValue(), rt), nr, Some(rw.c.sizeOf(rt, o)))
+      case (LLVMTPointer(Some(lt)), LLVMTPointer(Some(rt))) =>
+        if (CoercionUtils.firstElementIsType(lt, rt)) {
+          op(nl, cast(nr, rt, lt), Some(rw.c.sizeOf(lt, o)))
+        } else if (CoercionUtils.firstElementIsType(rt, lt)) {
+          op(cast(nl, lt, rt), nr, Some(rw.c.sizeOf(rt, o)))
+        } else { throw InvalidPointerEquality(o, lt, rt) }
+      case (l, r) if l.asPointer.isDefined && r.asPointer.isDefined =>
+        if (
+          CoercionUtils
+            .getAnyCoercion(l.asPointer.get.element, r.asPointer.get.element)
+            .isDefined
+        ) { op(nl, nr, Some(rw.c.sizeOf(l.asPointer.get.element, o))) }
+        else { throw InvalidPointerComparison(o) }
+      case (_, _) => op(nl, nr, None)
+    }
   }
 
   def result(ref: RefLLVMFunctionDefinition[Pre])(

--- a/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
@@ -464,7 +464,9 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
 
     // TODO: This could be made more generic and also work with Assign nodes
     program.collect {
-      case Assign(target, value) =>
+      case Assign(target, value)
+          if target.t.isInstanceOf[LLVMTPointer[Pre]] ||
+            value.t.isInstanceOf[LLVMTPointer[Pre]] =>
         getVariable(target).foreach(v => {
           val dependencies = findDependencies(value)
           addTypeGuess(

--- a/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
@@ -193,6 +193,8 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
   // are assigned using store-instructions.
   private val assignedInLoop: ScopedStack[mutable.Set[Variable[Pre]]] =
     ScopedStack()
+  private val usedInLoop: ScopedStack[mutable.Set[Variable[Pre]]] =
+    ScopedStack()
 
   // Initializer-functions for the tuples that are returned by the llvm intrinsics
   // for arithmetic operaitons with overflows.
@@ -708,9 +710,7 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
         implicit val o: Origin = pallasResArgPermOrigin
         c.rewrite(contextEverywhere =
           (PointerNeq(Local(arg), Null(), const(0))) &* Perm(
-            AmbiguousLocation(DerefPointer(Local(arg))(LLVMSretPerm))(
-              LLVMSretPerm
-            ),
+            AmbiguousLocation(DerefPointer(Local(arg))(LLVMSretPerm)),
             WritePerm[Post](),
           ) &* rw.dispatch(c.contextEverywhere)
         )
@@ -1651,7 +1651,7 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
     implicit val o: Origin = llvmPerm.o
     val locExpr = Local[Post](rw.succ(llvmPerm.loc.decl))
     Perm[Post](
-      PointerLocation[Post](locExpr)(llvmPerm.blame),
+      AmbiguousLocation[Post](DerefPointer(locExpr)(llvmPerm.blame)),
       Local[Post](rw.succ(llvmPerm.perm.decl)),
     )
   }
@@ -1859,9 +1859,11 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
       loopBlocks.addAll(loop.blocks.get)
       // Determine which variables are assigned using store-instructions
       val assignedVars = mutable.Set[Variable[Pre]]()
+      val usedVars = mutable.Set[Variable[Pre]]()
       loop.blocks.getOrElse(mutable.Set.empty).foreach { b =>
-        b.body.collect { case LLVMStore(_, Local(Ref(v)), _) =>
-          assignedVars.add(v)
+        b.body.collect {
+          case LLVMStore(_, Local(Ref(v)), _) => assignedVars.add(v)
+          case Local(Ref(v)) => usedVars.add(v)
         }
       }
       Label(
@@ -1870,7 +1872,9 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
           Block(Nil)(block.o),
           tt[Post],
           Block(Nil)(block.o),
-          assignedInLoop.having(assignedVars) { rw.dispatch(loop.contract) },
+          assignedInLoop.having(assignedVars) {
+            usedInLoop.having(usedVars) { rw.dispatch(loop.contract) }
+          },
           Block(
             blockToLabel(loop.headerBlock.get) +: loop.blocks.get.filterNot {
               b => b == loop.headerBlock.get || b == loop.latchBlock.get
@@ -1889,20 +1893,23 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
     implicit val o: Origin = llvmContract.o
     // Add Permission for alloca-variables
     var extendedInv = rw.dispatch(llvmContract.invariant)
-    allocaVars.topOption.getOrElse(mutable.Set.empty).foreach { v =>
-      // If the variable is assigned to, assert write-perm, otherwise read perm
-      val perm =
-        if (assignedInLoop.topOption.getOrElse(mutable.Set.empty).contains(v)) {
-          WritePerm[Post]()
-        } else { ReadPerm[Post]() }
-      extendedInv =
-        Perm(
-          PointerLocation[Post](Local(rw.succ(v)))(PanicBlame(
-            "Generated locals always have permission"
-          )),
-          perm,
-        ) &* extendedInv
-    }
+    allocaVars.topOption.getOrElse(mutable.Set.empty)
+      .intersect(usedInLoop.topOption.getOrElse(mutable.Set.empty))
+      .foreach { v =>
+        // If the variable is assigned to, assert write-perm, otherwise read perm
+        val perm =
+          if (
+            assignedInLoop.topOption.getOrElse(mutable.Set.empty).contains(v)
+          ) { WritePerm[Post]() }
+          else { ReadPerm[Post]() }
+        extendedInv =
+          Perm(
+            AmbiguousLocation[Post](DerefPointer(Local[Post](rw.succ(v)))(
+              PanicBlame("Generated locals always have permission")
+            )),
+            perm,
+          ) &* extendedInv
+      }
     LoopInvariant[Post](extendedInv, None)(llvmContract.blame)
   }
 

--- a/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
@@ -717,7 +717,9 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
     }
   }
 
-  private def addCast(arg: Expr[Pre], v: Variable[Pre]): Expr[Post] = {
+  private def addCast(arg: Expr[Pre], v: Variable[Pre])(
+      implicit o: Origin
+  ): Expr[Post] = {
     arg match {
       case dp @ DerefPointer(p) => {
         val pt = getInferredType(p)
@@ -736,7 +738,7 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
               rw.c.sizeOf(vt, v.o),
             )(dp.o)
           )(dp.blame)(dp.o)
-        } else { throw InvalidPointerEquality(inv.o, vt, et) }
+        } else { throw InvalidPointerEquality(o, vt, et) }
       }
       case _ if arg.t.asPointer.isDefined => {
         val pt = getInferredType(arg)
@@ -755,7 +757,7 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
             rw.c.sizeOf(pet, arg.o),
             rw.c.sizeOf(vet, v.o),
           )(arg.o)
-        } else { throw InvalidPointerEquality(inv.o, vet, pet) }
+        } else { throw InvalidPointerEquality(o, vet, pet) }
       }
       case _ => rw.dispatch(arg)
     }

--- a/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangLLVMToCol.scala
@@ -460,10 +460,12 @@ case class LangLLVMToCol[Pre <: Generation](rw: LangSpecificToCol[Pre])
         obj: Object,
         dependencies: Set[Object],
         inferType: Unit => Type[Pre],
-    ): Unit =
+    ): Unit = {
+      val inferred = inferType()
       typeGuesses
         .getOrElseUpdate(obj, new TypeGuess(currentType = inferType(())))
         .add(dependencies, inferType)
+    }
 
     // TODO: This could be made more generic and also work with Assign nodes
     program.collect {

--- a/src/rewrite/vct/rewrite/lang/LangSpecificToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangSpecificToCol.scala
@@ -453,6 +453,8 @@ case class LangSpecificToCol[Pre <: Generation](
         silver.adtInvocation(inv)
       case map: SilverUntypedNonemptyLiteralMap[Pre] => silver.nonemptyMap(map)
 
+      case inv: LLVMAmbiguousFunctionInvocation[Pre] =>
+        llvm.rewriteAmbiguousFunctionInvocation(inv)
       case inv: LLVMFunctionInvocation[Pre] =>
         llvm.rewriteFunctionInvocation(inv)
       case local: LLVMLocal[Pre] => llvm.rewriteLocal(local)

--- a/src/rewrite/vct/rewrite/lang/LangSpecificToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangSpecificToCol.scala
@@ -333,7 +333,7 @@ case class LangSpecificToCol[Pre <: Generation](
       case goto: CGoto[Pre] => c.rewriteGoto(goto)
       case barrier: GpgpuBarrier[Pre] => c.gpuBarrier(barrier)
       case atomic: GpgpuAtomic[Pre] => c.gpuAtomic(atomic)
-      
+
       case eval @ Eval(CPPInvocation(_, _, _, _)) =>
         cpp.invocationStatement(eval)
 
@@ -475,6 +475,8 @@ case class LangSpecificToCol[Pre <: Generation](
       case zext: LLVMZeroExtend[Pre] => llvm.rewriteZeroExtend(zext)
       case trunc: LLVMTruncate[Pre] => llvm.rewriteTruncate(trunc)
       case fpext: LLVMFloatExtend[Pre] => llvm.rewriteFloatExtend(fpext)
+      case cast: LLVMIntegerPointerCast[Pre] =>
+        llvm.rewriteIntegerPointerCast(cast)
       case result: LLVMResult[Pre] => llvm.rewriteResult(result)
       case llvmPerm: LLVMPerm[Pre] => llvm.rewritePerm(llvmPerm)
       case llvmPBL: LLVMPtrBlockLength[Pre] =>

--- a/src/rewrite/vct/rewrite/lang/LangSpecificToCol.scala
+++ b/src/rewrite/vct/rewrite/lang/LangSpecificToCol.scala
@@ -49,18 +49,6 @@ case object LangSpecificToCol extends RewriterBuilderArg[Boolean] {
       )
   }
 
-  private case class IncompatibleBitVectorSize(
-      op: Expr[_],
-      l: BigInt,
-      r: BigInt,
-  ) extends UserError {
-    override def code: String = "incompatibleBVSize"
-    override def text: String =
-      op.o.messageInContext(
-        s"The sizes of the operands for this bitwise operation are `$l` and `$r` respectively. Only operations on equal sizes are supported"
-      )
-  }
-
   private case class IndeterminableBitVectorSign(op: Expr[_])
       extends UserError {
     override def code: String = "unknownBVSign"
@@ -93,6 +81,13 @@ case object LangSpecificToCol extends RewriterBuilderArg[Boolean] {
     override def text: String =
       op.o.messageInContext(
         "It is not possible to perform an arithmetic right-shift on an unsigned value"
+      )
+  }
+  case class InvalidPointerComparison(cmp: Origin) extends UserError {
+    override def code: String = "incompatiblePointerComparison"
+    override def text: String =
+      cmp.messageInContext(
+        "Comparison between pointers of different types is not supported"
       )
   }
 }
@@ -460,8 +455,6 @@ case class LangSpecificToCol[Pre <: Generation](
 
       case inv: LLVMFunctionInvocation[Pre] =>
         llvm.rewriteFunctionInvocation(inv)
-      case inv: LLVMAmbiguousFunctionInvocation[Pre] =>
-        llvm.rewriteAmbiguousFunctionInvocation(inv)
       case local: LLVMLocal[Pre] => llvm.rewriteLocal(local)
       case pointer: LLVMFunctionPointerValue[Pre] =>
         llvm.rewriteFunctionPointer(pointer)
@@ -489,6 +482,24 @@ case class LangSpecificToCol[Pre <: Generation](
       case llvmOr: LLVMOr[Pre] => llvm.rewriteOr(llvmOr)
       case llvmStar: LLVMStar[Pre] => llvm.rewriteStar(llvmStar)
       case llvmOld: LLVMOld[Pre] => llvm.rewriteOld(llvmOld)
+      case eq: AmbiguousEq[Pre] =>
+        llvm.correctPointerComparison(
+          eq.left,
+          eq.right,
+          AmbiguousEq(_, _, dispatch(eq.vectorInnerType), _)(e.o),
+        )(e.o)
+      case neq: AmbiguousNeq[Pre] =>
+        llvm.correctPointerComparison(
+          neq.left,
+          neq.right,
+          AmbiguousNeq(_, _, dispatch(neq.vectorInnerType), _)(e.o),
+        )(e.o)
+      case sel: Select[Pre] =>
+        llvm.correctPointerComparison(
+          sel.whenTrue,
+          sel.whenFalse,
+          (l, r, _) => Select(dispatch(sel.condition), l, r)(e.o),
+        )(e.o)
       case b @ BitAnd(left, right, 0, true) =>
         BitAnd(
           dispatch(left),

--- a/src/viper/viper/api/transform/SilverToCol.scala
+++ b/src/viper/viper/api/transform/SilverToCol.scala
@@ -422,10 +422,7 @@ case class SilverToCol[G](
         else
           col.BagAdd(f(left), f(right))
       case silver.CondExp(cond, thn, els) => col.Select(f(cond), f(thn), f(els))
-      case silver.CurrentPerm(res) =>
-        col.CurPerm(col.AmbiguousLocation(f(res))(
-          vct.col.origin.PanicBlame("Silver does not have pointers.")
-        ))
+      case silver.CurrentPerm(res) => col.CurPerm(col.AmbiguousLocation(f(res)))
       case silver.Div(left, right) => col.FloorDiv(f(left), f(right))(blame(e))
       case silver.DomainFuncApp(funcname, args, typVarMap) =>
         col.SilverPartialADTFunctionInvocation(
@@ -558,7 +555,7 @@ case class SilverToCol[G](
       case silver.ForPerm(variables, resource, body) =>
         col.ForPerm(
           variables.map(transform),
-          col.AmbiguousLocation(f(resource))(blame(resource)),
+          col.AmbiguousLocation(f(resource)),
           f(body),
         )
       case silver.EpsilonPerm() => ??(e)

--- a/test/main/vct/test/integration/examples/LLVMSpec.scala
+++ b/test/main/vct/test/integration/examples/LLVMSpec.scala
@@ -11,6 +11,7 @@ class LLVMSpec extends VercorsSpec {
   vercors should verify using silicon example "concepts/llvm/fib.ll"
   vercors should verify using silicon example "concepts/llvm/cubed.c"
   vercors should verify using silicon example "concepts/llvm/pointer_relations.ll"
+  vercors should verify using silicon example "concepts/llvm/pointer_casts.ll"
   vercors should verify using silicon flags("--contract-import-file", "examples/concepts/llvm/cubed-contracts.pvl") example "concepts/llvm/cubed.ll"
   vercors should verify using silicon flags("--contract-import-file", "examples/concepts/llvm/void-contracts.pvl") example "concepts/llvm/void.ll"
   vercors should fail withCode "unreachable" using silicon in "reaching an 'unreachable' statement" llvm

--- a/test/main/vct/test/integration/examples/LLVMSpec.scala
+++ b/test/main/vct/test/integration/examples/LLVMSpec.scala
@@ -10,6 +10,7 @@ class LLVMSpec extends VercorsSpec {
   vercors should verify using silicon example "concepts/llvm/fib.c"
   vercors should verify using silicon example "concepts/llvm/fib.ll"
   vercors should verify using silicon example "concepts/llvm/cubed.c"
+  vercors should verify using silicon example "concepts/llvm/pointer_relations.ll"
   vercors should verify using silicon flags("--contract-import-file", "examples/concepts/llvm/cubed-contracts.pvl") example "concepts/llvm/cubed.ll"
   vercors should verify using silicon flags("--contract-import-file", "examples/concepts/llvm/void-contracts.pvl") example "concepts/llvm/void.ll"
   vercors should fail withCode "unreachable" using silicon in "reaching an 'unreachable' statement" llvm

--- a/test/main/vct/test/integration/helper/ExampleFiles.scala
+++ b/test/main/vct/test/integration/helper/ExampleFiles.scala
@@ -55,6 +55,7 @@ case object ExampleFiles {
     "examples/concepts/llvm/pallas/pallas_swift_assert.swift",
     "examples/concepts/llvm/pallas/pallas_c_loop_unused.c",
     "examples/concepts/llvm/pallas/pallas_c_assume.c",
+    "examples/concepts/llvm/pointer_casts.c"
   ).map(_.replaceAll("/", File.separator))
 
   val EXCLUSIONS: Seq[Path => Boolean] = Seq(

--- a/util/githooks/pre-commit
+++ b/util/githooks/pre-commit
@@ -14,10 +14,22 @@ then
     elif command -v clang-format-16 > /dev/null 2>&1
     then
         CLANG_FMT=clang-format-16
-
     elif command -v clang-format-15 > /dev/null 2>&1
     then
         CLANG_FMT=clang-format-15
+    fi
+    if command -v git-clang-format > /dev/null 2>&1
+    then
+        GIT_CLANG_FMT=git-clang-format
+    elif command -v git-clang-format-17 > /dev/null 2>&1
+    then
+        GIT_CLANG_FMT=git-clang-format-17
+    elif command -v git-clang-format-16 > /dev/null 2>&1
+    then
+        GIT_CLANG_FMT=git-clang-format-16
+    elif command -v git-clang-format-15 > /dev/null 2>&1
+    then
+        GIT_CLANG_FMT=git-clang-format-15
     fi
 fi
 
@@ -25,6 +37,14 @@ if [ -z "$CLANG_FMT" ]
 then
     echo "[WARN] clang-format was not found so the cpp sources could not be formatted"
     echo "[NOTE] you can set the CLANG_FMT environment variable to specify the clang-format executable that should be used if the one you want to use isn't automatically detected"
+else
+    if [ -z "$GIT_CLANG_FMT" ]
+    then
+        echo "[WARN] git-clang-format was not found, you may have to manually invoke git add after running this script to commit the formatted files"
+        find src -regex '.*\.\(h\|cpp\)' -print0 | xargs -0 $CLANG_FMT -i
+    else
+        "$GIT_CLANG_FMT" --extensions h,cpp --binary "$CLANG_FMT"
+    fi
 fi
-find src -regex '.*\.\(h\|cpp\)' -print0 | xargs -0 $CLANG_FMT -i
+
 echo "=== end of pre-commit tasks ==="


### PR DESCRIPTION
Checklist: 

- [ ] The wiki is updated in accordance with the changes in this PR. For example: syntax changes, semantics changes, VerCors flags changes, etc.

# PR description
- Add support for `ptrtoint` and `inttoptr` instructions
- Move C++ build to CMake with Ninja
  - This enables parallel compilation of the C++ code (currently limited to 8 threads because with too many threads I kept running out of memory)
  - This adds a new required tool for compilation, i.e. Ninja
  - This allows easy use of compilation caches like sccache (just add environment variables `CMAKE_C_COMPILER_LAUNCHER=sccache` and `CMAKE_CXX_COMPILER_LAUNCHER=sccache`)
- Improved clang-format githook such that it automatically adds the formatted files to the commit
- Enabled generation of `compile_commands.json` file which can be used by clangd (the included `.clangd` file points it to the right location)
- Add parsing for the memcpy instruction
- Add struct consolidation pass (`pallas-consolidate-structs`) which attempts to merge function arguments into a struct to work around compiler frontends splitting up small structs across multiple function arguments
