### PR TITLE
Update Viper

### DIFF
--- a/.github/workflows/scalatest.yml
+++ b/.github/workflows/scalatest.yml
@@ -77,7 +77,7 @@ jobs:
       - name: ls
         run: ls
       - name: Run scalatest
-        run: java -Xss64m -cp "out.jar;res/universal/deps;res/universal/res" org.scalatest.tools.Runner -o -u report -s vct.test.integration.examples.BasicExamplesSpec
+        run: java -Xss128m -cp "out.jar;res/universal/deps;res/universal/res" org.scalatest.tools.Runner -o -u report -s vct.test.integration.examples.BasicExamplesSpec
       - name: Upload test reports
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -104,7 +104,7 @@ jobs:
       - name: ls
         run: ls
       - name: Run scalatest
-        run: java -Xss64m -cp out.jar:res/universal/deps:res/universal/res org.scalatest.tools.Runner -o -u report -s vct.test.integration.examples.BasicExamplesSpec
+        run: java -Xss128m -cp out.jar:res/universal/deps:res/universal/res org.scalatest.tools.Runner -o -u report -s vct.test.integration.examples.BasicExamplesSpec
       - name: Upload test reports
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -141,7 +141,7 @@ jobs:
       - name: ls
         run: ls -lasFhR
       - name: Run scalatest
-        run: java -Xss64m -Xmx2G -cp out.jar:res/universal/deps:res/universal/res:. org.scalatest.tools.Runner -R out.jar -o -u report -w vct ${{matrix.batch}}
+        run: java -Xss128m -Xmx2G -cp out.jar:res/universal/deps:res/universal/res:. org.scalatest.tools.Runner -R out.jar -o -u report -w vct ${{matrix.batch}}
       - name: Upload test reports
         if: success() || failure()
         uses: actions/upload-artifact@v4

--- a/bin/testSuite
+++ b/bin/testSuite
@@ -2,4 +2,4 @@
 set -e
 ROOT="$(dirname "$(dirname "$(readlink -f $0)")")"
 (cd "$ROOT"; ./mill -j 0 vercors.allTests.runScript)
-"$ROOT/out/vercors/allTests/runScript.dest/testSuite" -o "$@"
+"$ROOT/out/vercors/allTests/runScript.dest/testSuite" -oDF "$@"

