### PR TITLE
Add check for duplicate declaration IDs in generated Deserialize classes

### DIFF
--- a/src/helpers/vct/col/ast/helpers/defn/Constants.scala
+++ b/src/helpers/vct/col/ast/helpers/defn/Constants.scala
@@ -65,6 +65,8 @@ object Constants {
   val SuccessorsProvider: Type = t"_root_.vct.col.ast.SuccessorsProvider"
   val SerializeBlame: Term = q"_root_.vct.col.serialize.SerializeBlame"
   val SerializeOrigin: Term = q"_root_.vct.col.serialize.SerializeOrigin"
+  val UnreachableError: Term =
+    q"_root_.vct.result.VerificationError.Unreachable"
 
   val CompareResult = t"_root_.vct.col.compare.CompareResult"
   val MatchingDeclaration = t"_root_.vct.col.compare.MatchingDeclaration"

--- a/src/helpers/vct/col/ast/helpers/generator/Deserialize.scala
+++ b/src/helpers/vct/col/ast/helpers/generator/Deserialize.scala
@@ -52,7 +52,7 @@ class Deserialize extends NodeGenerator {
         """
 
     if (node.kind == DeclaredNode)
-      q"{ val res = $instance; decls($term.id) = res; res }"
+      q"""{ val res = $instance; if (decls.contains($term.id)) { throw $UnreachableError(s"Got a duplicate declaration id new: `$$res`, old: `$${decls($term.id)}`") }; decls($term.id) = res; res }"""
     else
       instance
   }


### PR DESCRIPTION
Checklist: <!-- Please first submit your pull request, you can check the checkboxes later. Feel free to ask for help if you don't know how/where to make changes. -->

- [x] The wiki is updated in accordance with the changes in this PR. For example: syntax changes, semantics changes, VerCors flags changes, etc.

# PR description
@RobertMensing recently dealt with a bug that was hard to track down and was ultimately caused by two declarations sharing an ID during deserialization. This PR adds a check to catch such cases.