--- a/build.sc
+++ b/build.sc
@@ -41,7 +41,7 @@ object external extends Module {
 object viper extends ScalaModule {
   object silverGit extends GitModule {
     def url = T { "https://github.com/viperproject/silver.git" }
-    def commitish = T { "e61ca81bd46612a5e126c40b757fe27966965b7e" }
+    def commitish = T { "e7ce7757caff264b17e54f5c4fecedc77862c9ad" }
     def filteredRepo = T {
       val workspace = repo()
       os.remove.all(workspace / "src" / "test")
@@ -51,7 +51,7 @@ object viper extends ScalaModule {
 
   object siliconGit extends GitModule {
     def url = T { "https://github.com/viperproject/silicon.git" }
-    def commitish = T { "3e24b7a87a1b2d7af95a96edf8af5d207465672b" }
+    def commitish = T { "2af1a000401a30ddc80eb482111df6662c4e49d3" }
     def filteredRepo = T {
       val workspace = repo()
       os.remove.all(workspace / "src" / "test")

--- a/build.sc
+++ b/build.sc
@@ -41,7 +41,7 @@ object external extends Module {
 object viper extends ScalaModule {
   object silverGit extends GitModule {
     def url = T { "https://github.com/viperproject/silver.git" }
-    def commitish = T { "52953937ac318914e9e88f0103fdcea7072b985f" }
+    def commitish = T { "e61ca81bd46612a5e126c40b757fe27966965b7e" }
     def filteredRepo = T {
       val workspace = repo()
       os.remove.all(workspace / "src" / "test")
@@ -51,7 +51,7 @@ object viper extends ScalaModule {
 
   object siliconGit extends GitModule {
     def url = T { "https://github.com/viperproject/silicon.git" }
-    def commitish = T { "19bbbb524c4d2555abdbde68870a52f5abec49b4" }
+    def commitish = T { "3e24b7a87a1b2d7af95a96edf8af5d207465672b" }
     def filteredRepo = T {
       val workspace = repo()
       os.remove.all(workspace / "src" / "test")
@@ -62,7 +62,7 @@ object viper extends ScalaModule {
 
   object carbonGit extends GitModule {
     def url = T { "https://github.com/viperproject/carbon.git" }
-    def commitish = T { "e6d2393f85b5d8b53639b0f22e59c84004379ee7" }
+    def commitish = T { "7c5c1df49844ce2cd27d42d4d95859bbc3ad0142" }
     def filteredRepo = T {
       val workspace = repo()
       os.remove.all(workspace / "src" / "test")

--- a/examples/publications/2020/permutations/timsort1.pvl
+++ b/examples/publications/2020/permutations/timsort1.pvl
@@ -11,8 +11,8 @@ requires start >= 0 && start < size;
 requires end >= 0 && end < size;
 requires start <= end;
 context (\forall* int i; i >= 0 && i < size; Perm(input[i], write));
-requires (\forall int i; 0 <= i && i < size; input[i] == inp_seq[i]);
-ensures (\forall int i; 0 <= i && i < size; input[i] == out_seq[i]);
+requires (\forall int i; 0 <= i && i < size; input[i] == {:inp_seq[i]:});
+ensures (\forall int i; 0 <= i && i < size; input[i] == {:out_seq[i]:});
 requires isPermutation<int>(orig_seq, inp_seq);
 ensures isPermutation<int>(orig_seq, out_seq);
 void insertion(int[] input, int size, int start, int end, seq<int> inp_seq){
@@ -27,7 +27,7 @@ void insertion(int[] input, int size, int start, int end, seq<int> inp_seq){
     loop_invariant outerLoop >= start+1 && outerLoop <= end+1;
     loop_invariant (\forall* int i; i >= 0 && i < size; Perm(input[i], write));
     loop_invariant |out_seq| == size;
-    loop_invariant (\forall int i; 0 <= i && i < size; input[i] == out_seq[i]);
+    loop_invariant (\forall int i; 0 <= i && i < size; input[i] == {:out_seq[i]:});
     loop_invariant isPermutation<int>(orig_seq, out_seq);
     while(outerLoop < end+1){
         innerLoop = outerLoop;
@@ -39,7 +39,7 @@ void insertion(int[] input, int size, int start, int end, seq<int> inp_seq){
         loop_invariant innerLoop >= start && innerLoop <= outerLoop;
         loop_invariant (\forall* int i; i >= 0 && i < size; Perm(input[i], write));
         loop_invariant |out_seq| == size;
-        loop_invariant (\forall int i; 0 <= i && i < size; input[i] == out_seq[i]);
+        loop_invariant (\forall int i; 0 <= i && i < size; input[i] == {:out_seq[i]:});
         loop_invariant isPermutation<int>(orig_seq, out_seq);
         while(innerLoop > start && input[innerLoop-1] > input[innerLoop]){
             lemma_permutation_apply<int>(orig_seq, out_seq, innerLoop-1, innerLoop);
@@ -78,8 +78,8 @@ context |inp_seq| == size;
 requires |orig_seq| == size;
 ensures |out_seq| == size;
 context (\forall* int k; k >= 0 && k < size; Perm(input[k], write));
-requires (\forall int k; 0 <= k && k < size; input[k] == inp_seq[k]);
-ensures (\forall int k; 0 <= k && k < size; input[k] == out_seq[k]);
+requires (\forall int k; 0 <= k && k < size; input[k] == {:inp_seq[k]:});
+ensures (\forall int k; 0 <= k && k < size; input[k] == {:out_seq[k]:});
 requires isPermutation<int>(orig_seq, inp_seq);
 ensures isPermutation<int>(orig_seq, out_seq);
 void Tomerge(int[] input, int size, int start, int mid, int end, seq<int> inp_seq)
@@ -102,7 +102,7 @@ void Tomerge(int[] input, int size, int start, int mid, int end, seq<int> inp_se
     loop_invariant mid <= end;
     loop_invariant start2 > mid && start2 <= end+1;
     loop_invariant (\forall* int k; k >= 0 && k < size; Perm(input[k], write));
-    loop_invariant (\forall int k; 0 <= k && k < size; input[k] == out_seq[k]);
+    loop_invariant (\forall int k; 0 <= k && k < size; input[k] == {:out_seq[k]:});
     loop_invariant isPermutation<int>(orig_seq, out_seq);
     while (start <= mid && start2 <= end) {
 
@@ -124,7 +124,7 @@ void Tomerge(int[] input, int size, int start, int mid, int end, seq<int> inp_se
             loop_invariant start2 > mid && start2 <= end;
             loop_invariant index <= start2 && index >= start;
             loop_invariant (\forall* int k; k >= 0 && k < size; Perm(input[k], write));
-            loop_invariant (\forall int k; 0 <= k && k < size; input[k] == out_seq[k]);
+            loop_invariant (\forall int k; 0 <= k && k < size; input[k] == {:out_seq[k]:});
             loop_invariant isPermutation<int>(orig_seq, out_seq);
             while (index != start) {
                 //input[index] = input[index - 1];
@@ -156,8 +156,8 @@ context_everywhere size > 0;
 context |inp_seq| == size;
 ensures |out_seq| == size;
 context (\forall* int i; i >= 0 && i < size; Perm(input[i], write));
-requires (\forall int i; 0 <= i && i < size; input[i] == inp_seq[i]);
-ensures (\forall int i; 0 <= i && i < size; input[i] == out_seq[i]);
+requires (\forall int i; 0 <= i && i < size; input[i] == {:inp_seq[i]:});
+ensures (\forall int i; 0 <= i && i < size; input[i] == {:out_seq[i]:});
 ensures isPermutation<int>(inp_seq, out_seq);
 void timSort(int[] input, int size, seq<int> inp_seq)
 {
@@ -170,7 +170,7 @@ void timSort(int[] input, int size, seq<int> inp_seq)
     loop_invariant loopCounter >= 0 && loopCounter < size + RUN;
     loop_invariant (\forall* int i; i >= 0 && i < size; Perm(input[i], write));
     loop_invariant |out_seq| == size;
-    loop_invariant (\forall int i; 0 <= i && i < size; input[i] == out_seq[i]);
+    loop_invariant (\forall int i; 0 <= i && i < size; input[i] == {:out_seq[i]:});
     loop_invariant isPermutation<int>(inp_seq, out_seq);
     //for (int i = 0; i < size; i+=RUN){
     while(loopCounter < size)
@@ -194,7 +194,7 @@ void timSort(int[] input, int size, seq<int> inp_seq)
     loop_invariant chunk >= RUN && chunk < size + chunk;
     loop_invariant (\forall* int i; i >= 0 && i < size; Perm(input[i], write));
     loop_invariant |out_seq| == size;
-    loop_invariant (\forall int i; 0 <= i && i < size; input[i] == out_seq[i]);
+    loop_invariant (\forall int i; 0 <= i && i < size; input[i] == {:out_seq[i]:});
     loop_invariant isPermutation<int>(inp_seq, out_seq);
     while(chunk < size)
     {
@@ -208,7 +208,7 @@ void timSort(int[] input, int size, seq<int> inp_seq)
         loop_invariant chunk < size;
         loop_invariant (\forall* int i; i >= 0 && i < size; Perm(input[i], write));
         loop_invariant |out_seq| == size;
-        loop_invariant (\forall int i; 0 <= i && i < size; input[i] == out_seq[i]);
+        loop_invariant (\forall int i; 0 <= i && i < size; input[i] == {:out_seq[i]:});
         loop_invariant isPermutation<int>(inp_seq, out_seq);
         while(left < size)
         {

--- a/examples/publications/2020/permutations/timsort2.pvl
+++ b/examples/publications/2020/permutations/timsort2.pvl
@@ -11,8 +11,8 @@ requires start >= 0 && start < size;
 requires end >= 0 && end < size;
 requires start <= end;
 context (\forall* int i; i >= 0 && i < size; Perm(input[i], write));
-requires (\forall int i; 0 <= i && i < size; input[i] == inp_seq[i]);
-ensures (\forall int i; 0 <= i && i < size; input[i] == out_seq[i]);
+requires (\forall int i; 0 <= i && i < size; input[i] == {:inp_seq[i]:});
+ensures (\forall int i; 0 <= i && i < size; input[i] == {:out_seq[i]:});
 requires isPermutation<int>(orig_seq, inp_seq);
 ensures isPermutation<int>(orig_seq, out_seq);
 void insertion(int[] input, int size, int start, int end, seq<int> inp_seq){
@@ -28,7 +28,7 @@ void insertion(int[] input, int size, int start, int end, seq<int> inp_seq){
     loop_invariant outerLoop >= start+1 && outerLoop <= end+1;
     loop_invariant (\forall* int i; i >= 0 && i < size; Perm(input[i], write));
     loop_invariant |out_seq| == size;
-    loop_invariant (\forall int i; 0 <= i && i < size; input[i] == out_seq[i]);
+    loop_invariant (\forall int i; 0 <= i && i < size; input[i] == {:out_seq[i]:});
     loop_invariant isPermutation<int>(orig_seq, out_seq);
     while(outerLoop < end+1){
         innerLoop = outerLoop;
@@ -40,7 +40,7 @@ void insertion(int[] input, int size, int start, int end, seq<int> inp_seq){
         loop_invariant innerLoop >= start && innerLoop <= outerLoop;
         loop_invariant (\forall* int i; i >= 0 && i < size; Perm(input[i], write));
         loop_invariant |out_seq| == size;
-        loop_invariant (\forall int i; 0 <= i && i < size; input[i] == out_seq[i]);
+        loop_invariant (\forall int i; 0 <= i && i < size; input[i] == {:out_seq[i]:});
         loop_invariant isPermutation<int>(orig_seq, out_seq);
         while(innerLoop > start && input[innerLoop-1] > input[innerLoop]){
             lemma_permutation_apply<int>(orig_seq, out_seq, innerLoop-1, innerLoop);
@@ -77,8 +77,8 @@ context |inp_seq| == size;
 requires |orig_seq| == size;
 ensures |out_seq| == size;
 context (\forall* int k; k >= 0 && k < size; Perm(input[k], write));
-requires (\forall int k; 0 <= k && k < size; input[k] == inp_seq[k]);
-ensures (\forall int k; 0 <= k && k < size; input[k] == out_seq[k]);
+requires (\forall int k; 0 <= k && k < size; input[k] == {:inp_seq[k]:});
+ensures (\forall int k; 0 <= k && k < size; input[k] == {:out_seq[k]:});
 requires isPermutation<int>(orig_seq, inp_seq);
 ensures isPermutation<int>(orig_seq, out_seq);
 void Tomerge(int[] input, int size, int start, int mid, int end, seq<int> inp_seq)
@@ -107,7 +107,7 @@ void Tomerge(int[] input, int size, int start, int mid, int end, seq<int> inp_se
     loop_invariant start <= end;
     loop_invariant right - mid +1== mid - left;
     loop_invariant (\forall* int k; k >= 0 && k < size; Perm(input[k], write));
-    loop_invariant (\forall int k; 0 <= k && k < size; input[k] == out_seq[k]);
+    loop_invariant (\forall int k; 0 <= k && k < size; input[k] == {:out_seq[k]:});
     while (start <= left && right < end && input[left] > input[right]) {
         left--;
         right++;
@@ -117,7 +117,7 @@ void Tomerge(int[] input, int size, int start, int mid, int end, seq<int> inp_se
     int i = 0;
     int temp;
 
-    assert (\forall int k; 0 <= k && k < size; input[k] == out_seq[k]);
+    assert (\forall int k; 0 <= k && k < size; {:input[k]:} == out_seq[k]);
 
 
     loop_invariant |out_seq| == size;
@@ -132,7 +132,7 @@ void Tomerge(int[] input, int size, int start, int mid, int end, seq<int> inp_se
     loop_invariant right - mid +1 == mid - left;
     //loop_invariant mid+1+i < right;
     loop_invariant (\forall* int k; k >= 0 && k < size; Perm(input[k], write));
-    loop_invariant (\forall int k; 0 <= k && k < size; input[k] == out_seq[k]);
+    loop_invariant (\forall int k; 0 <= k && k < size; input[k] == {:out_seq[k]:});
     loop_invariant isPermutation<int>(orig_seq, out_seq);
     //for (int i = 0; i < n; i++){
     while(i < n){
@@ -162,8 +162,8 @@ context_everywhere size > 0;
 context |inp_seq| == size;
 ensures |out_seq| == size;
 context (\forall* int i; i >= 0 && i < size; Perm(input[i], write));
-requires (\forall int i; 0 <= i && i < size; input[i] == inp_seq[i]);
-ensures (\forall int i; 0 <= i && i < size; input[i] == out_seq[i]);
+requires (\forall int i; 0 <= i && i < size; input[i] == {:inp_seq[i]:});
+ensures (\forall int i; 0 <= i && i < size; input[i] == {:out_seq[i]:});
 ensures isPermutation<int>(inp_seq, out_seq);
 void timSort(int[] input, int size, seq<int> inp_seq)
 {
@@ -175,7 +175,7 @@ void timSort(int[] input, int size, seq<int> inp_seq)
     loop_invariant loopCounter >= 0 && loopCounter < size + RUN;
     loop_invariant (\forall* int i; i >= 0 && i < size; Perm(input[i], write));
     loop_invariant |out_seq| == size;
-    loop_invariant (\forall int i; 0 <= i && i < size; input[i] == out_seq[i]);
+    loop_invariant (\forall int i; 0 <= i && i < size; input[i] == {:out_seq[i]:});
     loop_invariant isPermutation<int>(inp_seq, out_seq);
     //for (int i = 0; i < size; i+=RUN){
     while(loopCounter < size)
@@ -199,7 +199,7 @@ void timSort(int[] input, int size, seq<int> inp_seq)
     loop_invariant chunk >= RUN && chunk < size + chunk;
     loop_invariant (\forall* int i; i >= 0 && i < size; Perm(input[i], write));
     loop_invariant |out_seq| == size;
-    loop_invariant (\forall int i; 0 <= i && i < size; input[i] == out_seq[i]);
+    loop_invariant (\forall int i; 0 <= i && i < size; input[i] == {:out_seq[i]:});
     loop_invariant isPermutation<int>(inp_seq, out_seq);
     while(chunk < size)
     {
@@ -213,7 +213,7 @@ void timSort(int[] input, int size, seq<int> inp_seq)
         loop_invariant chunk < size;
         loop_invariant (\forall* int i; i >= 0 && i < size; Perm(input[i], write));
         loop_invariant |out_seq| == size;
-        loop_invariant (\forall int i; 0 <= i && i < size; input[i] == out_seq[i]);
+        loop_invariant (\forall int i; 0 <= i && i < size; input[i] == {:out_seq[i]:});
         loop_invariant isPermutation<int>(inp_seq, out_seq);
         while(left < size)
         {

--- a/src/viper/viper/api/backend/silicon/Silicon.scala
+++ b/src/viper/viper/api/backend/silicon/Silicon.scala
@@ -95,7 +95,7 @@ case class Silicon(
       totalTimeOut.toString,
       "--z3Exe",
       z3Path.toString,
-      "--z3ConfigArgs",
+      "--proverConfigArgs",
       z3Config,
     )
     if (optimizeUnsafe)


### PR DESCRIPTION
Upgrades to a new version of the Viper tools. Significant changes since the last version:
- Termination plugin optimisations
- Inclusion of the modular product programs and information flow specification plugin (SIF plugin)
- Trigger generation for expressions with let is improved
- Some internal performance improvements in silver related to hashing AST nodes
- Fixing a crash when using --moreJoins
- QP related unsoundness and incompleteness fixes
- Improved quantifier naming in SMT output
- Setting timeouts when running with CVC5 (making it actually usable)
- Performance improvement for fold/unfold with new flag `--enableSimplifiedUnfolds`
- Switch to resource bounds instead of time bounds (this *should* make verification very stable)